### PR TITLE
feat(security): add reusable JWT validation core

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,45 @@ Behavior notes:
 - `EnvOverride=true` applies env values using `EnvPrefix` and deterministic keys (for example `COMMON_FWK_SECURITY_AUTH_JWT_SECRET`).
 - `ExpandEnv=false` preserves `${VAR}` placeholders.
 - `ExpandEnv=true` expands placeholders against a per-load env snapshot deterministically.
+
+## Security core JWT validation
+
+`security/*` provides a framework-agnostic JWT validation core with deterministic dependencies.
+
+```go
+jwtCfg := config.NewJWTConfig("secret", "common-fwk", 15)
+compat := securityjwt.FromConfigJWT(jwtCfg)
+
+validator, err := securityjwt.NewValidator(compat.Options)
+if err != nil {
+	// invalid validator options (for example missing resolver)
+}
+
+validatedClaims, err := validator.Validate(ctx, rawToken)
+if err != nil {
+	if errors.Is(err, securityjwt.ErrInvalidMethod) {
+		// token alg is not in allowlist
+	}
+	if errors.Is(err, securityjwt.ErrExpiredToken) {
+		// token exp is before validator clock
+	}
+
+	var vErr *securityjwt.ValidationError
+	if errors.As(err, &vErr) {
+		// inspect stage metadata while preserving sentinel assertability
+	}
+}
+
+_ = validatedClaims
+_ = compat.TokenTTL // token issuing concern, not validator runtime enforcement
+```
+
+Package boundaries:
+- `security/claims`: standard claim model and audience normalization helpers.
+- `security/keys`: deterministic key resolution contracts (`kid` + default key fallback).
+- `security/jwt`: validator options, typed/sentinel error taxonomy, validation flow, config compatibility helper.
+
+Explicit non-goals of this security core:
+- no Gin middleware coupling
+- no app-global singleton coupling
+- no OAuth/JWKS provider adapter/network fetch coupling

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.1
 require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=

--- a/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/archive-report.md
+++ b/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/archive-report.md
@@ -1,0 +1,66 @@
+# Archive Report: issue-4-security-core-jwt-validation
+
+## Archive Metadata
+
+- **Change**: `issue-4-security-core-jwt-validation`
+- **Archived On**: `2026-04-26`
+- **Artifact Mode**: `hybrid`
+- **Verification Verdict**: **PASS WITH WARNINGS**
+
+## Inputs Reviewed
+
+- OpenSpec artifacts reviewed from archived change folder:
+  - `proposal.md`
+  - `specs/config-core/spec.md`
+  - `specs/security-core-jwt-validation/spec.md`
+  - `design.md`
+  - `tasks.md`
+  - `verify-report.md`
+- Engram artifacts retrieved (full observations):
+  - Proposal: `#265` (`sdd/issue-4-security-core-jwt-validation/proposal`)
+  - Spec: `#267` (`sdd/issue-4-security-core-jwt-validation/spec`)
+  - Design: `#269` (`sdd/issue-4-security-core-jwt-validation/design`)
+  - Tasks: `#270` (`sdd/issue-4-security-core-jwt-validation/tasks`)
+  - Apply Progress: `#274` (`sdd/issue-4-security-core-jwt-validation/apply-progress`)
+  - Verify Report: `#275` (`sdd/issue-4-security-core-jwt-validation/verify-report`)
+
+## Spec Sync Completed
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| `config-core` | Updated | Applied MODIFIED requirement `Validation and normalization baseline`; preserved all other existing requirements unchanged. |
+| `security-core-jwt-validation` | Created | Added new source-of-truth spec from delta as full domain spec. |
+
+Updated source-of-truth files:
+- `openspec/specs/config-core/spec.md`
+- `openspec/specs/security-core-jwt-validation/spec.md`
+
+## Archive Move Completed
+
+- Moved active folder:
+  - `openspec/changes/issue-4-security-core-jwt-validation/`
+- To archive:
+  - `openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/`
+
+Archive contents confirmed:
+- `proposal.md` ✅
+- `specs/` ✅
+- `design.md` ✅
+- `tasks.md` ✅ (12/12 complete)
+- `verify-report.md` ✅
+- `archive-report.md` ✅
+
+## Verify Status Note
+
+Verification result is **PASS WITH WARNINGS** (9/9 scenarios compliant, build/tests passed, no critical blockers).
+
+## Pending Non-Blocking Follow-Up
+
+1. Add direct unit tests for `security/jwt/compat.go` (`FromConfigJWT`) to close current coverage gap.
+2. Add focused boundary tests for `claims.Audience.MarshalJSON`, `claims.HasAudience`, and extra `parseNumericDate` variants.
+
+These follow-ups are non-blocking and do not prevent archive closure.
+
+## Conclusion
+
+Delta specs have been synchronized into main OpenSpec sources of truth, the change folder has been archived with ISO date prefix, and the SDD cycle for this change is complete.

--- a/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/design.md
+++ b/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/design.md
@@ -1,0 +1,115 @@
+# Design: Issue #4 Security Core JWT Validation
+
+## Technical Approach
+
+Implement an additive, framework-agnostic JWT validation core split into `security/claims`, `security/keys`, and `security/jwt`. The validator composes injected dependencies (key resolver, clock, parser options) and returns wrapped, assertable errors. `config` remains configuration-only; compatibility is handled by a thin mapping function from `config.JWTConfig` to validator options.
+
+## Architecture Decisions
+
+| Decision | Options | Tradeoff | Selected |
+|---|---|---|---|
+| Package boundaries | Single `security/jwt`; split `claims` + `keys` + `jwt` | Single package is simpler but mixes policy, claims, and key concerns; split adds files but keeps interfaces minimal and explicit | Split packages with narrow contracts |
+| Key resolution | Inline key param; resolver interface | Inline key is easy but blocks `kid` selection and multi-key verification; resolver adds one abstraction but keeps deterministic tests | `keys.Resolver` interface keyed by `kid` |
+| Time handling | `time.Now()` direct; injected clock | Direct time is simpler but non-deterministic; injected clock improves deterministic tests | `Now func() time.Time` option with default |
+| Error model | String/opaque errors; sentinel+typed wrappers | Opaque errors are brittle; typed+sentinel errors require discipline but preserve `errors.Is/As` | Sentinel categories plus typed context wrappers |
+
+## Data Flow
+
+```text
+Validate(token, opts)
+  -> Parse JWT structure (claims+header)
+  -> Method gate (alg allowlist)
+  -> Resolve verification key (kid/default via resolver)
+  -> Verify signature
+  -> Claim checks (iss, aud, exp, nbf)
+  -> Option checks (required issuer/audience policy)
+  -> Return normalized claims
+```
+
+Validation order is intentional: reject malformed/disallowed method before expensive or ambiguous checks; classify failures by stage.
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `security/claims/doc.go` | Create | Package contract and scope. |
+| `security/claims/claims.go` | Create | Standard claims model, audience normalization helpers. |
+| `security/claims/claims_test.go` | Create | `aud` string/array normalization and optional claim behavior. |
+| `security/keys/doc.go` | Create | Package contract for verification keys. |
+| `security/keys/types.go` | Create | Key type and metadata (`kid`, method). |
+| `security/keys/resolver.go` | Create | `Resolver` interface and deterministic in-memory resolver. |
+| `security/keys/resolver_test.go` | Create | Present/missing key and default-key behavior. |
+| `security/jwt/doc.go` | Create | Validator scope and non-goals. |
+| `security/jwt/errors.go` | Create | Sentinel categories and typed validation error wrapper. |
+| `security/jwt/options.go` | Create | Validator options (`Methods`, `Issuer`, `Audience`, `Now`, resolver). |
+| `security/jwt/validator.go` | Create | Parse/validate orchestration and wrapping rules. |
+| `security/jwt/validator_test.go` | Create | Deterministic validator contract tests (happy/failure paths). |
+| `security/jwt/compat.go` | Create | Mapping helper from `config.JWTConfig` to jwt options. |
+| `README.md` | Modify | Security core usage and compatibility notes. |
+
+## Interfaces / Contracts
+
+```go
+// security/keys
+type Key struct {
+    ID     string
+    Method string
+    Verify any // concrete key material for jwt library
+}
+
+type Resolver interface {
+    Resolve(ctx context.Context, kid string) (Key, error)
+}
+
+// security/jwt
+type Options struct {
+    Methods  []string
+    Issuer   string
+    Audience []string
+    Now      func() time.Time
+    Resolver keys.Resolver
+}
+
+type Validator interface {
+    Validate(ctx context.Context, raw string) (claims.Claims, error)
+}
+```
+
+Error taxonomy (`security/jwt/errors.go`):
+- `ErrMalformedToken`
+- `ErrInvalidSignature`
+- `ErrInvalidIssuer`
+- `ErrInvalidAudience`
+- `ErrInvalidMethod`
+- `ErrExpiredToken`
+- `ErrNotYetValidToken`
+- `ErrKeyResolution`
+
+Wrapping rule: stage-specific failures are wrapped with `%w`; exported sentinels must remain assertable with `errors.Is`, and typed context (`ValidationError{Stage, Err}`) must remain assertable via `errors.As`.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Unit (`security/claims`) | `aud` normalization and optional claims | Table tests for string/array/missing `aud`. |
+| Unit (`security/keys`) | Resolver deterministic behavior | In-memory resolver tests for `kid` hit/miss and default fallback. |
+| Unit (`security/jwt`) | Flow categories by stage | Fixed tokens + fixed clock + fake resolver; assert sentinels and typed wrappers. |
+| Contract | `errors.Is/As` compatibility | Wrap returned errors and assert category/typed extraction still works. |
+
+Determinism hooks are first-class: validator accepts injected `Now` and `Resolver`; tests avoid global time or network key fetch.
+
+## Migration / Rollout
+
+No breaking migration required. `config.ValidateConfig` semantics and `config.JWTConfig` fields (`Secret`, `Issuer`, `TTLMinutes`) stay unchanged.
+
+Compatibility mapping contract:
+- `JWTConfig.Secret` -> local symmetric verification key in resolver
+- `JWTConfig.Issuer` -> `Options.Issuer`
+- `JWTConfig.TTLMinutes` -> token-issuing concern (not validator gate), documented as compatible but not revalidated in `config`
+
+Rollout is phased and additive: introduce security packages, add compatibility helper, then document usage.
+
+## Open Questions
+
+- [ ] Should initial method allowlist default to HS256-only or require explicit configuration?
+- [ ] Should `compat.go` live in `security/jwt` or an adapter package if more runtimes appear?

--- a/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/proposal.md
+++ b/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/proposal.md
@@ -1,0 +1,76 @@
+# Proposal: issue-4-security-core-jwt-validation
+
+## Intent
+
+Extract a reusable, framework-agnostic JWT validation core under `security/` with deterministic behavior, explicit key handling, and assertable typed errors, without coupling runtime validation to config adapters.
+
+## Scope
+
+### In Scope
+- Add reusable claims model and helpers for standard JWT claims under `security/claims`.
+- Add keypair/key resolver contracts under `security/keys` for deterministic verification inputs.
+- Add runtime JWT validator under `security/jwt` with explicit options (issuer/audience/signing methods/time source) and typed error taxonomy.
+- Add compatibility mapping from existing `config.JWTConfig` fields to validator options without changing current `config.ValidateConfig` semantics.
+- Add unit and contract tests as acceptance criteria for happy path, malformed token, claim failures, algorithm mismatch, key resolution failures, and error assertability.
+
+### Out of Scope
+- Gin/App middleware integration and HTTP auth flow wiring.
+- OAuth2 provider/JWKS remote fetch implementation.
+- Refresh-token/session issuance redesign.
+
+## Capabilities
+
+### New Capabilities
+- `security-core-jwt-validation`: Reusable claims, key material abstractions, and deterministic JWT validation runtime.
+
+### Modified Capabilities
+- `config-core`: Clarify compatibility contract so existing JWT config fields remain stable while being mappable into security-core validator options.
+
+## Approach
+
+Use package split approach:
+- `security/claims`: claim structs + normalization/access helpers.
+- `security/keys`: verifier keypair representation + resolver interfaces.
+- `security/jwt`: validator service, parser policy, clock injection, and wrapped typed errors.
+
+Keep `config` package configuration-only; mapping from `config.JWTConfig` to `security/jwt` options occurs in thin adapter code, not inside `config` core.
+
+## Phased Implementation Path
+
+1. **Phase 1 (contracts):** introduce `security/claims` and `security/keys` types/interfaces + unit tests.
+2. **Phase 2 (validator):** implement `security/jwt` validator, method allowlist, clock injection, and typed errors.
+3. **Phase 3 (compatibility):** add mapping layer from `config.JWTConfig` into validator options; keep config semantics unchanged.
+4. **Phase 4 (docs + hardening):** add README examples and full contract tests (`errors.Is/As`, edge claims, key failures).
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `security/claims` | New | Claims model and claim validation helpers |
+| `security/keys` | New | Keypair and resolver contracts |
+| `security/jwt` | New | Token validator API and typed errors |
+| `config/types.go` | Modified | Compatibility notes and mapping hooks |
+| `README.md` | Modified | Security-core usage and migration notes |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Unsafe algorithm acceptance | Med | Default allowlist and explicit method configuration |
+| Claim interpretation drift (`iss/aud/exp/nbf`) | Med | Centralized claim validation rules + clock injection tests |
+| Error taxonomy inconsistency | Low/Med | Package-level sentinels/types and `errors.Is/As` contract tests |
+
+## Rollback Plan
+
+Revert `security/*` additions and any mapping hooks in a single change; keep existing `config` validation path untouched so applications continue current behavior.
+
+## Dependencies
+
+- JWT parsing/verification library selection (`github.com/golang-jwt/jwt/v5` recommended).
+
+## Success Criteria
+
+- [ ] New security-core packages compile and pass `go test ./...` with deterministic tests.
+- [ ] Typed JWT validation errors are assertable via `errors.Is`/`errors.As`.
+- [ ] Existing config JWT field semantics remain backward-compatible.
+- [ ] Proposal path supports phased delivery without framework coupling.

--- a/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/specs/config-core/spec.md
+++ b/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/specs/config-core/spec.md
@@ -1,0 +1,28 @@
+# Delta for config-core
+
+## MODIFIED Requirements
+
+### Requirement: Validation and normalization baseline
+
+The config core MUST provide validation entrypoints for domains (server, JWT, cookie, login, OAuth2 generic). Validation errors SHALL be assertable through a stable taxonomy (`ErrXxx` sentinels). Login email normalization SHALL trim whitespace and lowercase before validation success. Integrating adapters MUST preserve core validation assertability when wrapping validation errors. JWT field semantics (`secret`, `issuer`, `expiry`) SHALL remain backward-compatible and MUST map to security-core validator options without runtime validation coupling in `config`.
+(Previously: JWT fields were validated in config-core without an explicit compatibility mapping contract to security-core validator options.)
+
+#### Scenario: Baseline validation succeeds for compliant config
+
+- GIVEN a config value that satisfies baseline rules
+- WHEN validation is executed
+- THEN validation succeeds
+- AND normalized login email values are stored/returned in trimmed lowercase form
+
+#### Scenario: Baseline validation reports assertable failures
+
+- GIVEN a config value violating one or more baseline rules
+- WHEN validation is executed
+- THEN validation fails with context-wrapped errors
+- AND callers can assert failure classes via stable sentinels/types
+
+#### Scenario: Wrapped core validation remains assertable through adapters
+
+- GIVEN an adapter validates mapped config using core validation and wraps the returned error
+- WHEN validation fails for a core rule
+- THEN callers can still assert the underlying core failure class

--- a/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/specs/security-core-jwt-validation/spec.md
+++ b/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/specs/security-core-jwt-validation/spec.md
@@ -1,0 +1,71 @@
+# Security Core JWT Validation Specification
+
+## Purpose
+
+Define deterministic JWT validation under `security/*`.
+
+## Requirements
+
+### Requirement: Claims model behavior and compatibility
+
+The core MUST support standard claims (`iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`) and MAY include private claims. It SHALL accept `aud` as string or array and normalize to one form.
+
+#### Scenario: Audience encodings normalize consistently
+
+- GIVEN equivalent payloads with `aud` as string/array
+- WHEN claims are parsed
+- THEN both produce equivalent normalized claims
+- AND missing optional claims do not fail parsing by themselves
+
+### Requirement: Key provider and keypair abstraction behavior
+
+The core MUST define keypair/resolver contracts selecting verification keys by `kid` or default. Resolvers SHALL be deterministic and MUST NOT require network access.
+
+#### Scenario: Resolver handles present and missing keys
+
+- GIVEN a token header `kid=A` and a resolver with/without key `A`
+- WHEN key resolution runs
+- THEN matching key `A` is returned when present
+- AND missing `A` fails with key-resolution category
+
+### Requirement: Validator issuer/audience/method policy checks
+
+The validator MUST verify signature and enforce issuer, audience, and method allowlist checks. It SHALL reject tokens with disallowed `alg`.
+
+#### Scenario: Policy success and method rejection
+
+- GIVEN one valid token and one token signed with disallowed method
+- WHEN both are validated with identical issuer/audience policy
+- THEN the valid token succeeds
+- AND the non-allowed method token fails with invalid-method category
+
+### Requirement: Temporal claims and deterministic testing
+
+The validator MUST evaluate `exp` and `nbf` using an injected time source. Tests SHALL set fixed time.
+
+#### Scenario: Expired and not-before outcomes
+
+- GIVEN fixed injected time `T` and tokens with `exp < T` and `nbf > T`
+- WHEN validation executes
+- THEN `exp < T` fails with expired-token category
+- AND `nbf > T` fails with not-yet-valid category
+
+### Requirement: Typed/sentinel error categories and wrapping contract
+
+The validator MUST expose categories for malformed token, invalid signature, invalid issuer, invalid audience, invalid method, expired token, not-yet-valid token, and key-resolution failure. Wrapped errors SHALL stay assertable via `errors.Is`/`errors.As`.
+
+#### Scenario: Wrapped errors are assertable
+
+- GIVEN malformed input and a wrapped validation error return
+- WHEN callers inspect with `errors.Is` or `errors.As`
+- THEN the expected category is assertable
+
+### Requirement: Explicit boundaries and non-goals
+
+This capability MUST NOT depend on Gin middleware, app globals, or OAuth/JWKS provider adapters. Core scope is validation contracts only.
+
+#### Scenario: Core remains framework-agnostic
+
+- GIVEN `security/claims`, `security/keys`, and `security/jwt`
+- WHEN building and testing these packages in isolation
+- THEN no Gin, app-global singleton, or provider adapter dependency is required

--- a/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/tasks.md
+++ b/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Issue #4 Security Core JWT Validation
+
+## Phase 1: Foundation Contracts (claims + keys)
+
+- [x] 1.1 Create `security/claims/doc.go` and `security/claims/claims.go` with standard claims model and `aud` normalization helper.
+  Completion: package compiles and supports `iss/sub/aud/exp/nbf/iat/jti` plus private claims without validation side effects.
+- [x] 1.2 Create `security/keys/doc.go`, `security/keys/types.go`, and `security/keys/resolver.go` with `Key` and `Resolver` contracts plus deterministic in-memory resolver.
+  Completion: resolver returns `kid` match, default key fallback, and categorized miss error without network access.
+
+## Phase 2: Validator Core + Error Contracts
+
+- [x] 2.1 Create `security/jwt/doc.go` and `security/jwt/errors.go` with sentinel taxonomy and typed `ValidationError` wrapper.
+  Completion: malformed/signature/issuer/audience/method/expired/not-yet-valid/key-resolution categories are exported and `errors.Is/As` compatible.
+- [x] 2.2 Create `security/jwt/options.go` with `Methods`, `Issuer`, `Audience`, `Now`, and `Resolver` options, including safe defaults.
+  Completion: options can be constructed without globals and default `Now` is deterministic when overridden in tests.
+- [x] 2.3 Create `security/jwt/validator.go` implementing ordered flow: parse → method gate → key resolve → signature verify → claims checks.
+  Completion: `Validate(ctx, raw)` returns normalized claims on success and stage-appropriate wrapped errors on failure.
+
+## Phase 3: Compatibility + Documentation
+
+- [x] 3.1 Create `security/jwt/compat.go` mapping `config.JWTConfig` (`Secret`, `Issuer`, `TTLMinutes`) into validator options without adding runtime coupling to `config` validation.
+  Completion: mapping preserves backward-compatible JWT field semantics and keeps `config` package configuration-only.
+- [x] 3.2 Update `README.md` with security-core usage examples and explicit non-goals (no Gin middleware/JWKS adapter scope).
+  Completion: README documents package boundaries, validator setup, and compatibility mapping behavior.
+
+## Phase 4: Tests and Verification
+
+- [x] 4.1 Add `security/claims/claims_test.go` table tests for `aud` string/array normalization and optional-claim parsing.
+  Completion: tests cover equivalent audience encodings and missing optional claims scenarios.
+- [x] 4.2 Add `security/keys/resolver_test.go` for `kid` hit/miss and default-key behavior.
+  Completion: resolver tests assert deterministic outcomes and key-resolution error category.
+- [x] 4.3 Add `security/jwt/validator_test.go` deterministic tests (fixed clock + fake resolver) for happy path and each failure category.
+  Completion: tests assert method rejection, invalid issuer/audience, expired, not-before, malformed token, invalid signature, and key-resolution failures.
+- [x] 4.4 Add contract tests (can be in `security/jwt/validator_test.go`) that wrap returned errors and assert `errors.Is`/`errors.As` stability.
+  Completion: wrapped validation errors remain assertable by sentinel and typed wrapper.
+- [x] 4.5 Run validation commands: `go test ./...` then `go build ./...`.
+  Completion: both commands succeed with no failing packages.

--- a/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/verify-report.md
+++ b/openspec/changes/archive/2026-04-26-issue-4-security-core-jwt-validation/verify-report.md
@@ -1,0 +1,111 @@
+## Verification Report
+
+**Change**: issue-4-security-core-jwt-validation  
+**Version**: N/A  
+**Mode**: Standard
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 12 |
+| Tasks complete | 12 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/issue-4-security-core-jwt-validation/tasks.md` are marked complete (`[x]`).
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed
+
+```text
+Command: go build ./...
+Exit code: 0
+Output: (no output)
+```
+
+**Tests**: ✅ 70 passed / ❌ 0 failed / ⚠️ 0 skipped
+
+```text
+Command: go test ./... -count=1 -json
+Exit code: 0
+Summary: TEST_PASS=70, TEST_FAIL=0, TEST_SKIP=0
+```
+
+**Additional boundary evidence**: ✅ `go test ./security/... -count=1` passed (`security/claims`, `security/keys`, `security/jwt`) proving package-level isolation/buildability for core security packages.
+
+**Coverage**: 75.5% / threshold: 0% → ✅ Above threshold
+
+```text
+Command: go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out
+Total statements coverage: 75.5%
+```
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Claims model behavior and compatibility | Audience encodings normalize consistently | `security/claims/claims_test.go > TestAudienceNormalization/audience_as_string` + `.../audience_as_array` + `.../missing_optional_claims` | ✅ COMPLIANT |
+| Key provider and keypair abstraction behavior | Resolver handles present and missing keys | `security/keys/resolver_test.go > TestStaticResolverResolve/kid_hit` + `.../kid_miss` (+ default fallback in same table) | ✅ COMPLIANT |
+| Validator issuer/audience/method policy checks | Policy success and method rejection | `security/jwt/validator_test.go > TestValidatorValidateScenarios/valid_token` + `.../disallowed_method` | ✅ COMPLIANT |
+| Temporal claims and deterministic testing | Expired and not-before outcomes | `security/jwt/validator_test.go > TestValidatorValidateScenarios/expired_token` + `.../not_yet_valid` | ✅ COMPLIANT |
+| Typed/sentinel error categories and wrapping contract | Wrapped errors are assertable | `security/jwt/validator_test.go > TestValidationErrorAssertabilityWhenWrapped` (plus `TestValidatorValidateScenarios/*` typed wrapper checks) | ✅ COMPLIANT |
+| Explicit boundaries and non-goals | Core remains framework-agnostic | `go test ./security/...` pass evidence + static boundary evidence (`security/jwt/doc.go`) | ✅ COMPLIANT |
+| Validation and normalization baseline (config-core, modified) | Baseline validation succeeds for compliant config | `config/validate_test.go > TestValidateConfigValid` + `TestValidateConfigNormalizesLoginEmail` | ✅ COMPLIANT |
+| Validation and normalization baseline (config-core, modified) | Baseline validation reports assertable failures | `config/validate_test.go > TestValidateConfigInvalid/*` | ✅ COMPLIANT |
+| Validation and normalization baseline (config-core, modified) | Wrapped core validation remains assertable through adapters | `config/viper/loader_test.go > TestLoadWrapsCoreValidation` (+ `config/viper/errors_test.go > TestValidationErrorPreservesCoreAssertability`) | ✅ COMPLIANT |
+
+**Compliance summary**: 9/9 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Claims model behavior and compatibility | ✅ Implemented | `security/claims/claims.go` models standard claims, supports private claims, and normalizes `aud` via custom `Audience` marshal/unmarshal. |
+| Key provider and keypair abstraction behavior | ✅ Implemented | `security/keys/types.go` + `security/keys/resolver.go` provide deterministic resolver contracts with categorized miss (`ErrKeyNotFound`). |
+| Validator issuer/audience/method policy checks | ✅ Implemented | `security/jwt/validator.go` enforces method allowlist, resolves key by `kid`, verifies signature, and checks issuer/audience. |
+| Temporal claims and deterministic testing | ✅ Implemented | `security/jwt/options.go` exposes injectable `Now`; validator compares `exp/nbf` against injected clock. |
+| Typed/sentinel error categories and wrapping contract | ✅ Implemented | `security/jwt/errors.go` defines sentinel taxonomy + `ValidationError` with unwrap contract; validator stages wrap failures consistently. |
+| Explicit boundaries and non-goals | ✅ Implemented | `security/*` packages have no Gin/app-global/JWKS adapter runtime coupling; docs explicitly define non-goals. |
+| Validation and normalization baseline (config-core, modified) | ✅ Implemented | `config/validate.go` preserves domain validation + login email normalization; adapter wrapping assertability covered in `config/viper`. |
+
+---
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Split packages with narrow contracts (`claims`, `keys`, `jwt`) | ✅ Yes | Implemented exactly under `security/claims`, `security/keys`, `security/jwt`. |
+| Resolver abstraction keyed by `kid` | ✅ Yes | `keys.Resolver` with deterministic static resolver implementation and default fallback. |
+| Injected clock (`Now`) for deterministic tests | ✅ Yes | `Options.Now` with tests using fixed time. |
+| Sentinel + typed wrapper error model | ✅ Yes | Sentinels + `ValidationError` implemented and tested with `errors.Is/As`. |
+| Planned file changes | ⚠️ Slightly deviated | Additional `go.mod`/`go.sum` updates (new JWT dependency) and explicit `ErrResolverRequired`/`CompatOptions.TokenTTL` extensions beyond listed file-change table; both are coherent with design intent. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+- None.
+
+**WARNING** (should fix):
+- `security/jwt/compat.go` behavior is not directly unit-tested (`FromConfigJWT` shows 0.0% function coverage), creating regression risk for the config-to-validator mapping contract despite static correctness.
+
+**SUGGESTION** (nice to have):
+- Add focused tests for `claims.Audience.MarshalJSON`, `claims.HasAudience`, and additional `parseNumericDate` input variants to improve confidence on boundary parsing semantics.
+
+---
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+Implementation is functionally compliant with all specified scenarios (9/9), builds and tests pass deterministically, and boundaries/error contracts are preserved; one non-blocking test coverage gap remains around config compatibility mapping.

--- a/openspec/specs/config-core/spec.md
+++ b/openspec/specs/config-core/spec.md
@@ -42,7 +42,7 @@ The config core SHALL provide explicit constructors/builders for root and nested
 
 ### Requirement: Validation and normalization baseline
 
-The config core MUST provide validation entrypoints for baseline domains (server, JWT, cookie, login, OAuth2 generic). Validation errors SHALL be assertable through a stable error taxonomy (including `ErrXxx` sentinels where applicable). Login email normalization SHALL trim surrounding whitespace and lowercase the result before validation success is reported. Integrating adapters MUST preserve core validation assertability when wrapping returned validation errors.
+The config core MUST provide validation entrypoints for domains (server, JWT, cookie, login, OAuth2 generic). Validation errors SHALL be assertable through a stable taxonomy (`ErrXxx` sentinels). Login email normalization SHALL trim whitespace and lowercase before validation success. Integrating adapters MUST preserve core validation assertability when wrapping validation errors. JWT field semantics (`secret`, `issuer`, `expiry`) SHALL remain backward-compatible and MUST map to security-core validator options without runtime validation coupling in `config`.
 
 #### Scenario: Baseline validation succeeds for compliant config
 

--- a/openspec/specs/security-core-jwt-validation/spec.md
+++ b/openspec/specs/security-core-jwt-validation/spec.md
@@ -1,0 +1,71 @@
+# Security Core JWT Validation Specification
+
+## Purpose
+
+Define deterministic JWT validation under `security/*`.
+
+## Requirements
+
+### Requirement: Claims model behavior and compatibility
+
+The core MUST support standard claims (`iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`) and MAY include private claims. It SHALL accept `aud` as string or array and normalize to one form.
+
+#### Scenario: Audience encodings normalize consistently
+
+- GIVEN equivalent payloads with `aud` as string/array
+- WHEN claims are parsed
+- THEN both produce equivalent normalized claims
+- AND missing optional claims do not fail parsing by themselves
+
+### Requirement: Key provider and keypair abstraction behavior
+
+The core MUST define keypair/resolver contracts selecting verification keys by `kid` or default. Resolvers SHALL be deterministic and MUST NOT require network access.
+
+#### Scenario: Resolver handles present and missing keys
+
+- GIVEN a token header `kid=A` and a resolver with/without key `A`
+- WHEN key resolution runs
+- THEN matching key `A` is returned when present
+- AND missing `A` fails with key-resolution category
+
+### Requirement: Validator issuer/audience/method policy checks
+
+The validator MUST verify signature and enforce issuer, audience, and method allowlist checks. It SHALL reject tokens with disallowed `alg`.
+
+#### Scenario: Policy success and method rejection
+
+- GIVEN one valid token and one token signed with disallowed method
+- WHEN both are validated with identical issuer/audience policy
+- THEN the valid token succeeds
+- AND the non-allowed method token fails with invalid-method category
+
+### Requirement: Temporal claims and deterministic testing
+
+The validator MUST evaluate `exp` and `nbf` using an injected time source. Tests SHALL set fixed time.
+
+#### Scenario: Expired and not-before outcomes
+
+- GIVEN fixed injected time `T` and tokens with `exp < T` and `nbf > T`
+- WHEN validation executes
+- THEN `exp < T` fails with expired-token category
+- AND `nbf > T` fails with not-yet-valid category
+
+### Requirement: Typed/sentinel error categories and wrapping contract
+
+The validator MUST expose categories for malformed token, invalid signature, invalid issuer, invalid audience, invalid method, expired token, not-yet-valid token, and key-resolution failure. Wrapped errors SHALL stay assertable via `errors.Is`/`errors.As`.
+
+#### Scenario: Wrapped errors are assertable
+
+- GIVEN malformed input and a wrapped validation error return
+- WHEN callers inspect with `errors.Is` or `errors.As`
+- THEN the expected category is assertable
+
+### Requirement: Explicit boundaries and non-goals
+
+This capability MUST NOT depend on Gin middleware, app globals, or OAuth/JWKS provider adapters. Core scope is validation contracts only.
+
+#### Scenario: Core remains framework-agnostic
+
+- GIVEN `security/claims`, `security/keys`, and `security/jwt`
+- WHEN building and testing these packages in isolation
+- THEN no Gin, app-global singleton, or provider adapter dependency is required

--- a/security/claims/claims.go
+++ b/security/claims/claims.go
@@ -1,0 +1,82 @@
+package claims
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+var ErrInvalidAudienceType = errors.New("invalid audience claim type")
+
+// Audience represents normalized JWT audience values.
+type Audience []string
+
+// UnmarshalJSON normalizes aud from either string or []string form.
+func (a *Audience) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*a = nil
+		return nil
+	}
+
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*a = Audience{single}
+		return nil
+	}
+
+	var many []string
+	if err := json.Unmarshal(data, &many); err == nil {
+		*a = Audience(many)
+		return nil
+	}
+
+	return fmt.Errorf("aud: %w", ErrInvalidAudienceType)
+}
+
+// MarshalJSON emits audience as a scalar when single-valued for compatibility.
+func (a Audience) MarshalJSON() ([]byte, error) {
+	switch len(a) {
+	case 0:
+		return []byte("null"), nil
+	case 1:
+		return json.Marshal(a[0])
+	default:
+		return json.Marshal([]string(a))
+	}
+}
+
+// Values returns a defensive copy of normalized audience values.
+func (a Audience) Values() []string {
+	out := make([]string, len(a))
+	copy(out, a)
+	return out
+}
+
+// Claims models standard JWT claims plus private, application-specific fields.
+type Claims struct {
+	Issuer    string                 `json:"iss,omitempty"`
+	Subject   string                 `json:"sub,omitempty"`
+	Audience  Audience               `json:"aud,omitempty"`
+	ExpiresAt *time.Time             `json:"exp,omitempty"`
+	NotBefore *time.Time             `json:"nbf,omitempty"`
+	IssuedAt  *time.Time             `json:"iat,omitempty"`
+	JWTID     string                 `json:"jti,omitempty"`
+	Private   map[string]interface{} `json:"-"`
+}
+
+// NormalizedAudience returns a defensive copy of audience values.
+func (c Claims) NormalizedAudience() []string {
+	return c.Audience.Values()
+}
+
+// HasAudience reports whether expected audience value exists.
+func (c Claims) HasAudience(expected string) bool {
+	for _, aud := range c.Audience {
+		if aud == expected {
+			return true
+		}
+	}
+
+	return false
+}

--- a/security/claims/claims_test.go
+++ b/security/claims/claims_test.go
@@ -1,0 +1,70 @@
+package claims
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestAudienceNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload string
+		wantAud []string
+	}{
+		{
+			name:    "audience as string",
+			payload: `{"iss":"common-fwk","aud":"app"}`,
+			wantAud: []string{"app"},
+		},
+		{
+			name:    "audience as array",
+			payload: `{"iss":"common-fwk","aud":["app"]}`,
+			wantAud: []string{"app"},
+		},
+		{
+			name:    "missing optional claims",
+			payload: `{"iss":"common-fwk"}`,
+			wantAud: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got Claims
+			if err := json.Unmarshal([]byte(tc.payload), &got); err != nil {
+				t.Fatalf("unmarshal claims: %v", err)
+			}
+
+			gotAud := got.NormalizedAudience()
+			if len(gotAud) != len(tc.wantAud) {
+				t.Fatalf("expected audience size %d, got %d", len(tc.wantAud), len(gotAud))
+			}
+
+			for i := range gotAud {
+				if gotAud[i] != tc.wantAud[i] {
+					t.Fatalf("expected audience[%d]=%q, got %q", i, tc.wantAud[i], gotAud[i])
+				}
+			}
+		})
+	}
+}
+
+func TestAudienceInvalidType(t *testing.T) {
+	t.Parallel()
+
+	var got Claims
+	err := json.Unmarshal([]byte(`{"aud":123}`), &got)
+	if err == nil {
+		t.Fatalf("expected invalid audience type error")
+	}
+
+	if !errors.Is(err, ErrInvalidAudienceType) {
+		t.Fatalf("expected ErrInvalidAudienceType, got %v", err)
+	}
+}

--- a/security/claims/doc.go
+++ b/security/claims/doc.go
@@ -1,0 +1,2 @@
+// Package claims defines JWT claims contracts used by security validators.
+package claims

--- a/security/jwt/compat.go
+++ b/security/jwt/compat.go
@@ -1,0 +1,32 @@
+package jwt
+
+import (
+	"time"
+
+	"github.com/matiasmartin-labs/common-fwk/config"
+	"github.com/matiasmartin-labs/common-fwk/security/keys"
+)
+
+// CompatOptions bundles validator options with token-issuing compatibility data.
+type CompatOptions struct {
+	Options  Options
+	TokenTTL time.Duration
+}
+
+// FromConfigJWT maps config.JWTConfig to security/jwt validator options.
+//
+// TTLMinutes remains a token-issuing concern and is exposed as TokenTTL for
+// callers that issue tokens; validator runtime checks do not enforce it.
+func FromConfigJWT(cfg config.JWTConfig) CompatOptions {
+	return CompatOptions{
+		Options: Options{
+			Methods: []string{"HS256"},
+			Issuer:  cfg.Issuer,
+			Resolver: keys.NewStaticResolver(
+				&keys.Key{Method: "HS256", Verify: []byte(cfg.Secret)},
+				nil,
+			),
+		},
+		TokenTTL: time.Duration(cfg.TTLMinutes) * time.Minute,
+	}
+}

--- a/security/jwt/doc.go
+++ b/security/jwt/doc.go
@@ -1,0 +1,5 @@
+// Package jwt provides framework-agnostic JWT validation contracts.
+//
+// Non-goals: Gin middleware integration, app-global singletons, and remote
+// provider adapters (for example JWKS/OAuth provider fetchers).
+package jwt

--- a/security/jwt/errors.go
+++ b/security/jwt/errors.go
@@ -1,0 +1,55 @@
+package jwt
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrMalformedToken   = errors.New("malformed token")
+	ErrInvalidSignature = errors.New("invalid signature")
+	ErrInvalidIssuer    = errors.New("invalid issuer")
+	ErrInvalidAudience  = errors.New("invalid audience")
+	ErrInvalidMethod    = errors.New("invalid method")
+	ErrExpiredToken     = errors.New("expired token")
+	ErrNotYetValidToken = errors.New("token not yet valid")
+	ErrKeyResolution    = errors.New("key resolution failed")
+)
+
+// ValidationError carries validation stage metadata while preserving unwrap.
+type ValidationError struct {
+	Stage string
+	Err   error
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+
+	if e.Stage == "" {
+		return fmt.Sprintf("validation failed: %v", e.Err)
+	}
+
+	return fmt.Sprintf("validation failed at %s: %v", e.Stage, e.Err)
+}
+
+func (e *ValidationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.Err
+}
+
+func wrap(stage string, sentinel, err error) error {
+	if err == nil {
+		err = sentinel
+	}
+
+	if sentinel == nil {
+		sentinel = err
+	}
+
+	return &ValidationError{Stage: stage, Err: fmt.Errorf("%w: %w", sentinel, err)}
+}

--- a/security/jwt/options.go
+++ b/security/jwt/options.go
@@ -1,0 +1,44 @@
+package jwt
+
+import (
+	"errors"
+	"time"
+
+	"github.com/matiasmartin-labs/common-fwk/security/keys"
+)
+
+var ErrResolverRequired = errors.New("resolver is required")
+
+// Options configures validator behavior.
+type Options struct {
+	Methods  []string
+	Issuer   string
+	Audience []string
+	Now      func() time.Time
+	Resolver keys.Resolver
+}
+
+func (o Options) withDefaults() (Options, error) {
+	out := o
+	if out.Now == nil {
+		out.Now = time.Now
+	}
+
+	if out.Resolver == nil {
+		return Options{}, ErrResolverRequired
+	}
+
+	if len(out.Methods) == 0 {
+		out.Methods = []string{"HS256"}
+	} else {
+		methods := make([]string, len(out.Methods))
+		copy(methods, out.Methods)
+		out.Methods = methods
+	}
+
+	audiences := make([]string, len(out.Audience))
+	copy(audiences, out.Audience)
+	out.Audience = audiences
+
+	return out, nil
+}

--- a/security/jwt/validator.go
+++ b/security/jwt/validator.go
@@ -1,0 +1,268 @@
+package jwt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	jwtlib "github.com/golang-jwt/jwt/v5"
+
+	"github.com/matiasmartin-labs/common-fwk/security/claims"
+)
+
+// Validator validates JWT values against policy options.
+type Validator interface {
+	Validate(ctx context.Context, raw string) (claims.Claims, error)
+}
+
+type validator struct {
+	options Options
+	allowed map[string]struct{}
+}
+
+// NewValidator constructs a framework-agnostic JWT validator.
+func NewValidator(options Options) (Validator, error) {
+	resolved, err := options.withDefaults()
+	if err != nil {
+		return nil, err
+	}
+
+	allowed := make(map[string]struct{}, len(resolved.Methods))
+	for _, method := range resolved.Methods {
+		allowed[method] = struct{}{}
+	}
+
+	return &validator{options: resolved, allowed: allowed}, nil
+}
+
+func (v *validator) Validate(ctx context.Context, raw string) (claims.Claims, error) {
+	if raw == "" {
+		return claims.Claims{}, wrap("parse", ErrMalformedToken, errors.New("token is empty"))
+	}
+
+	unverified, _, err := jwtlib.NewParser().ParseUnverified(raw, jwtlib.MapClaims{})
+	if err != nil {
+		return claims.Claims{}, wrap("parse", ErrMalformedToken, err)
+	}
+
+	alg := ""
+	if unverified.Method != nil {
+		alg = unverified.Method.Alg()
+	}
+	if _, ok := v.allowed[alg]; !ok {
+		return claims.Claims{}, wrap("method", ErrInvalidMethod, fmt.Errorf("alg %q not allowed", alg))
+	}
+
+	kid, err := kidFromHeader(unverified.Header)
+	if err != nil {
+		return claims.Claims{}, wrap("parse", ErrMalformedToken, err)
+	}
+
+	key, err := v.options.Resolver.Resolve(ctx, kid)
+	if err != nil {
+		return claims.Claims{}, wrap("resolve-key", ErrKeyResolution, err)
+	}
+
+	parser := jwtlib.NewParser(
+		jwtlib.WithValidMethods(v.options.Methods),
+		jwtlib.WithoutClaimsValidation(),
+	)
+
+	verified, err := parser.Parse(raw, func(token *jwtlib.Token) (any, error) {
+		if token.Method == nil {
+			return nil, errors.New("token method missing")
+		}
+
+		if key.Method != "" && token.Method.Alg() != key.Method {
+			return nil, fmt.Errorf("token alg %q does not match key method %q", token.Method.Alg(), key.Method)
+		}
+
+		return key.Verify, nil
+	})
+	if err != nil {
+		if errors.Is(err, jwtlib.ErrTokenSignatureInvalid) {
+			return claims.Claims{}, wrap("verify-signature", ErrInvalidSignature, err)
+		}
+
+		return claims.Claims{}, wrap("parse", ErrMalformedToken, err)
+	}
+
+	mapped, err := claimsFromToken(verified)
+	if err != nil {
+		return claims.Claims{}, wrap("parse", ErrMalformedToken, err)
+	}
+
+	if v.options.Issuer != "" && mapped.Issuer != v.options.Issuer {
+		return claims.Claims{}, wrap("claims", ErrInvalidIssuer, fmt.Errorf("expected %q, got %q", v.options.Issuer, mapped.Issuer))
+	}
+
+	if len(v.options.Audience) > 0 && !hasAnyAudience(mapped, v.options.Audience) {
+		return claims.Claims{}, wrap("claims", ErrInvalidAudience, fmt.Errorf("expected one of %v, got %v", v.options.Audience, mapped.NormalizedAudience()))
+	}
+
+	now := v.options.Now()
+	if mapped.ExpiresAt != nil && mapped.ExpiresAt.Before(now) {
+		return claims.Claims{}, wrap("claims", ErrExpiredToken, fmt.Errorf("exp %s before now %s", mapped.ExpiresAt.UTC().Format(time.RFC3339), now.UTC().Format(time.RFC3339)))
+	}
+
+	if mapped.NotBefore != nil && mapped.NotBefore.After(now) {
+		return claims.Claims{}, wrap("claims", ErrNotYetValidToken, fmt.Errorf("nbf %s after now %s", mapped.NotBefore.UTC().Format(time.RFC3339), now.UTC().Format(time.RFC3339)))
+	}
+
+	return mapped, nil
+}
+
+func kidFromHeader(header map[string]any) (string, error) {
+	v, ok := header["kid"]
+	if !ok {
+		return "", nil
+	}
+
+	kid, ok := v.(string)
+	if !ok {
+		return "", errors.New("kid header must be string")
+	}
+
+	return kid, nil
+}
+
+func claimsFromToken(token *jwtlib.Token) (claims.Claims, error) {
+	mapClaims, ok := token.Claims.(jwtlib.MapClaims)
+	if !ok {
+		return claims.Claims{}, errors.New("unexpected claims type")
+	}
+
+	mapped := claims.Claims{}
+	if issuer, ok := mapClaims["iss"].(string); ok {
+		mapped.Issuer = issuer
+	}
+	if subject, ok := mapClaims["sub"].(string); ok {
+		mapped.Subject = subject
+	}
+	if jwtID, ok := mapClaims["jti"].(string); ok {
+		mapped.JWTID = jwtID
+	}
+
+	audience, err := parseAudience(mapClaims["aud"])
+	if err != nil {
+		return claims.Claims{}, err
+	}
+	mapped.Audience = audience
+
+	if exp, ok, err := parseNumericDate(mapClaims["exp"]); err != nil {
+		return claims.Claims{}, fmt.Errorf("exp: %w", err)
+	} else if ok {
+		mapped.ExpiresAt = &exp
+	}
+
+	if nbf, ok, err := parseNumericDate(mapClaims["nbf"]); err != nil {
+		return claims.Claims{}, fmt.Errorf("nbf: %w", err)
+	} else if ok {
+		mapped.NotBefore = &nbf
+	}
+
+	if iat, ok, err := parseNumericDate(mapClaims["iat"]); err != nil {
+		return claims.Claims{}, fmt.Errorf("iat: %w", err)
+	} else if ok {
+		mapped.IssuedAt = &iat
+	}
+
+	private := make(map[string]interface{})
+	for key, value := range mapClaims {
+		switch key {
+		case "iss", "sub", "aud", "exp", "nbf", "iat", "jti":
+			continue
+		default:
+			private[key] = value
+		}
+	}
+	if len(private) > 0 {
+		mapped.Private = private
+	}
+
+	return mapped, nil
+}
+
+func parseAudience(raw any) (claims.Audience, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	switch value := raw.(type) {
+	case string:
+		return claims.Audience{value}, nil
+	case []string:
+		out := make([]string, len(value))
+		copy(out, value)
+		return claims.Audience(out), nil
+	case []any:
+		out := make([]string, 0, len(value))
+		for _, elem := range value {
+			s, ok := elem.(string)
+			if !ok {
+				return nil, claims.ErrInvalidAudienceType
+			}
+			out = append(out, s)
+		}
+		return claims.Audience(out), nil
+	default:
+		return nil, claims.ErrInvalidAudienceType
+	}
+}
+
+func parseNumericDate(raw any) (time.Time, bool, error) {
+	if raw == nil {
+		return time.Time{}, false, nil
+	}
+
+	var seconds int64
+	switch value := raw.(type) {
+	case float64:
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return time.Time{}, false, errors.New("invalid numeric date value")
+		}
+		seconds = int64(value)
+	case float32:
+		fv := float64(value)
+		if math.IsNaN(fv) || math.IsInf(fv, 0) {
+			return time.Time{}, false, errors.New("invalid numeric date value")
+		}
+		seconds = int64(value)
+	case int64:
+		seconds = value
+	case int32:
+		seconds = int64(value)
+	case int:
+		seconds = int64(value)
+	case json.Number:
+		parsed, err := strconv.ParseInt(value.String(), 10, 64)
+		if err != nil {
+			return time.Time{}, false, err
+		}
+		seconds = parsed
+	case string:
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return time.Time{}, false, err
+		}
+		seconds = parsed
+	default:
+		return time.Time{}, false, fmt.Errorf("unsupported numeric date type %T", raw)
+	}
+
+	return time.Unix(seconds, 0).UTC(), true, nil
+}
+
+func hasAnyAudience(claimsValue claims.Claims, expected []string) bool {
+	for _, candidate := range expected {
+		if claimsValue.HasAudience(candidate) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/security/jwt/validator_test.go
+++ b/security/jwt/validator_test.go
@@ -1,0 +1,239 @@
+package jwt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	jwtlib "github.com/golang-jwt/jwt/v5"
+
+	"github.com/matiasmartin-labs/common-fwk/security/keys"
+)
+
+func TestValidatorValidateScenarios(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 26, 12, 0, 0, 0, time.UTC)
+
+	resolver := keys.NewStaticResolver(
+		&keys.Key{ID: "default", Method: "HS256", Verify: []byte("good-secret")},
+		map[string]keys.Key{
+			"A": {ID: "A", Method: "HS256", Verify: []byte("good-secret")},
+		},
+	)
+
+	v, err := NewValidator(Options{
+		Methods:  []string{"HS256"},
+		Issuer:   "common-fwk",
+		Audience: []string{"mobile-app"},
+		Now: func() time.Time {
+			return now
+		},
+		Resolver: resolver,
+	})
+	if err != nil {
+		t.Fatalf("new validator: %v", err)
+	}
+
+	validToken := mustSignToken(t, jwtlib.SigningMethodHS256, []byte("good-secret"), map[string]any{
+		"iss": "common-fwk",
+		"aud": []string{"mobile-app"},
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"nbf": now.Add(-1 * time.Minute).Unix(),
+		"sub": "user-1",
+		"jti": "token-1",
+		"rol": "admin",
+	}, nil)
+
+	disallowedMethod := mustSignToken(t, jwtlib.SigningMethodHS384, []byte("good-secret"), map[string]any{
+		"iss": "common-fwk",
+		"aud": []string{"mobile-app"},
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"nbf": now.Add(-1 * time.Minute).Unix(),
+	}, nil)
+
+	invalidSignature := mustSignToken(t, jwtlib.SigningMethodHS256, []byte("wrong-secret"), map[string]any{
+		"iss": "common-fwk",
+		"aud": []string{"mobile-app"},
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"nbf": now.Add(-1 * time.Minute).Unix(),
+	}, nil)
+
+	invalidIssuer := mustSignToken(t, jwtlib.SigningMethodHS256, []byte("good-secret"), map[string]any{
+		"iss": "other-issuer",
+		"aud": []string{"mobile-app"},
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"nbf": now.Add(-1 * time.Minute).Unix(),
+	}, nil)
+
+	invalidAudience := mustSignToken(t, jwtlib.SigningMethodHS256, []byte("good-secret"), map[string]any{
+		"iss": "common-fwk",
+		"aud": []string{"api"},
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"nbf": now.Add(-1 * time.Minute).Unix(),
+	}, nil)
+
+	expired := mustSignToken(t, jwtlib.SigningMethodHS256, []byte("good-secret"), map[string]any{
+		"iss": "common-fwk",
+		"aud": []string{"mobile-app"},
+		"exp": now.Add(-1 * time.Minute).Unix(),
+		"nbf": now.Add(-2 * time.Minute).Unix(),
+	}, nil)
+
+	notBefore := mustSignToken(t, jwtlib.SigningMethodHS256, []byte("good-secret"), map[string]any{
+		"iss": "common-fwk",
+		"aud": []string{"mobile-app"},
+		"exp": now.Add(10 * time.Minute).Unix(),
+		"nbf": now.Add(1 * time.Minute).Unix(),
+	}, nil)
+
+	missingKid := mustSignToken(t, jwtlib.SigningMethodHS256, []byte("good-secret"), map[string]any{
+		"iss": "common-fwk",
+		"aud": []string{"mobile-app"},
+		"exp": now.Add(10 * time.Minute).Unix(),
+		"nbf": now.Add(-1 * time.Minute).Unix(),
+	}, map[string]any{"kid": "missing"})
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantSentinel error
+		assertClaims func(t *testing.T, got map[string]any)
+	}{
+		{
+			name: "valid token",
+			raw:  validToken,
+			assertClaims: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if got["subject"] != "user-1" {
+					t.Fatalf("expected subject user-1, got %v", got["subject"])
+				}
+				if got["aud0"] != "mobile-app" {
+					t.Fatalf("expected audience mobile-app, got %v", got["aud0"])
+				}
+				if got["private.rol"] != "admin" {
+					t.Fatalf("expected private claim rol=admin, got %v", got["private.rol"])
+				}
+			},
+		},
+		{name: "malformed token", raw: "not-a-jwt", wantSentinel: ErrMalformedToken},
+		{name: "disallowed method", raw: disallowedMethod, wantSentinel: ErrInvalidMethod},
+		{name: "invalid signature", raw: invalidSignature, wantSentinel: ErrInvalidSignature},
+		{name: "invalid issuer", raw: invalidIssuer, wantSentinel: ErrInvalidIssuer},
+		{name: "invalid audience", raw: invalidAudience, wantSentinel: ErrInvalidAudience},
+		{name: "expired token", raw: expired, wantSentinel: ErrExpiredToken},
+		{name: "not yet valid", raw: notBefore, wantSentinel: ErrNotYetValidToken},
+		{name: "key resolution failure", raw: missingKid, wantSentinel: ErrKeyResolution},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := v.Validate(context.Background(), tc.raw)
+			if tc.wantSentinel == nil {
+				if err != nil {
+					t.Fatalf("expected success, got %v", err)
+				}
+
+				if tc.assertClaims != nil {
+					tc.assertClaims(t, map[string]any{
+						"subject":     got.Subject,
+						"aud0":        first(got.NormalizedAudience()),
+						"private.rol": got.Private["rol"],
+					})
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			if !errors.Is(err, tc.wantSentinel) {
+				t.Fatalf("expected sentinel %v, got %v", tc.wantSentinel, err)
+			}
+
+			var vErr *ValidationError
+			if !errors.As(err, &vErr) {
+				t.Fatalf("expected ValidationError wrapper, got %T", err)
+			}
+		})
+	}
+}
+
+func TestValidationErrorAssertabilityWhenWrapped(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 26, 12, 0, 0, 0, time.UTC)
+	v, err := NewValidator(Options{
+		Methods: []string{"HS256"},
+		Now: func() time.Time {
+			return now
+		},
+		Resolver: keys.NewStaticResolver(
+			&keys.Key{Method: "HS256", Verify: []byte("good-secret")},
+			nil,
+		),
+	})
+	if err != nil {
+		t.Fatalf("new validator: %v", err)
+	}
+
+	errToken := "not-a-jwt"
+	_, validationErr := v.Validate(context.Background(), errToken)
+	if validationErr == nil {
+		t.Fatalf("expected malformed token error")
+	}
+
+	wrapped := fmt.Errorf("adapter wrap: %w", validationErr)
+
+	if !errors.Is(wrapped, ErrMalformedToken) {
+		t.Fatalf("expected wrapped error to preserve ErrMalformedToken")
+	}
+
+	var vErr *ValidationError
+	if !errors.As(wrapped, &vErr) {
+		t.Fatalf("expected wrapped error to preserve ValidationError type")
+	}
+}
+
+func TestNewValidatorRequiresResolver(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewValidator(Options{})
+	if err == nil {
+		t.Fatalf("expected resolver required error")
+	}
+
+	if !errors.Is(err, ErrResolverRequired) {
+		t.Fatalf("expected ErrResolverRequired, got %v", err)
+	}
+}
+
+func mustSignToken(t *testing.T, method jwtlib.SigningMethod, secret []byte, claims map[string]any, header map[string]any) string {
+	t.Helper()
+
+	token := jwtlib.NewWithClaims(method, jwtlib.MapClaims(claims))
+	for key, value := range header {
+		token.Header[key] = value
+	}
+
+	raw, err := token.SignedString(secret)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	return raw
+}
+
+func first(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+
+	return values[0]
+}

--- a/security/keys/doc.go
+++ b/security/keys/doc.go
@@ -1,0 +1,2 @@
+// Package keys provides deterministic JWT verification key resolution contracts.
+package keys

--- a/security/keys/resolver.go
+++ b/security/keys/resolver.go
@@ -1,0 +1,47 @@
+package keys
+
+import (
+	"context"
+	"fmt"
+)
+
+// Resolver resolves JWT verification keys by kid or deterministic fallback.
+type Resolver interface {
+	Resolve(ctx context.Context, kid string) (Key, error)
+}
+
+type staticResolver struct {
+	defaultKey *Key
+	byID       map[string]Key
+}
+
+// NewStaticResolver returns a deterministic in-memory Resolver.
+func NewStaticResolver(defaultKey *Key, byID map[string]Key) Resolver {
+	cloned := make(map[string]Key, len(byID))
+	for id, key := range byID {
+		cloned[id] = key
+	}
+
+	var clonedDefault *Key
+	if defaultKey != nil {
+		copyKey := *defaultKey
+		clonedDefault = &copyKey
+	}
+
+	return &staticResolver{defaultKey: clonedDefault, byID: cloned}
+}
+
+func (r *staticResolver) Resolve(_ context.Context, kid string) (Key, error) {
+	if kid != "" {
+		if key, ok := r.byID[kid]; ok {
+			return key, nil
+		}
+		return Key{}, fmt.Errorf("kid %q: %w", kid, ErrKeyNotFound)
+	}
+
+	if r.defaultKey != nil {
+		return *r.defaultKey, nil
+	}
+
+	return Key{}, ErrKeyNotFound
+}

--- a/security/keys/resolver_test.go
+++ b/security/keys/resolver_test.go
@@ -1,0 +1,67 @@
+package keys
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestStaticResolverResolve(t *testing.T) {
+	t.Parallel()
+
+	defaultKey := &Key{ID: "default", Method: "HS256", Verify: []byte("default")}
+	resolver := NewStaticResolver(defaultKey, map[string]Key{
+		"A": {ID: "A", Method: "HS256", Verify: []byte("a")},
+	})
+
+	tests := []struct {
+		name    string
+		kid     string
+		wantID  string
+		wantErr error
+	}{
+		{name: "kid hit", kid: "A", wantID: "A"},
+		{name: "default fallback", kid: "", wantID: "default"},
+		{name: "kid miss", kid: "missing", wantErr: ErrKeyNotFound},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := resolver.Resolve(context.Background(), tc.kid)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("resolve key: %v", err)
+			}
+
+			if key.ID != tc.wantID {
+				t.Fatalf("expected key ID %q, got %q", tc.wantID, key.ID)
+			}
+		})
+	}
+}
+
+func TestStaticResolverNoDefault(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewStaticResolver(nil, nil)
+	_, err := resolver.Resolve(context.Background(), "")
+	if err == nil {
+		t.Fatalf("expected missing default key error")
+	}
+
+	if !errors.Is(err, ErrKeyNotFound) {
+		t.Fatalf("expected ErrKeyNotFound, got %v", err)
+	}
+}

--- a/security/keys/types.go
+++ b/security/keys/types.go
@@ -1,0 +1,12 @@
+package keys
+
+import "errors"
+
+var ErrKeyNotFound = errors.New("verification key not found")
+
+// Key contains key metadata and verification material.
+type Key struct {
+	ID     string
+	Method string
+	Verify any
+}


### PR DESCRIPTION
Closes #4

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Extract reusable framework-agnostic security core under `security/claims`, `security/keys`, and `security/jwt`.
- Add configurable JWT validation (issuer, audience, signing methods, key resolver/input) with typed/sentinel errors.
- Add deterministic tests and sync/archive OpenSpec artifacts for issue #4.

## Changes
| File | Change |
|------|--------|
| `security/claims/*` | Added claims model and normalization tests |
| `security/keys/*` | Added key abstractions/resolver and tests |
| `security/jwt/*` | Added validator/options/errors/compat and tests |
| `README.md` | Added security-core usage and boundaries documentation |
| `openspec/**` | Added/synced specs, reports, and archived change artifacts |

## Test Plan
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `go test ./security/...`
