### PR TITLE
docs(usage): add quickstart architecture and integration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,119 +1,289 @@
 # common-fwk
-Common framework
 
-## Config core usage
+Reusable framework primitives for config, security validation, and HTTP adapters.
 
-```go
-cfg := config.NewConfig(
-	config.NewServerConfig("127.0.0.1", 8080),
-	config.NewSecurityConfig(
-		config.NewAuthConfig(
-			config.NewJWTConfig("secret", "common-fwk", 15),
-			config.NewCookieConfig("session", "example.com", true, true, "Lax"),
-			config.NewLoginConfig("  ADMIN@Example.COM  "),
-			config.NewOAuth2Config(map[string]config.OAuth2ProviderConfig{
-				"github": config.NewOAuth2ProviderConfig(
-					"client-id",
-					"client-secret",
-					"https://github.com/login/oauth/authorize",
-					"https://github.com/login/oauth/access_token",
-					"https://app.example.com/auth/github/callback",
-					[]string{"read:user", "user:email"},
-				),
-			}),
-		),
-	),
-)
+## Quickstart
 
-validated, err := config.ValidateConfig(cfg)
-if err != nil {
-	if errors.Is(err, config.ErrInvalidConfig) {
-		// handle classified validation failures
-	}
-}
+### Install
 
-// validated.Security.Auth.Login.Email == "admin@example.com"
+```bash
+go get github.com/matiasmartin-labs/common-fwk@latest
 ```
 
-## Optional Viper adapter usage
+### 1) Build validated core config (explicit API)
 
 ```go
-loaded, err := viper.Load(viper.Options{
-	ConfigPath:  "./config/app.yaml",
-	ConfigType:  "",          // infer from extension when empty
-	EnvPrefix:   "COMMON_FWK", // default when omitted
-	EnvOverride: true,          // env values override file values
-	ExpandEnv:   true,          // expand ${VAR} placeholders from env snapshot
-})
-if err != nil {
-	var loadErr *viper.LoadError
-	var decodeErr *viper.DecodeError
-	var mapErr *viper.MappingError
-	var validateErr *viper.ValidationError
+package main
 
-	switch {
-	case errors.As(err, &loadErr):
-		// file access or option/application failure
-	case errors.As(err, &decodeErr):
-		// parse/unmarshal failure
-	case errors.As(err, &mapErr):
-		// explicit raw -> core mapping failure
-	case errors.As(err, &validateErr):
-		// wraps config.ValidateConfig failures
+import (
+	"errors"
+	"fmt"
+
+	"github.com/matiasmartin-labs/common-fwk/config"
+)
+
+func main() {
+	cfg := config.NewConfig(
+		config.NewServerConfig("127.0.0.1", 8080),
+		config.NewSecurityConfig(
+			config.NewAuthConfig(
+				config.NewJWTConfig("secret", "common-fwk", 15),
+				config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+				config.NewLoginConfig("  ADMIN@Example.COM  "),
+				config.NewOAuth2Config(map[string]config.OAuth2ProviderConfig{
+					"github": config.NewOAuth2ProviderConfig(
+						"client-id",
+						"client-secret",
+						"https://github.com/login/oauth/authorize",
+						"https://github.com/login/oauth/access_token",
+						"https://app.example.com/auth/github/callback",
+						[]string{"read:user", "user:email"},
+					),
+				}),
+			),
+		),
+	)
+
+	validated, err := config.ValidateConfig(cfg)
+	if err != nil {
+		if errors.Is(err, config.ErrInvalidConfig) {
+			panic("invalid config")
+		}
+		panic(err)
 	}
 
-	if errors.Is(err, config.ErrInvalidConfig) {
-		// preserved core classification through ValidationError wrapping
-	}
+	fmt.Println(validated.Security.Auth.Login.Email)
+	// Output: admin@example.com
 }
+```
 
-_ = loaded
+### 2) Optional facade adapter (`config/viper`)
+
+```go
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/matiasmartin-labs/common-fwk/config"
+	cfgviper "github.com/matiasmartin-labs/common-fwk/config/viper"
+)
+
+func main() {
+	loaded, err := cfgviper.Load(cfgviper.Options{
+		ConfigPath:  "./config/app.yaml",
+		ConfigType:  "",           // inferred from extension when empty
+		EnvPrefix:   "COMMON_FWK", // default when omitted
+		EnvOverride: true,           // env values override file values
+		ExpandEnv:   true,           // expands ${VAR} using a per-load env snapshot
+	})
+	if err != nil {
+		var loadErr *cfgviper.LoadError
+		var decodeErr *cfgviper.DecodeError
+		var mapErr *cfgviper.MappingError
+		var validateErr *cfgviper.ValidationError
+
+		switch {
+		case errors.As(err, &loadErr):
+			fmt.Println("load error")
+		case errors.As(err, &decodeErr):
+			fmt.Println("decode error")
+		case errors.As(err, &mapErr):
+			fmt.Println("mapping error")
+		case errors.As(err, &validateErr):
+			fmt.Println("validation error")
+		}
+
+		if errors.Is(err, config.ErrInvalidConfig) {
+			fmt.Println("core validation failed")
+		}
+		return
+	}
+
+	fmt.Println(loaded.Server.Host, loaded.Server.Port)
+}
 ```
 
 Behavior notes:
-- `EnvOverride=false` keeps file values as source of truth.
-- `EnvOverride=true` applies env values using `EnvPrefix` and deterministic keys (for example `COMMON_FWK_SECURITY_AUTH_JWT_SECRET`).
-- `ExpandEnv=false` preserves `${VAR}` placeholders.
-- `ExpandEnv=true` expands placeholders against a per-load env snapshot deterministically.
+- `EnvOverride=false`: file values remain source of truth.
+- `EnvOverride=true`: uses deterministic keys (example: `COMMON_FWK_SECURITY_AUTH_JWT_SECRET`).
+- `ExpandEnv=false`: `${VAR}` placeholders are preserved.
+- `ExpandEnv=true`: placeholders are expanded from a per-load env snapshot.
 
-## Security core JWT validation
+`./config/app.yaml` example:
 
-`security/*` provides a framework-agnostic JWT validation core with deterministic dependencies.
-
-```go
-jwtCfg := config.NewJWTConfig("secret", "common-fwk", 15)
-compat := securityjwt.FromConfigJWT(jwtCfg)
-
-validator, err := securityjwt.NewValidator(compat.Options)
-if err != nil {
-	// invalid validator options (for example missing resolver)
-}
-
-validatedClaims, err := validator.Validate(ctx, rawToken)
-if err != nil {
-	if errors.Is(err, securityjwt.ErrInvalidMethod) {
-		// token alg is not in allowlist
-	}
-	if errors.Is(err, securityjwt.ErrExpiredToken) {
-		// token exp is before validator clock
-	}
-
-	var vErr *securityjwt.ValidationError
-	if errors.As(err, &vErr) {
-		// inspect stage metadata while preserving sentinel assertability
-	}
-}
-
-_ = validatedClaims
-_ = compat.TokenTTL // token issuing concern, not validator runtime enforcement
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8080
+security:
+  auth:
+    jwt:
+      secret: ${JWT_SECRET}
+      issuer: common-fwk
+      ttlMinutes: 15
+    cookie:
+      name: session
+      domain: example.com
+      secure: true
+      httpOnly: true
+      sameSite: Lax
+    login:
+      email: admin@example.com
+    oauth2:
+      providers:
+        github:
+          clientID: ${GITHUB_CLIENT_ID}
+          clientSecret: ${GITHUB_CLIENT_SECRET}
+          authURL: https://github.com/login/oauth/authorize
+          tokenURL: https://github.com/login/oauth/access_token
+          redirectURL: https://app.example.com/auth/github/callback
+          scopes: [read:user, user:email]
 ```
 
-Package boundaries:
-- `security/claims`: standard claim model and audience normalization helpers.
-- `security/keys`: deterministic key resolution contracts (`kid` + default key fallback).
-- `security/jwt`: validator options, typed/sentinel error taxonomy, validation flow, config compatibility helper.
+### 3) Security validator usage (core + compatibility facade)
 
-Explicit non-goals of this security core:
-- no Gin middleware coupling
-- no app-global singleton coupling
-- no OAuth/JWKS provider adapter/network fetch coupling
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/matiasmartin-labs/common-fwk/config"
+	securityjwt "github.com/matiasmartin-labs/common-fwk/security/jwt"
+)
+
+func main() {
+	jwtCfg := config.NewJWTConfig("secret", "common-fwk", 15)
+	compat := securityjwt.FromConfigJWT(jwtCfg)
+
+	validator, err := securityjwt.NewValidator(compat.Options)
+	if err != nil {
+		panic(err)
+	}
+
+	validatedClaims, err := validator.Validate(context.Background(), "raw-token")
+	if err != nil {
+		if errors.Is(err, securityjwt.ErrInvalidMethod) {
+			fmt.Println("invalid method")
+		}
+		if errors.Is(err, securityjwt.ErrExpiredToken) {
+			fmt.Println("expired token")
+		}
+
+		var vErr *securityjwt.ValidationError
+		if errors.As(err, &vErr) {
+			fmt.Println("validation stage error")
+		}
+		return
+	}
+
+	_ = compat.TokenTTL // token issuing concern, not validator runtime enforcement
+	fmt.Println(validatedClaims.Subject)
+}
+```
+
+### 4) Gin integration example (fluent option-style API)
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	ginfwk "github.com/matiasmartin-labs/common-fwk/http/gin"
+	"github.com/matiasmartin-labs/common-fwk/security/keys"
+	securityjwt "github.com/matiasmartin-labs/common-fwk/security/jwt"
+)
+
+func main() {
+	validator, err := securityjwt.NewValidator(securityjwt.Options{
+		Methods: []string{"HS256"},
+		Issuer:  "common-fwk",
+		Resolver: keys.NewStaticResolver(
+			&keys.Key{Method: "HS256", Verify: []byte("secret")},
+			nil,
+		),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	r := gin.New()
+	r.Use(ginfwk.NewAuthMiddleware(
+		validator,
+		ginfwk.WithHeaderName("Authorization"),
+		ginfwk.WithCookieName("session"),
+		ginfwk.WithContextKey("claims"),
+		ginfwk.WithAuthEnabled(true),
+	))
+
+	r.GET("/me", func(c *gin.Context) {
+		cl, ok := ginfwk.GetClaims(c, "claims")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"code": "auth_token_missing"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"sub": cl.Subject})
+	})
+
+	if err := r.Run(":8080"); err != nil {
+		panic(err)
+	}
+}
+```
+
+---
+
+## Layered architecture overview
+
+`common-fwk` is organized in layers to keep domain logic reusable and adapter-agnostic:
+
+1. **Core domain layer**
+   - `config`: typed config model + constructors + validation.
+   - `security/claims`, `security/keys`, `security/jwt`: token validation model/contracts/engine.
+2. **Adapter layer**
+   - `config/viper`: optional config loader adapter into core `config.Config`.
+   - `http/gin`: optional HTTP middleware adapter that depends on `security.Validator` interface.
+3. **App boundary**
+   - `app`: application bootstrap boundary.
+
+Dependency direction is always inward:
+- Adapters depend on core contracts.
+- Core packages do **not** depend on framework-specific adapters.
+
+## Package responsibilities and boundaries
+
+- `config`
+  - owns the canonical configuration model and validation rules.
+  - no global mutable state, no adapter runtime coupling.
+
+- `config/viper`
+  - optional loader facade for file + env decoding.
+  - maps adapter-local raw structs to core types, then validates via `config.ValidateConfig`.
+
+- `security/claims`
+  - claim model + audience normalization helpers.
+
+- `security/keys`
+  - deterministic key resolution contracts (`kid` + default fallback), no network fetch.
+
+- `security/jwt`
+  - framework-agnostic JWT validator options, typed errors, validation flow.
+
+- `http/gin`
+  - thin adapter that extracts tokens, calls `security.Validator`, and injects claims into `gin.Context`.
+
+## Non-goals
+
+- No app-global singleton coupling.
+- No framework lock-in inside core packages.
+- No remote provider/JWKS fetcher coupling in `security/*`.
+- **Google provider implementation is intentionally outside this framework**.
+  - This repo provides generic OAuth2 config fields.
+  - Concrete Google OAuth flows, APIs, and provider-specific behavior belong to the consuming application/service layer.

--- a/skills/common-fwk-usage/SKILL.md
+++ b/skills/common-fwk-usage/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: common-fwk-usage
+description: >
+  Create or update integration documentation and usage examples for common-fwk.
+  Trigger: When writing README quickstarts, architecture overviews, package boundaries,
+  or integration examples for config/security/http adapters.
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## When to Use
+
+- Updating README usage docs for `common-fwk`
+- Writing quickstart examples that users should follow end-to-end
+- Documenting architecture layers and dependency boundaries
+- Documenting package responsibilities and explicit non-goals
+
+## Critical Patterns
+
+- Keep examples buildable: include `package main`, imports, and `main()` when snippet scope is full-flow.
+- Prefer explicit core API first (`config`, `security/jwt`) and then optional adapters (`config/viper`, `http/gin`).
+- Keep boundary clarity explicit: adapters depend on core contracts, never the other way around.
+- Preserve non-goals in docs: no app-global singletons, no framework lock-in in core, no remote provider coupling in `security/*`.
+- State provider ownership clearly: Google OAuth provider logic stays in consuming apps, outside this framework.
+
+## Documentation Structure
+
+1. One-line project purpose
+2. Install step (`go get ...`)
+3. Quickstart sequence:
+   - explicit core config usage
+   - optional `config/viper` facade usage
+   - `security/jwt` validator usage
+   - `http/gin` middleware integration
+4. Layered architecture overview
+5. Package responsibilities and boundaries
+6. Non-goals
+
+## Code Examples
+
+```go
+cfg := config.NewConfig(
+	config.NewServerConfig("127.0.0.1", 8080),
+	config.NewSecurityConfig(
+		config.NewAuthConfig(
+			config.NewJWTConfig("secret", "common-fwk", 15),
+			config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+			config.NewLoginConfig("admin@example.com"),
+			config.NewOAuth2Config(nil),
+		),
+	),
+)
+
+validated, err := config.ValidateConfig(cfg)
+if err != nil {
+	return
+}
+
+_ = validated
+```
+
+```go
+validator, err := securityjwt.NewValidator(securityjwt.Options{
+	Methods: []string{"HS256"},
+	Issuer:  "common-fwk",
+	Resolver: keys.NewStaticResolver(
+		&keys.Key{Method: "HS256", Verify: []byte("secret")},
+		nil,
+	),
+})
+if err != nil {
+	return
+}
+
+r := gin.New()
+r.Use(ginfwk.NewAuthMiddleware(validator))
+```
+
+## Commands
+
+```bash
+go test ./...
+```
+
+```bash
+go test ./... -run TestAuthMiddleware
+```
+
+## Resources
+
+- `README.md`
+- `config/doc.go`
+- `config/viper/doc.go`
+- `security/jwt/doc.go`
+- `http/gin/doc.go`


### PR DESCRIPTION
Closes #7

## Summary
- Reworked `README.md` into a complete integration guide with install step, quickstart flow, layered architecture overview, package boundaries, and explicit non-goals.
- Added realistic, self-contained usage examples for core config, optional `config/viper`, `security/jwt`, and `http/gin` middleware integration.
- Added a reusable project skill `common-fwk-usage` to standardize future docs updates around usage, architecture, and boundary conventions.

## Changes
| File | Change |
|------|--------|
| `README.md` | Expanded usage documentation with buildable examples and boundary/non-goal definitions |
| `skills/common-fwk-usage/SKILL.md` | Added project skill for consistent common-fwk usage docs |

## Test Plan
- [x] `go test ./...`
- [x] Verified examples align with existing package APIs and current code boundaries

## Acceptance Criteria Check
- [x] Project can be integrated by following README only
- [x] Examples are realistic and aligned with package APIs
- [x] Package responsibilities and boundaries are clearly defined