### PR TITLE
feat(bootstrap): initialize common-fwk module and base structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.1"
+
+      - name: Run tests
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ go.work.sum
 # env file
 .env
 
+# Agent Team Lite local registry artifacts
+.atl/
+
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/app/doc.go
+++ b/app/doc.go
@@ -1,0 +1,2 @@
+// Package app defines the application bootstrap boundary for common-fwk.
+package app

--- a/bootstrap_guard_test.go
+++ b/bootstrap_guard_test.go
@@ -1,0 +1,113 @@
+package bootstrap_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var bootstrapPackageDirs = []string{
+	"app",
+	"config",
+	"config/viper",
+	"security",
+	"http/gin",
+	"errors",
+}
+
+func TestBootstrapPackagesRemainStructuralOnly(t *testing.T) {
+	t.Helper()
+
+	for _, dir := range bootstrapPackageDirs {
+		dir := dir
+		t.Run(dir, func(t *testing.T) {
+			t.Helper()
+
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("read bootstrap dir %q: %v", dir, err)
+			}
+
+			goFiles := make([]string, 0)
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+
+				if strings.HasSuffix(entry.Name(), ".go") {
+					goFiles = append(goFiles, entry.Name())
+				}
+			}
+
+			if len(goFiles) != 1 || goFiles[0] != "doc.go" {
+				t.Fatalf("bootstrap package %q must contain only doc.go, got %v", dir, goFiles)
+			}
+
+			docPath := filepath.Join(dir, "doc.go")
+			content, err := os.ReadFile(docPath)
+			if err != nil {
+				t.Fatalf("read %q: %v", docPath, err)
+			}
+
+			doc := string(content)
+			if strings.Contains(doc, "func ") {
+				t.Fatalf("business behavior detected in %q: functions are not allowed during bootstrap", docPath)
+			}
+		})
+	}
+}
+
+func TestCIBaselineIncludesPRTriggerAndGoTestCommand(t *testing.T) {
+	t.Helper()
+
+	workflowPath := filepath.Join(".github", "workflows", "ci.yml")
+	content, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read workflow %q: %v", workflowPath, err)
+	}
+
+	workflow := string(content)
+
+	mustContain := []string{
+		"push:",
+		"pull_request:",
+		"run: go test ./...",
+	}
+
+	for _, fragment := range mustContain {
+		if !strings.Contains(workflow, fragment) {
+			t.Fatalf("workflow %q missing required fragment %q", workflowPath, fragment)
+		}
+	}
+
+	if strings.Contains(workflow, "continue-on-error: true") {
+		t.Fatalf("workflow %q disables fail-on-error semantics via continue-on-error", workflowPath)
+	}
+
+	if strings.Contains(workflow, "run: go test ./... || true") {
+		t.Fatalf("workflow %q disables fail-on-error semantics via shell bypass", workflowPath)
+	}
+}
+
+func TestCIBaselineRemainsBootstrapMinimal(t *testing.T) {
+	t.Helper()
+
+	workflowPath := filepath.Join(".github", "workflows", "ci.yml")
+	content, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read workflow %q: %v", workflowPath, err)
+	}
+
+	workflow := string(content)
+
+	if strings.Count(workflow, "run: go test ./...") != 1 {
+		t.Fatalf("workflow %q must keep a single baseline go test command", workflowPath)
+	}
+
+	for _, forbidden := range []string{"golangci-lint", "coverage", "release"} {
+		if strings.Contains(workflow, forbidden) {
+			t.Fatalf("workflow %q includes out-of-scope gate %q", workflowPath, forbidden)
+		}
+	}
+}

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,0 +1,2 @@
+// Package config defines shared configuration boundaries for common-fwk.
+package config

--- a/config/viper/doc.go
+++ b/config/viper/doc.go
@@ -1,0 +1,2 @@
+// Package viper defines the Viper-backed configuration adapter namespace.
+package viper

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,0 +1,2 @@
+// Package errors defines framework-level error boundaries for common-fwk.
+package errors

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/matiasmartin-labs/common-fwk
+
+go 1.25.1

--- a/http/gin/doc.go
+++ b/http/gin/doc.go
@@ -1,0 +1,2 @@
+// Package gin defines Gin HTTP adapter boundaries for common-fwk.
+package gin

--- a/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/archive-report.md
+++ b/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/archive-report.md
@@ -1,0 +1,107 @@
+## Archive Report
+
+**Change**: `bootstrap-common-fwk`  
+**Archive Date**: `2026-04-25`  
+**Artifact Store Mode**: `hybrid`  
+**Final Verification Verdict**: **PASS WITH WARNINGS**
+
+---
+
+### Executive Summary
+
+`bootstrap-common-fwk` is archived after successful implementation and verification of bootstrap scope. Delta specs were synced into main OpenSpec source-of-truth specs for `framework-bootstrap` and `ci-test-baseline`, and the change folder was moved to `openspec/changes/archive/2026-04-25-bootstrap-common-fwk/`.
+
+Verification reported no CRITICAL issues and 7/7 scenario compliance; one WARNING remains about design-file traceability for `bootstrap_guard_test.go`.
+
+---
+
+### Inputs Reviewed
+
+Required artifacts were read from OpenSpec (filesystem) and Engram (when available):
+
+- `exploration`: `openspec/changes/bootstrap-common-fwk/exploration.md`  
+- `proposal`: `openspec/changes/bootstrap-common-fwk/proposal.md` + Engram #187 (`sdd/bootstrap-common-fwk/proposal`)  
+- `spec`: `openspec/changes/bootstrap-common-fwk/specs/{framework-bootstrap,ci-test-baseline}/spec.md` + Engram #189 (`sdd/bootstrap-common-fwk/spec`)  
+- `design`: `openspec/changes/bootstrap-common-fwk/design.md` + Engram #192 (`sdd/bootstrap-common-fwk/design`)  
+- `tasks`: `openspec/changes/bootstrap-common-fwk/tasks.md` + Engram #193 (`sdd/bootstrap-common-fwk/tasks`)  
+- `apply-progress`: Engram #194 (`sdd/bootstrap-common-fwk/apply-progress`)  
+- `verify-report`: `openspec/changes/bootstrap-common-fwk/verify-report.md` + Engram #197 (`sdd/bootstrap-common-fwk/verify-report`)
+
+---
+
+### Delta Spec Sync Result
+
+| Domain | Main Spec Path | Action | Delta Type | Result |
+|---|---|---|---|---|
+| `framework-bootstrap` | `openspec/specs/framework-bootstrap/spec.md` | Created | Full new spec | ✅ Synced |
+| `ci-test-baseline` | `openspec/specs/ci-test-baseline/spec.md` | Created | Full new spec | ✅ Synced |
+
+No existing main specs were present; both domain deltas were treated as full-source spec creation.
+
+---
+
+### Archive Move Result
+
+- **From**: `openspec/changes/bootstrap-common-fwk/`
+- **To**: `openspec/changes/archive/2026-04-25-bootstrap-common-fwk/`
+- **Status**: ✅ Moved successfully
+
+Archive folder contents verified:
+
+- `exploration.md`
+- `proposal.md`
+- `specs/`
+- `design.md`
+- `tasks.md`
+- `verify-report.md`
+- `archive-report.md`
+
+Active changes verification:
+
+- `openspec/changes/` now contains only `archive/` (no active `bootstrap-common-fwk` folder)
+
+---
+
+### Final Status and Risks
+
+**Overall Status**: ✅ Archived (with warning carried forward)
+
+**Pass/Fail Basis**:
+- Verify verdict: **PASS WITH WARNINGS**
+- Compliance matrix: **7/7 scenarios compliant**
+- CRITICAL issues: **None**
+
+**Outstanding Warnings/Risks**:
+1. **WARNING (traceability)**: `design.md` File Changes table does not list `bootstrap_guard_test.go`.
+2. **Ongoing low/medium risks from proposal/design**:
+   - `errors` package naming ambiguity vs stdlib `errors` (future aliasing guidance recommended).
+   - `gin` package naming ambiguity in imports (prefer explicit/qualified imports in future runtime code).
+
+---
+
+### Source-of-Truth References
+
+Main specs now updated at:
+
+- `openspec/specs/framework-bootstrap/spec.md`
+- `openspec/specs/ci-test-baseline/spec.md`
+
+Archived change record:
+
+- `openspec/changes/archive/2026-04-25-bootstrap-common-fwk/`
+
+Engram traceability IDs used in this archive operation:
+
+- Proposal: #187
+- Spec: #189
+- Design: #192
+- Tasks: #193
+- Apply Progress: #194
+- Verify Report: #197
+
+---
+
+### Recommended Follow-up
+
+- Optional cleanup change: update archived design narrative (or a follow-up change design template) to include guard-test artifacts explicitly in file-trace tables.
+- Next functional change can now start from updated main specs (`framework-bootstrap`, `ci-test-baseline`).

--- a/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/design.md
+++ b/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/design.md
@@ -1,0 +1,93 @@
+# Design: Bootstrap common-fwk module and base scaffold
+
+## Technical Approach
+
+Implement issue #1 as a structural bootstrap only: initialize the Go module, create tracked package stubs, and wire a minimal CI test workflow. The design maps directly to `framework-bootstrap` and `ci-test-baseline` specs by ensuring `go test ./...` passes without introducing runtime behavior.
+
+Package layout aligns with extraction targets observed in `auth-provider-ms` (`app`, `config`, `config/viper`, `security`, `http/gin`, `errors`) so future extraction can add real contracts/implementations in-place instead of reshaping directories later.
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Empty directories only | Not tracked reliably by Git; ambiguous package existence | Rejected |
+| `doc.go` stubs per package | Slight boilerplate, but explicit and compilable | **Chosen** |
+| Placeholder APIs/tests now | Faster next phase, but violates no-business-logic scope | Rejected |
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Add CI gates (lint/coverage/release) now | Better quality baseline, but out of scope for issue #1 | Rejected |
+| Single baseline workflow with `go test ./...` | Minimal safety net only | **Chosen** |
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Introduce config/security interfaces now | Early contracts, but drifts into implementation design | Rejected |
+| Keep bootstrap structural and document-only | Defers detail, preserves guardrails | **Chosen** |
+
+## Data Flow
+
+Bootstrap validation flow is compile/test-only:
+
+    Developer Push / PR
+            │
+            ▼
+    GitHub Actions workflow
+            │ runs
+            ▼
+       go test ./...
+            │
+     ┌──────┴──────┐
+     ▼             ▼
+  package discovery  compile checks
+     │             │
+     └──────┬──────┘
+            ▼
+        pass/fail status
+
+No request/runtime business flow is introduced in this phase.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `go.mod` | Create | Initialize module `github.com/matiasmartin-labs/common-fwk` with pinned Go version for local/CI consistency. |
+| `app/doc.go` | Create | Declare package boundary for application composition. |
+| `config/doc.go` | Create | Declare config contract namespace. |
+| `config/viper/doc.go` | Create | Declare Viper adapter namespace without behavior. |
+| `security/doc.go` | Create | Declare security namespace for future extraction. |
+| `http/gin/doc.go` | Create | Declare Gin adapter namespace for HTTP layer. |
+| `errors/doc.go` | Create | Declare framework error namespace (future imports may alias vs stdlib). |
+| `.github/workflows/ci.yml` | Create | Run `go test ./...` on pull requests and pushes. |
+
+## Interfaces / Contracts
+
+No runtime interfaces are added in this phase by design.
+
+Bootstrap contract is structural:
+- Each target directory MUST contain a valid Go package declaration.
+- Files in this phase MUST be documentation/package stubs only.
+- No handlers, auth flows, config loading, or middleware logic is allowed.
+
+Recommended `doc.go` pattern:
+
+```go
+// Package config defines shared configuration boundaries for common-fwk.
+package config
+```
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Package compilation and discovery | Use `go test ./...` with no behavioral tests required for stubs. |
+| Integration | CI pipeline bootstrap wiring | GitHub Actions executes `go test ./...` and fails on non-zero exit. |
+| E2E | Not applicable in bootstrap | Deferred until runtime features exist. |
+
+## Migration / Rollout
+
+No migration required. Rollout is additive: merge scaffold and enforce baseline CI on subsequent PRs.
+
+## Open Questions
+
+- [ ] Which exact Go version should be pinned in `go.mod`/CI to match org toolchain policy?
+- [ ] Should future framework package imports enforce aliasing guidance for `errors` to avoid stdlib ambiguity?

--- a/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/exploration.md
+++ b/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/exploration.md
@@ -1,0 +1,49 @@
+## Exploration: bootstrap-common-fwk module and base structure
+
+### Current State
+Repository is at very early bootstrap stage: only `README.md`, `LICENSE`, and `.gitignore` exist. There is no `go.mod`, no Go source files, no package directories, and no CI workflow. This means there is currently nothing for `go test ./...` to execute in CI.
+
+### Affected Areas
+- `go.mod` — required to initialize module path `github.com/matiasmartin-labs/common-fwk`.
+- `app/` — scaffold package boundary for app-level wiring.
+- `config/` — scaffold shared config contract package.
+- `config/viper/` — scaffold concrete Viper-based config implementation package.
+- `security/` — scaffold security-oriented package namespace.
+- `http/gin/` — scaffold Gin HTTP adapter package namespace.
+- `errors/` — scaffold framework-level error package namespace.
+- `.github/workflows/ci.yml` — minimal CI to run `go test ./...`.
+
+### Approaches
+1. **Directory-only scaffold** — create folders with no `.go` files
+   - Pros: Absolute minimum footprint, fastest initial commit.
+   - Cons: Empty directories are not tracked by Git by default; Go tooling ignores non-package folders; acceptance around “structure exists and compiles” can become ambiguous.
+   - Effort: Low
+
+2. **Package-stub scaffold (`doc.go` per package) + minimal CI** — create `go.mod`, one `doc.go` (or equivalent stub) in each target package, and CI running `go test ./...`
+   - Pros: Deterministic package presence in Git, explicit package names, `go test ./...` validates real package graph, still no business logic.
+   - Cons: Slightly more boilerplate than empty folders; package naming decisions become visible early.
+   - Effort: Low
+
+3. **Richer bootstrap with placeholder APIs/tests** — include starter interfaces, sentinel errors, and initial tests
+   - Pros: Stronger early contract and faster next-phase development.
+   - Cons: Exceeds issue scope (“no business logic yet”), risks premature abstraction.
+   - Effort: Medium
+
+### Recommendation
+Adopt **Approach 2**. It best satisfies acceptance with minimal risk: package layout is explicit and versioned, module initialization is complete, and CI validates compilation via `go test ./...` without introducing business behavior.
+
+Suggested naming baseline (idiomatic + clear):
+- `app` package in `app/`
+- `config` package in `config/`
+- `viper` package in `config/viper/`
+- `security` package in `security/`
+- `gin` package in `http/gin/`
+- `errors` package in `errors/` (acceptable per scope, but import aliasing may be needed in future call sites)
+
+### Risks
+- `errors/` package can be confused with stdlib `errors`; future imports may require explicit aliasing (`stdErrors` vs framework package).
+- `http/gin/` introduces a package named `gin` that may be mistaken for upstream framework imports if callers use vague aliases.
+- CI may fail if Go version is unspecified or too old for chosen tooling defaults.
+
+### Ready for Proposal
+Yes — proceed to **sdd-propose** with Approach 2 as baseline scope and explicitly note naming/import clarity mitigations for `errors` and `gin` packages.

--- a/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/proposal.md
+++ b/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: Bootstrap common-fwk module and base scaffold
+
+## Intent
+
+Establish a minimal, compile-safe Go framework skeleton so extraction work from `auth-provider-ms` has a stable target. The change creates module identity, package boundaries, and CI validation without introducing business behavior.
+
+## Scope
+
+### In Scope
+- Initialize `go.mod` with module path `github.com/matiasmartin-labs/common-fwk`.
+- Scaffold package stubs (tracked Go packages) for `app`, `config`, `config/viper`, `security`, `http/gin`, and `errors`.
+- Add a minimal CI workflow running `go test ./...`.
+
+### Out of Scope
+- Any runtime/business logic, API handlers, auth flows, or configuration behavior.
+- Additional tooling (linting, release automation, coverage gates) beyond baseline test execution.
+
+## Capabilities
+
+### New Capabilities
+- `framework-bootstrap`: Initialize module metadata and baseline package layout that compiles with no business logic.
+- `ci-test-baseline`: Validate bootstrap integrity by running `go test ./...` in CI.
+
+### Modified Capabilities
+None.
+
+## Approach
+
+Use package-stub scaffolding (`doc.go` per package) plus minimal CI. This keeps structure explicit in Git, ensures deterministic compilation checks, and matches issue #1 acceptance while keeping bootstrap code minimal and idiomatic.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `go.mod` | New | Declare module path and Go version baseline. |
+| `app/doc.go` | New | Package stub for app-level composition boundary. |
+| `config/doc.go` | New | Package stub for config contract boundary. |
+| `config/viper/doc.go` | New | Package stub for Viper-backed config adapter boundary. |
+| `security/doc.go` | New | Package stub for security namespace. |
+| `http/gin/doc.go` | New | Package stub for Gin HTTP adapter namespace. |
+| `errors/doc.go` | New | Package stub for framework error namespace. |
+| `.github/workflows/ci.yml` | New | Execute `go test ./...` on pushes/PRs. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| `errors` package naming conflicts with stdlib `errors` | Med | Document import aliasing convention in follow-up specs/examples. |
+| `gin` package naming ambiguity in imports | Low | Keep package docs explicit; prefer qualified imports in future code. |
+| CI instability from unspecified/unsupported Go version | Low | Pin supported Go version in workflow and module. |
+
+## Rollback Plan
+
+Revert the bootstrap commit (or delete added scaffold files/directories), removing `go.mod`, package stubs, and CI workflow to return repository to pre-bootstrap state.
+
+## Dependencies
+
+- GitHub Actions availability for CI execution.
+- A pinned Go toolchain version supported by repository and CI runner.
+
+## Success Criteria
+
+- [ ] `go test ./...` passes locally from repository root.
+- [ ] CI runs `go test ./...` successfully for pull requests.
+- [ ] Target package layout exists as Go packages and compiles.
+- [ ] No business logic is introduced in bootstrap files.

--- a/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/specs/ci-test-baseline/spec.md
+++ b/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/specs/ci-test-baseline/spec.md
@@ -1,0 +1,35 @@
+# CI Test Baseline Specification
+
+## Purpose
+
+Define the minimal CI behavior required by issue #1 to continuously validate that the bootstrap scaffold remains compilable.
+
+## Requirements
+
+### Requirement: CI executes Go test baseline
+
+The system MUST provide a CI workflow that runs `go test ./...` for pull requests and SHALL fail the run if that command fails.
+
+#### Scenario: Pull request triggers baseline Go tests
+
+- GIVEN a pull request targeting the repository
+- WHEN CI workflows execute for that pull request
+- THEN CI runs `go test ./...`
+- AND the workflow reports pass/fail based on the command result
+
+#### Scenario: Failed tests fail the CI workflow
+
+- GIVEN `go test ./...` returns a non-zero exit code in CI
+- WHEN the workflow evaluates job status
+- THEN the workflow result is failure
+
+### Requirement: CI scope stays bootstrap-minimal
+
+The baseline CI workflow SHOULD remain limited to bootstrap compile/test validation in this phase and MUST NOT require additional quality gates (for example lint, release, or coverage thresholds) before the bootstrap is accepted.
+
+#### Scenario: Baseline CI has no extra mandatory gates
+
+- GIVEN issue #1 bootstrap acceptance criteria
+- WHEN reviewing the CI workflow for this phase
+- THEN `go test ./...` is required
+- AND extra gates beyond this baseline are not mandatory

--- a/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/specs/framework-bootstrap/spec.md
+++ b/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/specs/framework-bootstrap/spec.md
@@ -1,0 +1,41 @@
+# Framework Bootstrap Specification
+
+## Purpose
+
+Define the minimal Go module and package scaffold required by issue #1 so the repository compiles without introducing business behavior.
+
+## Requirements
+
+### Requirement: Module and package scaffold compiles
+
+The repository MUST declare module path `github.com/matiasmartin-labs/common-fwk` and SHALL provide these Go packages as tracked, compilable package boundaries: `app`, `config`, `config/viper`, `security`, `http/gin`, and `errors`.
+
+#### Scenario: Bootstrap scaffold compiles from repository root
+
+- GIVEN the bootstrap scaffold is present in the repository
+- WHEN `go test ./...` is executed from repository root
+- THEN command execution succeeds with exit code `0`
+- AND each listed package is discovered as a valid Go package
+
+#### Scenario: Minimal package stubs remain compilable
+
+- GIVEN each bootstrap package contains only minimal stub files (for example package docs)
+- WHEN `go test ./...` is executed
+- THEN compilation still succeeds without requiring runtime implementation
+
+### Requirement: Bootstrap contains no business logic
+
+Bootstrap artifacts MUST NOT include runtime/business behavior in this phase; they SHALL be limited to module metadata, package declarations/docs, and CI wiring needed for compile/test validation.
+
+#### Scenario: Bootstrap files are structural only
+
+- GIVEN files created by change `bootstrap-common-fwk`
+- WHEN bootstrap artifacts are reviewed
+- THEN no API handlers, auth flows, or configuration runtime logic is present
+- AND scaffold remains structural/documentary in nature
+
+#### Scenario: Business behavior is rejected during bootstrap phase
+
+- GIVEN a bootstrap change attempts to add functional business code
+- WHEN evaluating conformance to this specification
+- THEN the change is considered non-compliant for phase `sdd-spec`

--- a/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/tasks.md
+++ b/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Bootstrap common-fwk module and base scaffold
+
+## Phase 1: Module and package foundation
+
+- [x] 1.1 Create `go.mod` with module path `github.com/matiasmartin-labs/common-fwk` and a pinned Go version.
+- [x] 1.2 Create `app/doc.go` and `config/doc.go` with package comments + package declarations only (no runtime code).
+- [x] 1.3 Create `config/viper/doc.go` and `security/doc.go` as structural stubs for adapter/security namespaces.
+- [x] 1.4 Create `http/gin/doc.go` and `errors/doc.go` as structural stubs; keep names idiomatic and comments clear.
+
+## Phase 2: Baseline CI wiring
+
+- [x] 2.1 Create `.github/workflows/ci.yml` with `push` + `pull_request` triggers and a single job that runs `go test ./...`.
+- [x] 2.2 In `.github/workflows/ci.yml`, configure `actions/setup-go` using a version compatible with `go.mod`.
+- [x] 2.3 Verify CI remains bootstrap-minimal: no mandatory lint, coverage, release, or extra gates in this phase.
+
+## Phase 3: Verification and spec conformance
+
+- [x] 3.1 Verification: run `go test ./...` from repository root and confirm exit code `0`.
+- [x] 3.2 Verification: confirm package discovery for `app`, `config`, `config/viper`, `security`, `http/gin`, and `errors` during test run.
+- [x] 3.3 Verification: review bootstrap files (`go.mod`, `**/doc.go`, `.github/workflows/ci.yml`) to ensure no handlers, auth flows, or config runtime logic.
+- [x] 3.4 Verification: confirm CI failure semantics are preserved by default shell behavior (non-zero `go test` fails the job).
+
+## Phase 4: Change record hygiene
+
+- [x] 4.1 Update `openspec/changes/bootstrap-common-fwk/tasks.md` checkboxes during implementation (`sdd-apply`) in dependency order.
+- [x] 4.2 Keep task completion evidence tied to spec scenarios in `specs/framework-bootstrap/spec.md` and `specs/ci-test-baseline/spec.md`.

--- a/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/verify-report.md
+++ b/openspec/changes/archive/2026-04-25-bootstrap-common-fwk/verify-report.md
@@ -1,0 +1,124 @@
+## Verification Report
+
+**Change**: bootstrap-common-fwk  
+**Version**: N/A  
+**Mode**: Standard
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 13 |
+| Tasks complete | 13 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/bootstrap-common-fwk/tasks.md` are complete.
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed
+```text
+Command: go build ./...
+Exit code: 0
+Output: (none)
+```
+
+**Tests (baseline)**: ✅ Passed
+```text
+Command: go test ./...
+Exit code: 0
+ok   github.com/matiasmartin-labs/common-fwk	(cached)
+?    github.com/matiasmartin-labs/common-fwk/app	[no test files]
+?    github.com/matiasmartin-labs/common-fwk/config	[no test files]
+?    github.com/matiasmartin-labs/common-fwk/config/viper	[no test files]
+?    github.com/matiasmartin-labs/common-fwk/errors	[no test files]
+?    github.com/matiasmartin-labs/common-fwk/http/gin	[no test files]
+?    github.com/matiasmartin-labs/common-fwk/security	[no test files]
+```
+
+**Tests (guard evidence)**: ✅ Passed
+```text
+Command: go test -v .
+Exit code: 0
+=== RUN   TestBootstrapPackagesRemainStructuralOnly
+=== RUN   TestBootstrapPackagesRemainStructuralOnly/app
+=== RUN   TestBootstrapPackagesRemainStructuralOnly/config
+=== RUN   TestBootstrapPackagesRemainStructuralOnly/config/viper
+=== RUN   TestBootstrapPackagesRemainStructuralOnly/security
+=== RUN   TestBootstrapPackagesRemainStructuralOnly/http/gin
+=== RUN   TestBootstrapPackagesRemainStructuralOnly/errors
+--- PASS: TestBootstrapPackagesRemainStructuralOnly (0.00s)
+    --- PASS: TestBootstrapPackagesRemainStructuralOnly/app (0.00s)
+    --- PASS: TestBootstrapPackagesRemainStructuralOnly/config (0.00s)
+    --- PASS: TestBootstrapPackagesRemainStructuralOnly/config/viper (0.00s)
+    --- PASS: TestBootstrapPackagesRemainStructuralOnly/security (0.00s)
+    --- PASS: TestBootstrapPackagesRemainStructuralOnly/http/gin (0.00s)
+    --- PASS: TestBootstrapPackagesRemainStructuralOnly/errors (0.00s)
+=== RUN   TestCIBaselineIncludesPRTriggerAndGoTestCommand
+--- PASS: TestCIBaselineIncludesPRTriggerAndGoTestCommand (0.00s)
+=== RUN   TestCIBaselineRemainsBootstrapMinimal
+--- PASS: TestCIBaselineRemainsBootstrapMinimal (0.00s)
+PASS
+ok   github.com/matiasmartin-labs/common-fwk	0.238s
+```
+
+**Coverage**: ➖ Not available (no coverage tool/config detected)
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Module and package scaffold compiles | Bootstrap scaffold compiles from repository root | `go test ./...` (root execution) | ✅ COMPLIANT |
+| Module and package scaffold compiles | Minimal package stubs remain compilable | `go test ./...` (all listed packages compile) | ✅ COMPLIANT |
+| Bootstrap contains no business logic | Bootstrap files are structural only | `bootstrap_guard_test.go > TestBootstrapPackagesRemainStructuralOnly` | ✅ COMPLIANT |
+| Bootstrap contains no business logic | Business behavior is rejected during bootstrap phase | `bootstrap_guard_test.go > TestBootstrapPackagesRemainStructuralOnly` (fails if `func ` appears in bootstrap stubs) | ✅ COMPLIANT |
+| CI executes Go test baseline | Pull request triggers baseline Go tests | `bootstrap_guard_test.go > TestCIBaselineIncludesPRTriggerAndGoTestCommand` | ✅ COMPLIANT |
+| CI executes Go test baseline | Failed tests fail the CI workflow | `bootstrap_guard_test.go > TestCIBaselineIncludesPRTriggerAndGoTestCommand` (rejects bypass patterns) | ✅ COMPLIANT |
+| CI scope stays bootstrap-minimal | Baseline CI has no extra mandatory gates | `bootstrap_guard_test.go > TestCIBaselineRemainsBootstrapMinimal` | ✅ COMPLIANT |
+
+**Compliance summary**: 7/7 scenarios compliant.
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Module and package scaffold compiles | ✅ Implemented | `go.mod` module path matches spec and all required packages are valid Go packages. |
+| Bootstrap contains no business logic | ✅ Implemented | `app/config/config/viper/security/http/gin/errors` contain doc-only files and no runtime/business code. |
+| CI executes Go test baseline | ✅ Implemented | Workflow includes `pull_request` trigger and required `run: go test ./...` baseline. |
+| CI scope stays bootstrap-minimal | ✅ Implemented | Workflow includes only baseline test gate, with no mandatory lint/coverage/release gates. |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| `doc.go` stubs per package | ✅ Yes | Implemented exactly as chosen approach. |
+| Single baseline workflow running `go test ./...` | ✅ Yes | Workflow remains minimal and aligned with design. |
+| Keep bootstrap structural/document-only | ✅ Yes | Guard tests enforce this boundary while adding no runtime behavior. |
+| File changes match design table | ⚠️ Deviated (acceptable) | Added `bootstrap_guard_test.go` as verification-only evidence not listed in original file table. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+None.
+
+**WARNING** (should fix):
+- Design document `File Changes` table does not list `bootstrap_guard_test.go` (traceability gap only; behavior is compliant).
+
+**SUGGESTION** (nice to have):
+- Add a short note in `design.md` under Testing Strategy mentioning guard-test pattern for bootstrap constraints.
+
+---
+
+### Verdict
+**PASS WITH WARNINGS**
+
+Re-verification passed all executable checks with 7/7 scenario compliance; only a minor design traceability warning remains.

--- a/openspec/specs/ci-test-baseline/spec.md
+++ b/openspec/specs/ci-test-baseline/spec.md
@@ -1,0 +1,35 @@
+# CI Test Baseline Specification
+
+## Purpose
+
+Define the minimal CI behavior required by issue #1 to continuously validate that the bootstrap scaffold remains compilable.
+
+## Requirements
+
+### Requirement: CI executes Go test baseline
+
+The system MUST provide a CI workflow that runs `go test ./...` for pull requests and SHALL fail the run if that command fails.
+
+#### Scenario: Pull request triggers baseline Go tests
+
+- GIVEN a pull request targeting the repository
+- WHEN CI workflows execute for that pull request
+- THEN CI runs `go test ./...`
+- AND the workflow reports pass/fail based on the command result
+
+#### Scenario: Failed tests fail the CI workflow
+
+- GIVEN `go test ./...` returns a non-zero exit code in CI
+- WHEN the workflow evaluates job status
+- THEN the workflow result is failure
+
+### Requirement: CI scope stays bootstrap-minimal
+
+The baseline CI workflow SHOULD remain limited to bootstrap compile/test validation in this phase and MUST NOT require additional quality gates (for example lint, release, or coverage thresholds) before the bootstrap is accepted.
+
+#### Scenario: Baseline CI has no extra mandatory gates
+
+- GIVEN issue #1 bootstrap acceptance criteria
+- WHEN reviewing the CI workflow for this phase
+- THEN `go test ./...` is required
+- AND extra gates beyond this baseline are not mandatory

--- a/openspec/specs/framework-bootstrap/spec.md
+++ b/openspec/specs/framework-bootstrap/spec.md
@@ -1,0 +1,41 @@
+# Framework Bootstrap Specification
+
+## Purpose
+
+Define the minimal Go module and package scaffold required by issue #1 so the repository compiles without introducing business behavior.
+
+## Requirements
+
+### Requirement: Module and package scaffold compiles
+
+The repository MUST declare module path `github.com/matiasmartin-labs/common-fwk` and SHALL provide these Go packages as tracked, compilable package boundaries: `app`, `config`, `config/viper`, `security`, `http/gin`, and `errors`.
+
+#### Scenario: Bootstrap scaffold compiles from repository root
+
+- GIVEN the bootstrap scaffold is present in the repository
+- WHEN `go test ./...` is executed from repository root
+- THEN command execution succeeds with exit code `0`
+- AND each listed package is discovered as a valid Go package
+
+#### Scenario: Minimal package stubs remain compilable
+
+- GIVEN each bootstrap package contains only minimal stub files (for example package docs)
+- WHEN `go test ./...` is executed
+- THEN compilation still succeeds without requiring runtime implementation
+
+### Requirement: Bootstrap contains no business logic
+
+Bootstrap artifacts MUST NOT include runtime/business behavior in this phase; they SHALL be limited to module metadata, package declarations/docs, and CI wiring needed for compile/test validation.
+
+#### Scenario: Bootstrap files are structural only
+
+- GIVEN files created by change `bootstrap-common-fwk`
+- WHEN bootstrap artifacts are reviewed
+- THEN no API handlers, auth flows, or configuration runtime logic is present
+- AND scaffold remains structural/documentary in nature
+
+#### Scenario: Business behavior is rejected during bootstrap phase
+
+- GIVEN a bootstrap change attempts to add functional business code
+- WHEN evaluating conformance to this specification
+- THEN the change is considered non-compliant for phase `sdd-spec`

--- a/security/doc.go
+++ b/security/doc.go
@@ -1,0 +1,2 @@
+// Package security defines security-related extension points for common-fwk.
+package security


### PR DESCRIPTION
## Summary
- Bootstrap `common-fwk` as a Go module with path `github.com/matiasmartin-labs/common-fwk`.
- Add compile-safe scaffold packages (`app`, `config`, `config/viper`, `security`, `http/gin`, `errors`) with no business logic.
- Add baseline CI workflow executing `go test ./...` and guard tests to enforce bootstrap-only scope.
- Include SDD artifacts in `openspec/` (proposal/spec/design/tasks/verify/archive) under hybrid mode.

## Testing
- `go test ./...`
- `go test -v .`

Closes #1