### PR TITLE
feat(app): implement Application bootstrap — issue #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,71 @@ func main() {
 }
 ```
 
+### 5) Application bootstrap boundary (`app`)
+
+`common-fwk/app` now includes an instance-based bootstrap API (no package-level singleton):
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/matiasmartin-labs/common-fwk/app"
+	"github.com/matiasmartin-labs/common-fwk/config"
+	"github.com/matiasmartin-labs/common-fwk/security/keys"
+	securityjwt "github.com/matiasmartin-labs/common-fwk/security/jwt"
+)
+
+func main() {
+	cfg := config.NewConfig(
+		config.NewServerConfig("127.0.0.1", 8080),
+		config.NewSecurityConfig(config.NewAuthConfig(
+			config.NewJWTConfig("secret", "common-fwk", 15),
+			config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+			config.NewLoginConfig("admin@example.com"),
+			config.NewOAuth2Config(nil),
+		)),
+	)
+
+	validator, err := securityjwt.NewValidator(securityjwt.Options{
+		Methods: []string{"HS256"},
+		Issuer:  "common-fwk",
+		Resolver: keys.NewStaticResolver(
+			&keys.Key{Method: "HS256", Verify: []byte("secret")},
+			nil,
+		),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	a := app.NewApplication().
+		UseConfig(cfg).
+		UseServer().
+		UseServerSecurity(validator)
+
+	_ = a.RegisterGET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	_ = a.RegisterProtectedGET("/me", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	if err := a.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+Behavior notes:
+- Register methods return typed sentinel errors when used out of order (for example, server/security not ready).
+- `RegisterProtectedGET` uses `http/gin.NewAuthMiddleware` internally.
+- `RunListener(net.Listener)` is available for test-friendly startup flows.
+
 ---
 
 ## Layered architecture overview
@@ -251,7 +316,10 @@ func main() {
    - `config/viper`: optional config loader adapter into core `config.Config`.
    - `http/gin`: optional HTTP middleware adapter that depends on `security.Validator` interface.
 3. **App boundary**
-   - `app`: application bootstrap boundary.
+- `app`: application bootstrap boundary.
+  - `Application` fluent bootstrap: `UseConfig`, `UseServer`, `UseServerSecurity`.
+  - Route registration: `RegisterGET`, `RegisterPOST`, `RegisterProtectedGET`.
+  - Runtime startup: `Run`, `RunListener`.
 
 Dependency direction is always inward:
 - Adapters depend on core contracts.

--- a/app/application.go
+++ b/app/application.go
@@ -1,0 +1,179 @@
+package app
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/matiasmartin-labs/common-fwk/config"
+	httpgin "github.com/matiasmartin-labs/common-fwk/http/gin"
+	"github.com/matiasmartin-labs/common-fwk/security"
+)
+
+var (
+	ErrServerNotReady   = errors.New("server not ready")
+	ErrSecurityNotReady = errors.New("security not ready")
+	ErrInvalidPath      = errors.New("invalid path")
+	ErrNilHandler       = errors.New("nil handler")
+	ErrNilListener      = errors.New("nil listener")
+)
+
+// Application is an instance-scoped bootstrap container.
+type Application struct {
+	cfg           config.Config
+	server        http.Server
+	handler       *gin.Engine
+	validator     security.Validator
+	serverReady   bool
+	securityReady bool
+}
+
+// NewApplication creates a bootstrap instance with safe defaults.
+func NewApplication() *Application {
+	h := gin.New()
+
+	return &Application{
+		handler: h,
+	}
+}
+
+// UseConfig sets application configuration and returns the same instance.
+func (a *Application) UseConfig(cfg config.Config) *Application {
+	a.cfg = cfg
+	return a
+}
+
+// UseServer wires the HTTP server and marks server readiness.
+func (a *Application) UseServer() *Application {
+	if a.handler == nil {
+		a.handler = gin.New()
+	}
+
+	a.server.Handler = a.handler
+	a.serverReady = true
+
+	return a
+}
+
+// UseServerSecurity sets the validator and marks security readiness.
+func (a *Application) UseServerSecurity(v security.Validator) *Application {
+	a.validator = v
+	a.securityReady = v != nil
+
+	return a
+}
+
+func (a *Application) ensureServerReady() error {
+	if !a.serverReady {
+		return ErrServerNotReady
+	}
+
+	return nil
+}
+
+func (a *Application) ensureSecurityReady() error {
+	if !a.securityReady {
+		return ErrSecurityNotReady
+	}
+
+	return nil
+}
+
+func validatePath(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return ErrInvalidPath
+	}
+
+	return nil
+}
+
+func validateHandler(h gin.HandlerFunc) error {
+	if h == nil {
+		return ErrNilHandler
+	}
+
+	return nil
+}
+
+// RegisterGET registers a GET route in the application's gin engine.
+func (a *Application) RegisterGET(path string, h gin.HandlerFunc) error {
+	if err := a.ensureServerReady(); err != nil {
+		return err
+	}
+	if err := validatePath(path); err != nil {
+		return err
+	}
+	if err := validateHandler(h); err != nil {
+		return err
+	}
+
+	a.handler.GET(path, h)
+
+	return nil
+}
+
+// RegisterPOST registers a POST route in the application's gin engine.
+func (a *Application) RegisterPOST(path string, h gin.HandlerFunc) error {
+	if err := a.ensureServerReady(); err != nil {
+		return err
+	}
+	if err := validatePath(path); err != nil {
+		return err
+	}
+	if err := validateHandler(h); err != nil {
+		return err
+	}
+
+	a.handler.POST(path, h)
+
+	return nil
+}
+
+// RegisterProtectedGET registers a GET route guarded by auth middleware.
+func (a *Application) RegisterProtectedGET(path string, h gin.HandlerFunc) error {
+	if err := a.ensureServerReady(); err != nil {
+		return err
+	}
+	if err := a.ensureSecurityReady(); err != nil {
+		return err
+	}
+	if err := validatePath(path); err != nil {
+		return err
+	}
+	if err := validateHandler(h); err != nil {
+		return err
+	}
+
+	a.handler.GET(path, httpgin.NewAuthMiddleware(a.validator), h)
+
+	return nil
+}
+
+// Run starts serving with ListenAndServe.
+func (a *Application) Run() error {
+	if err := a.ensureServerReady(); err != nil {
+		return err
+	}
+
+	a.server.Handler = a.handler
+	a.server.Addr = net.JoinHostPort(a.cfg.Server.Host, strconv.Itoa(a.cfg.Server.Port))
+
+	return a.server.ListenAndServe()
+}
+
+// RunListener starts serving on a provided listener.
+func (a *Application) RunListener(l net.Listener) error {
+	if err := a.ensureServerReady(); err != nil {
+		return err
+	}
+	if l == nil {
+		return ErrNilListener
+	}
+
+	a.server.Handler = a.handler
+
+	return a.server.Serve(l)
+}

--- a/app/application_test.go
+++ b/app/application_test.go
@@ -1,0 +1,314 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/matiasmartin-labs/common-fwk/config"
+	"github.com/matiasmartin-labs/common-fwk/security/claims"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+type fakeValidator struct {
+	validateFn func(context.Context, string) (claims.Claims, error)
+}
+
+func (f *fakeValidator) Validate(ctx context.Context, raw string) (claims.Claims, error) {
+	if f.validateFn != nil {
+		return f.validateFn(ctx, raw)
+	}
+
+	return claims.Claims{}, nil
+}
+
+func testConfig() config.Config {
+	return config.Config{
+		Server: config.ServerConfig{Host: "127.0.0.1", Port: 0},
+	}
+}
+
+func TestBootstrapChain_PreservesPointerAndReadiness(t *testing.T) {
+	a := NewApplication()
+	original := a
+
+	validator := &fakeValidator{}
+	got := a.UseConfig(testConfig()).UseServer().UseServerSecurity(validator)
+
+	if got != original {
+		t.Fatalf("expected fluent chain to preserve same pointer")
+	}
+	if !a.serverReady {
+		t.Fatalf("expected serverReady=true")
+	}
+	if !a.securityReady {
+		t.Fatalf("expected securityReady=true")
+	}
+	if a.handler == nil {
+		t.Fatalf("expected handler to be initialized")
+	}
+	if a.server.Handler == nil {
+		t.Fatalf("expected server handler wiring")
+	}
+}
+
+func TestRouteRegistration_SucceedsAfterFullBootstrap(t *testing.T) {
+	a := NewApplication().
+		UseConfig(testConfig()).
+		UseServer().
+		UseServerSecurity(&fakeValidator{})
+
+	if err := a.RegisterGET("/public-get", func(c *gin.Context) { c.String(http.StatusOK, "get") }); err != nil {
+		t.Fatalf("register GET: %v", err)
+	}
+
+	if err := a.RegisterPOST("/public-post", func(c *gin.Context) { c.String(http.StatusCreated, "post") }); err != nil {
+		t.Fatalf("register POST: %v", err)
+	}
+
+	if err := a.RegisterProtectedGET("/protected", func(c *gin.Context) { c.String(http.StatusOK, "protected") }); err != nil {
+		t.Fatalf("register protected GET: %v", err)
+	}
+
+	wGet := httptest.NewRecorder()
+	a.handler.ServeHTTP(wGet, httptest.NewRequest(http.MethodGet, "/public-get", nil))
+	if wGet.Code != http.StatusOK {
+		t.Fatalf("GET /public-get expected 200 got %d", wGet.Code)
+	}
+
+	wPost := httptest.NewRecorder()
+	a.handler.ServeHTTP(wPost, httptest.NewRequest(http.MethodPost, "/public-post", nil))
+	if wPost.Code != http.StatusCreated {
+		t.Fatalf("POST /public-post expected 201 got %d", wPost.Code)
+	}
+
+	wProtected := httptest.NewRecorder()
+	a.handler.ServeHTTP(wProtected, httptest.NewRequest(http.MethodGet, "/protected", nil))
+	if wProtected.Code != http.StatusUnauthorized {
+		t.Fatalf("GET /protected expected 401 without token got %d", wProtected.Code)
+	}
+}
+
+func TestRegisterProtectedGET_Enforcement_MissingAndInvalidToken(t *testing.T) {
+	validator := &fakeValidator{
+		validateFn: func(_ context.Context, raw string) (claims.Claims, error) {
+			if raw == "good-token" {
+				return claims.Claims{Subject: "user-1"}, nil
+			}
+			return claims.Claims{}, errors.New("invalid token")
+		},
+	}
+
+	a := NewApplication().
+		UseConfig(testConfig()).
+		UseServer().
+		UseServerSecurity(validator)
+
+	if err := a.RegisterProtectedGET("/me", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	}); err != nil {
+		t.Fatalf("register protected route: %v", err)
+	}
+
+	missing := httptest.NewRecorder()
+	a.handler.ServeHTTP(missing, httptest.NewRequest(http.MethodGet, "/me", nil))
+	if missing.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token expected 401 got %d", missing.Code)
+	}
+
+	invalidReq := httptest.NewRequest(http.MethodGet, "/me", nil)
+	invalidReq.Header.Set("Authorization", "Bearer bad-token")
+	invalid := httptest.NewRecorder()
+	a.handler.ServeHTTP(invalid, invalidReq)
+	if invalid.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid token expected 401 got %d", invalid.Code)
+	}
+}
+
+func TestOrderingGuards_ReturnExpectedErrors(t *testing.T) {
+	t.Run("register get before server", func(t *testing.T) {
+		a := NewApplication()
+		err := a.RegisterGET("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+		if !errors.Is(err, ErrServerNotReady) {
+			t.Fatalf("expected ErrServerNotReady, got %v", err)
+		}
+	})
+
+	t.Run("register post before server", func(t *testing.T) {
+		a := NewApplication()
+		err := a.RegisterPOST("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+		if !errors.Is(err, ErrServerNotReady) {
+			t.Fatalf("expected ErrServerNotReady, got %v", err)
+		}
+	})
+
+	t.Run("protected route before security", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig()).UseServer()
+		err := a.RegisterProtectedGET("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+		if !errors.Is(err, ErrSecurityNotReady) {
+			t.Fatalf("expected ErrSecurityNotReady, got %v", err)
+		}
+	})
+
+	t.Run("invalid path", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig()).UseServer()
+		err := a.RegisterGET("   ", func(c *gin.Context) { c.Status(http.StatusOK) })
+		if !errors.Is(err, ErrInvalidPath) {
+			t.Fatalf("expected ErrInvalidPath, got %v", err)
+		}
+	})
+
+	t.Run("nil handler", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig()).UseServer()
+		err := a.RegisterGET("/x", nil)
+		if !errors.Is(err, ErrNilHandler) {
+			t.Fatalf("expected ErrNilHandler, got %v", err)
+		}
+	})
+
+	t.Run("run before server", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig())
+		err := a.Run()
+		if !errors.Is(err, ErrServerNotReady) {
+			t.Fatalf("expected ErrServerNotReady, got %v", err)
+		}
+	})
+
+	t.Run("run listener nil before server", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig())
+		err := a.RunListener(nil)
+		if !errors.Is(err, ErrServerNotReady) {
+			t.Fatalf("expected ErrServerNotReady, got %v", err)
+		}
+	})
+
+	t.Run("run listener nil after server", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig()).UseServer()
+		err := a.RunListener(nil)
+		if !errors.Is(err, ErrNilListener) {
+			t.Fatalf("expected ErrNilListener, got %v", err)
+		}
+	})
+}
+
+func TestRunListener_ServesRequestAndStopsCleanly(t *testing.T) {
+	a := NewApplication().UseConfig(testConfig()).UseServer()
+	if err := a.RegisterGET("/health", func(c *gin.Context) { c.String(http.StatusOK, "ok") }); err != nil {
+		t.Fatalf("register health route: %v", err)
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- a.RunListener(l)
+	}()
+
+	url := "http://" + l.Addr().String() + "/health"
+	resp, err := waitHTTPGet(url, 2*time.Second)
+	if err != nil {
+		t.Fatalf("request health endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 got %d body=%s", resp.StatusCode, string(body))
+	}
+
+	if err := a.server.Close(); err != nil {
+		t.Fatalf("server close: %v", err)
+	}
+
+	select {
+	case serveErr := <-errCh:
+		if !errors.Is(serveErr, http.ErrServerClosed) {
+			t.Fatalf("expected http.ErrServerClosed, got %v", serveErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting RunListener to return")
+	}
+}
+
+func TestRunListener_ReturnsStartupErrors(t *testing.T) {
+	a := NewApplication().UseConfig(testConfig()).UseServer()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	err = a.RunListener(l)
+	if err == nil {
+		t.Fatalf("expected startup error for closed listener")
+	}
+}
+
+func TestRun_DelegatesToListenAndServeAndPropagatesErrors(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen occupied: %v", err)
+	}
+	defer occupied.Close()
+
+	tcpAddr, ok := occupied.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected TCP listener")
+	}
+
+	host := tcpAddr.IP.String()
+	if host == "" {
+		host = "127.0.0.1"
+	}
+
+	a := NewApplication().UseConfig(config.Config{
+		Server: config.ServerConfig{Host: host, Port: tcpAddr.Port},
+	}).UseServer()
+
+	err = a.Run()
+	if err == nil {
+		t.Fatalf("expected bind error from ListenAndServe")
+	}
+
+	if !strings.Contains(strings.ToLower(err.Error()), "address already in use") {
+		t.Fatalf("expected address-in-use error, got %v", err)
+	}
+
+	if wantAddr := net.JoinHostPort(host, strconv.Itoa(tcpAddr.Port)); a.server.Addr != wantAddr {
+		t.Fatalf("expected server.Addr=%q got %q", wantAddr, a.server.Addr)
+	}
+}
+
+func waitHTTPGet(url string, timeout time.Duration) (*http.Response, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	return nil, fmt.Errorf("timeout waiting for %s: %w", url, lastErr)
+}

--- a/bootstrap_guard_test.go
+++ b/bootstrap_guard_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 var bootstrapPackageDirs = []string{
-	"app",
+	// Keep this list for packages that MUST remain docs-only bootstrap stubs.
+	// `app` is intentionally excluded because issue-18 approved its evolution
+	// into a real implementation package.
 }
 
 func TestBootstrapPackagesRemainStructuralOnly(t *testing.T) {
@@ -170,6 +172,30 @@ func TestConfigViperPackageCanEvolveBeyondBootstrapDocs(t *testing.T) {
 
 	if len(goFiles) <= 1 {
 		t.Fatalf("config/viper package must include implementation files beyond doc.go, got %v", goFiles)
+	}
+}
+
+func TestAppPackageCanEvolveBeyondBootstrapDocs(t *testing.T) {
+	t.Helper()
+
+	entries, err := os.ReadDir("app")
+	if err != nil {
+		t.Fatalf("read app dir: %v", err)
+	}
+
+	goFiles := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		if strings.HasSuffix(entry.Name(), ".go") {
+			goFiles = append(goFiles, entry.Name())
+		}
+	}
+
+	if len(goFiles) <= 1 {
+		t.Fatalf("app package must be allowed to include implementation files beyond doc.go, got %v", goFiles)
 	}
 }
 

--- a/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/apply-progress.md
+++ b/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/apply-progress.md
@@ -1,0 +1,59 @@
+# Apply Progress: issue-18-app-bootstrap
+
+Mode: Standard (strict_tdd=false)
+
+## Task Checklist
+
+### Phase 1: Application foundation
+- ✅ 1.1 Create `app/application.go` with imports, `NewApplication()`, and sentinel errors.
+- ✅ 1.2 Define `Application` struct with required fields.
+- ✅ 1.3 Initialize default gin engine/state in `NewApplication()`.
+
+### Phase 2: Fluent bootstrap methods
+- ✅ 2.1 Implement `UseConfig(cfg config.Config) *Application`.
+- ✅ 2.2 Implement `UseServer() *Application`.
+- ✅ 2.3 Implement `UseServerSecurity(v security.Validator) *Application`.
+
+### Phase 3: Route and run operations
+- ✅ 3.1 Implement shared guard helpers for readiness/path/handler.
+- ✅ 3.2 Implement `RegisterGET`.
+- ✅ 3.3 Implement `RegisterPOST`.
+- ✅ 3.4 Implement `RegisterProtectedGET` with `http/gin.NewAuthMiddleware(a.validator)`.
+- ✅ 3.5 Implement `Run() error` with server readiness check and `ListenAndServe` delegation.
+- ✅ 3.6 Implement `RunListener(l net.Listener) error` with nil-listener guard and `Serve` delegation.
+
+### Phase 4: Tests
+- ✅ 4.1 Bootstrap chain tests.
+- ✅ 4.2 Route registration tests.
+- ✅ 4.3 Protected enforcement tests (missing/invalid token => 401).
+- ✅ 4.4 Ordering guard tests.
+- ✅ 4.5 `RunListener` behavior tests.
+- ✅ 4.6 `Run()` delegation/error propagation tests.
+
+## Decisions / Notes
+
+- Implemented sentinel names per current change key decisions and user constraints:
+  - `ErrServerNotReady`
+  - `ErrSecurityNotReady`
+  - `ErrInvalidPath`
+  - `ErrNilHandler`
+  - `ErrNilListener`
+- `UseServerSecurity(nil)` keeps `securityReady=false`; protected registration fails deterministically with `ErrSecurityNotReady`.
+- `Run()` sets `server.Addr` from `cfg.Server` using `net.JoinHostPort(host, port)` and delegates directly to `ListenAndServe()`.
+- No package-global `App` singleton was introduced.
+
+## Verification
+
+- `go build ./app/...` ✅
+- `go test ./app/...` ✅
+
+## Follow-up Fixes
+
+### Bootstrap guard conformance update
+- ✅ Updated `bootstrap_guard_test.go` so `app` is no longer treated as a structural-only bootstrap package.
+- ✅ Added explicit evolution assertion: `TestAppPackageCanEvolveBeyondBootstrapDocs`.
+- ✅ Searched for additional guard/conformance references to `app` structural-only assumption; no other files required changes.
+
+## Verification (follow-up)
+
+- `go test ./...` ✅

--- a/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/archive-report.md
+++ b/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/archive-report.md
@@ -1,0 +1,63 @@
+# Archive Report: issue-18-app-bootstrap
+
+**Date**: 2026-05-01  
+**Mode**: hybrid (OpenSpec + Engram)  
+**Source Active Dir**: `openspec/changes/active/2026-04-26-issue-18-app-bootstrap/`  
+**Archive Dir**: `openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/`
+
+## Summary
+
+Archived change `issue-18-app-bootstrap` after successful verification (PASS, no CRITICAL issues). Synced delta spec outcomes into source-of-truth specs by (1) updating the `framework-bootstrap` guard exception to include `app-bootstrap` and (2) creating finalized `app-bootstrap` main spec content under `openspec/specs/app-bootstrap/spec.md`.
+
+## Archive Move
+
+- Copied full change directory from active to archived location.
+- Deleted source active change directory after copy completed.
+- Result: archived directory now contains all lifecycle artifacts plus this archive report.
+
+## Spec Sync Actions
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| `app-bootstrap` | Created | Added finalized main spec at `openspec/specs/app-bootstrap/spec.md` from approved delta requirements/scenarios. |
+| `framework-bootstrap` | Updated | Modified existing requirement/scenario to allow approved runtime evolution in both `config` and `app` packages (`issue-2-config-core`, `issue-18-app-bootstrap`). |
+
+## Verification Gate
+
+- Verification artifact verdict: **PASS**
+- Critical issues: **None**
+- Test status: `go test ./...` passed across all packages
+
+## Implementation Snapshot (from apply + verify)
+
+- `app/application.go`: `Application` struct, fluent setup (`NewApplication`, `UseConfig`, `UseServer`, `UseServerSecurity`), route registration (`RegisterGET`, `RegisterPOST`, `RegisterProtectedGET`), runtime (`Run`, `RunListener`), deterministic sentinel errors.
+- `app/application_test.go`: end-to-end behavior coverage for chain, route registration, auth enforcement (401 missing/invalid token), ordering guards, and run behavior.
+- `bootstrap_guard_test.go`: removed `app` from structural-only bootstrap restriction; added `TestAppPackageCanEvolveBeyondBootstrapDocs`.
+
+## Engram Traceability (retrieved observation IDs)
+
+| Artifact | Topic Key | Observation ID |
+|----------|-----------|----------------|
+| Explore | `sdd/issue-18-app-bootstrap/explore` | `#326` |
+| Proposal | `sdd/issue-18-app-bootstrap/proposal` | `#329` |
+| Spec | `sdd/issue-18-app-bootstrap/spec` | `#330` |
+| Design | `sdd/issue-18-app-bootstrap/design` | `#332` |
+| Tasks | `sdd/issue-18-app-bootstrap/tasks` | `#334` |
+| Apply Progress | `sdd/issue-18-app-bootstrap/apply-progress` | `#336` |
+| Verify Report | `sdd/issue-18-app-bootstrap/verify-report` | `#339` |
+
+## Archived Contents Checklist
+
+- `explore.md` ✅
+- `proposal.md` ✅
+- `spec.md` ✅
+- `design.md` ✅
+- `tasks.md` ✅ (18/18 complete)
+- `apply-progress.md` ✅
+- `verify-report.md` ✅
+- `archive-report.md` ✅
+
+## Notes
+
+- This archive preserves complete audit history for the change.
+- Source of truth has been updated in `openspec/specs/` to reflect finalized behavior.

--- a/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/design.md
+++ b/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/design.md
@@ -1,0 +1,110 @@
+# Design: issue-18-app-bootstrap
+
+## Technical Approach
+
+Implement an instance-scoped `app.Application` that composes existing framework contracts (`config.Config`, `security.Validator`, `http/gin` auth middleware, and `*http.Server`) without globals. Setup methods are fluent (`*Application` return), while operation methods (`Register*`, `Run*`) return errors for explicit ordering/validation failures. Protected routes always attach `http/gin.NewAuthMiddleware` built from the injected validator.
+
+## Architecture Decisions
+
+| Decision | Options | Tradeoff | Choice |
+|---|---|---|---|
+| Application ownership | package-global singleton vs instance struct | singleton simplifies access but violates explicit DI/no-global policy | **Instance `Application` struct** |
+| Fluent API error model | panic on bad order vs error returns | panic is terse but unsafe in libraries | **No panic; explicit errors in `Register*`/`Run*`** |
+| Route protection wiring | internal token checks vs reuse adapter middleware | internal checks duplicate logic and drift | **Reuse `http/gin.NewAuthMiddleware`** |
+| Run testability | only `Run()` vs listener variant | only `Run()` is hard to test deterministically | **`Run()` + `RunListener(net.Listener)`** |
+
+## Data Flow
+
+Bootstrap and request flow:
+
+```
+caller
+  -> app.NewApplication()
+  -> UseConfig(config.Config)
+  -> UseServer(config.ServerConfig)
+  -> UseServerSecurity(security.Validator)
+  -> RegisterProtectedGET("/me", handler)
+       -> ginfwk.NewAuthMiddleware(validator)
+       -> engine.GET(path, authMW, handler)
+  -> Run() / RunListener(l)
+       -> http.Server{Addr, Handler: engine}
+       -> ListenAndServe / Serve(l)
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `app/application.go` | Create | `Application` struct, fluent setup methods, route registration, run methods, package errors. |
+| `app/application_test.go` | Create | Tests for chain behavior, ordering guards, protected route auth integration, and run path via listener. |
+
+## Interfaces / Contracts
+
+```go
+package app
+
+import (
+    nethttp "net/http"
+    "net"
+
+    gingonic "github.com/gin-gonic/gin"
+    "github.com/matiasmartin-labs/common-fwk/config"
+    "github.com/matiasmartin-labs/common-fwk/security"
+)
+
+type Application struct {
+    engine    *gingonic.Engine
+    cfg       config.Config
+    validator security.Validator
+    server    *nethttp.Server
+
+    hasConfig    bool
+    hasServer    bool
+    hasValidator bool
+}
+
+func NewApplication() *Application
+
+func (a *Application) UseConfig(cfg config.Config) *Application
+func (a *Application) UseServer(cfg config.ServerConfig) *Application
+func (a *Application) UseServerSecurity(v security.Validator) *Application
+
+func (a *Application) RegisterGET(path string, h gingonic.HandlerFunc) error
+func (a *Application) RegisterPOST(path string, h gingonic.HandlerFunc) error
+func (a *Application) RegisterProtectedGET(path string, h gingonic.HandlerFunc) error
+
+func (a *Application) Run() error
+func (a *Application) RunListener(l net.Listener) error
+```
+
+Guard/error contract (package-level sentinels, wrapped with context):
+- `ErrServerNotConfigured` for `Register*`/`Run*` before `UseServer`.
+- `ErrValidatorNotConfigured` for `RegisterProtectedGET` before `UseServerSecurity`.
+- `ErrNilHandler` for nil handlers.
+- `ErrInvalidPath` for empty/blank paths.
+- `ErrNilListener` for `RunListener(nil)`.
+
+`RegisterProtectedGET` wiring detail:
+- Build middleware: `authMW := ginfwk.NewAuthMiddleware(a.validator)`.
+- Register route: `a.engine.GET(path, authMW, h)`.
+- No custom auth logic in `app`; adapter remains source of auth semantics.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Fluent chain preserves same pointer and sets state | Table tests on `UseConfig/UseServer/UseServerSecurity` |
+| Unit | Method-order guards return expected sentinel errors | Call `Register*`/`Run*` without prerequisites and assert `errors.Is` |
+| Integration-lite | Protected route enforces auth middleware | `httptest.NewRecorder` + `httptest.NewRequest`; 401 without token, 200 with fake validator token |
+| Integration-lite | `RunListener` serves requests and shuts down cleanly | `net.Listen("tcp", "127.0.0.1:0")`, run in goroutine, issue HTTP call, close server |
+
+`Run()` remains blocking and thin: it delegates to configured `server.ListenAndServe()`.
+
+## Migration / Rollout
+
+No migration required. Services can incrementally replace local bootstrap wiring with `app.Application` while keeping existing validators/config loaders.
+
+## Open Questions
+
+- [ ] Should `UseServer` also validate host/port via `config.ValidateConfig`, or trust already-validated inputs?
+- [ ] Do we expose a `Shutdown(context.Context)` method in this change, or keep lifecycle minimal and defer to a follow-up issue?

--- a/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/explore.md
+++ b/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/explore.md
@@ -1,0 +1,47 @@
+## Exploration: issue-18-app-bootstrap
+
+### Current State
+The `app` package in `common-fwk` is currently a boundary stub only (`app/doc.go`) and contains no runtime bootstrap implementation. Core dependencies needed by an app bootstrap layer already exist: typed config values in `config`, JWT/security contracts in `security`, and reusable Gin auth middleware in `http/gin`.
+
+Relevant available contracts today:
+- `security.Validator` (`security/validator.go`) exposes `Validate(ctx, raw)` and is exactly what `http/gin.NewAuthMiddleware` expects.
+- `security/keys.Resolver` exists and is wired through `security/jwt.Options.Resolver`; resolver constructors include `NewStaticResolver`, `NewRSAResolver`, `NewRSAPublicKeyResolver`.
+- `config` currently exposes concrete types (`config.Config`, `config.ServerConfig`, etc.) but no config interface abstraction in the core package.
+
+Issue #17 dependency check: RSA resolver functionality is implemented and archived (`openspec/changes/archived/2026-04-26-issue-17-rsa-key-resolver/*`) with passing verify report, so the blocker is functionally resolved for `UseServerSecurity` design work.
+
+### Affected Areas
+- `app/doc.go` — package currently empty; bootstrap implementation goes here (new files expected).
+- `config/types.go` — defines the concrete config shape the app bootstrap may consume.
+- `config/viper/loader.go` — current adapter that materializes validated `config.Config` from file/env.
+- `security/validator.go` — interface required by app-level protected route wiring.
+- `security/jwt/options.go` + `security/jwt/compat.go` — validator option assembly patterns and resolver requirement.
+- `security/keys/resolver.go`, `security/keys/rsa.go` — key resolver contracts and RSA constructors used by JWT validation setup.
+- `http/gin/middleware.go` — provides `NewAuthMiddleware(validator security.Validator, opts ...Option)` required by `RegisterProtectedGET`.
+- `http/gin/middleware_test.go` — existing behavior reference for protected route middleware semantics and error contract.
+
+### Approaches
+1. **Direct port with framework boundary adaptation** — replicate `auth-provider-ms/pkg/application.go` shape, but replace globals and service-specific internals with `common-fwk` contracts.
+   - Pros: Fastest path; closely matches known API (`UseConfig`, `UseServer`, route registration, `Run`), low migration friction for consumers.
+   - Cons: Risk of carrying old assumptions (global-ish lifecycle/order coupling, implicit config loading, side-effect-heavy chain steps).
+   - Effort: Medium.
+
+2. **Interface-first bootstrap assembly** — keep the same public methods but implement with explicit dependency fields (config value, gin engine, validator) and strict guardrails (panic-free, order validation, explicit errors).
+   - Pros: Better alignment with `common-fwk` package philosophy (no globals, explicit dependencies, testability); cleaner future extension.
+   - Cons: Slightly more design effort now; may differ subtly from auth-provider-ms behavior and need clearer migration docs.
+   - Effort: Medium.
+
+### Recommendation
+Adopt **Approach 2 (interface-first assembly)** while preserving the requested API surface. Implement `Application` as an instance-scoped struct with fluent methods returning `*Application` (or `(*Application, error)` where needed), but keep state explicit and non-global. `RegisterProtectedGET` should always compose `http/gin.NewAuthMiddleware` with a stored `security.Validator` dependency and never use package singletons.
+
+This gives compatibility with the requested bootstrap chain while staying true to `common-fwk` architectural direction (adapter-independent, no global mutable state, explicit contracts).
+
+### Risks
+- **Config boundary ambiguity**: `config` has no interface type, only structs. `UseConfig` signature must choose between accepting `config.Config` directly vs adapter function/provider contract in `app` package.
+- **Method-order safety**: calling `Register*` before `UseServer`, or `RegisterProtectedGET` before security setup, can panic unless guarded.
+- **`UseServerSecurity` contract uncertainty**: blocker #17 is implemented, but issue-18 still needs to define whether security setup builds a JWT validator internally from config (`jwt.FromConfigJWT` + resolver) or accepts injected validator/resolver.
+- **Testability of `Run`**: direct `ListenAndServe` can block tests; design should allow entrypoint-only verification or injectable server start behavior.
+- **Port drift from source service**: auth-provider-ms implementation includes service-specific concepts (`KeyPair`, local token validation) that should not leak into `common-fwk/app`.
+
+### Ready for Proposal
+Yes — with one clarification recommended for proposal/spec phase: finalize `UseConfig` and `UseServerSecurity` method signatures (value injection vs constructor behavior) so tasks can be written without interface churn.

--- a/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/proposal.md
+++ b/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: issue-18-app-bootstrap
+
+## Intent
+
+Enable a real `app` bootstrap API in `common-fwk` so services (starting with `auth-provider-ms`) can migrate startup wiring into the framework. This removes ad-hoc service bootstrap code while preserving explicit dependency injection and no-singleton architecture.
+
+## Scope
+
+### In Scope
+- Introduce `app.Application` instance-based bootstrap (no package-global `App`).
+- Add bootstrap methods: `UseConfig(config.Config)`, `UseServer(config.ServerConfig)`, `UseServerSecurity(security.Validator)`, `RegisterGET`, `RegisterPOST`, `RegisterProtectedGET`, `Run`.
+- Wire protected route registration through `http/gin.NewAuthMiddleware(validator, opts...)`.
+- Add tests for bootstrap chain, route registration, and protected-route enforcement.
+
+### Out of Scope
+- Config loader abstractions (`viper`/provider interfaces) beyond accepting `config.Config` values.
+- Internal JWT validator construction in `app` (validator is injected).
+- Advanced lifecycle features (graceful shutdown orchestration, middleware registries, DI container).
+
+## Capabilities
+
+### New Capabilities
+- `app-bootstrap`: Runtime application bootstrap composition for config, server, route registration, auth-protected routing, and run entrypoint.
+
+### Modified Capabilities
+- `framework-bootstrap`: Relax bootstrap-only guard for `app/` similarly to prior `config/` exception, allowing approved runtime implementation under this change.
+
+## Approach
+
+Implement `Application` as an instance-scoped struct holding config, Gin engine/server state, and injected `security.Validator`. Keep method chaining for setup methods; enforce ordering through explicit `error` returns in `Register*` and `Run` when prerequisites are missing (instead of panics). `RegisterProtectedGET` composes `gin.NewAuthMiddleware` with stored validator and rejects registration if validator is unset. Make `Run` test-friendly by accepting an optional listener path (or equivalent injectable start path) so tests avoid hard blocking and random ports.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `app/` | New | `Application` implementation and API surface |
+| `app/*_test.go` | New | Chain/order/route/protected-route tests |
+| `openspec/changes/active/2026-04-26-issue-18-app-bootstrap/specs/` | New | Delta specs for new capability and bootstrap exception |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Method-order misuse by consumers | Med | Return explicit errors for missing server/validator |
+| API drift vs service bootstrap expectations | Med | Keep required method names and cover chain behavior with tests |
+| `Run` signature churn | Low | Lock testable run contract in spec before implementation |
+
+## Rollback Plan
+
+Revert `app` runtime files and related specs/tests, returning `app` to stub-only state (`doc.go`) while preserving unaffected capabilities.
+
+## Dependencies
+
+- `issue-17-rsa-key-resolver` (completed; provides resolver readiness for injected validator flows).
+
+## Success Criteria
+
+- [ ] `app.Application` bootstrap works end-to-end with framework contracts and no global singleton.
+- [ ] `RegisterProtectedGET` always applies `http/gin.NewAuthMiddleware` with injected `security.Validator`.
+- [ ] Tests verify bootstrap chain, route registration, and protected-route enforcement behavior.

--- a/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/spec.md
+++ b/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/spec.md
@@ -1,0 +1,79 @@
+# Delta Spec: issue-18-app-bootstrap
+
+## ADDED Requirements — app-bootstrap
+
+### Functional Requirements
+1. The framework MUST provide an instance-scoped `Application` bootstrap API in `app` and MUST NOT require any package-global singleton (for example, no global `App` variable).
+2. `UseConfig(cfg config.Config)`, `UseServer()`, and `UseServerSecurity(v security.Validator)` MUST support fluent chaining on the same `Application` instance.
+3. The API MUST provide `RegisterGET`, `RegisterPOST`, and `RegisterProtectedGET` for route registration.
+4. `RegisterProtectedGET` MUST wire authentication through `http/gin.NewAuthMiddleware` using the validator configured by `UseServerSecurity`.
+5. Misordered usage (for example registering routes before server setup, or protected routes before validator setup) MUST fail deterministically with an error and MUST NOT silently succeed.
+6. `Run()` MUST start application serving via configured framework components and MUST return execution/startup errors instead of terminating the process directly.
+
+### Non-Functional Requirements
+- The bootstrap API SHOULD remain test-friendly: behavior MUST be verifiable through automated tests without requiring process-level exits.
+- Startup wiring MUST preserve explicit dependency injection boundaries (config and validator are provided by caller).
+- Route registration behavior MUST be deterministic and reproducible across test runs.
+
+#### Scenario: Happy path bootstrap chain
+- GIVEN a new `Application` instance
+- WHEN the caller chains `UseConfig(...).UseServer().UseServerSecurity(...)`
+- THEN each step succeeds on the same instance
+- AND the application becomes ready for route registration and run
+
+#### Scenario: Route registration for GET, POST, and protected GET
+- GIVEN an application with config, server, and validator already configured
+- WHEN `RegisterGET`, `RegisterPOST`, and `RegisterProtectedGET` are invoked for distinct paths
+- THEN all routes are registered successfully
+- AND the protected route is registered with auth middleware
+
+#### Scenario: Protected route enforcement for missing token
+- GIVEN a protected GET route registered through `RegisterProtectedGET`
+- WHEN a request is sent without an authorization token
+- THEN the response status is `401 Unauthorized`
+
+#### Scenario: Protected route enforcement for invalid token
+- GIVEN a protected GET route registered through `RegisterProtectedGET`
+- WHEN a request is sent with an invalid authorization token
+- THEN the response status is `401 Unauthorized`
+
+#### Scenario: Method ordering guard
+- GIVEN an `Application` where server and/or validator prerequisites are not configured
+- WHEN protected or regular route registration (or `Run`) is called out of order
+- THEN the call returns an explicit error
+- AND no implicit partial startup is performed
+
+#### Scenario: Run behavior
+- GIVEN an `Application` with required bootstrap steps completed
+- WHEN `Run()` is invoked
+- THEN serving is started through framework wiring
+- AND startup/runtime failures are returned as errors to the caller
+
+## MODIFIED Requirements — framework-bootstrap
+
+### Requirement: Bootstrap contains no business logic
+
+Bootstrap artifacts created for the initial bootstrap phase MUST NOT include runtime/business behavior; they SHALL be limited to module metadata, package declarations/docs, and CI wiring needed for compile/test validation. This guard SHALL remain applicable to bootstrap-only packages, and SHALL NOT prevent implementation growth in packages explicitly evolved by later approved capabilities (including `config` for `config-core` and `app` for `app-bootstrap`).
+(Previously: Guard exceptions allowed `config` evolution only; `app` is now also an approved exception for this change.)
+
+#### Scenario: Bootstrap files are structural only
+- GIVEN files created by change `bootstrap-common-fwk`
+- WHEN bootstrap artifacts are reviewed
+- THEN no API handlers, auth flows, or configuration runtime logic is present
+- AND scaffold remains structural/documentary in nature
+
+#### Scenario: Business behavior is rejected during bootstrap phase
+- GIVEN a bootstrap change attempts to add functional business code
+- WHEN evaluating conformance to this specification
+- THEN the change is considered non-compliant for phase `sdd-spec`
+
+#### Scenario: Bootstrap guard allows approved config and app evolution
+- GIVEN change `issue-2-config-core` or `issue-18-app-bootstrap` includes implementation files in `config/` or `app/`
+- WHEN bootstrap structural guards are evaluated
+- THEN those guards do not fail solely because those packages contain non-doc implementation files
+- AND bootstrap-only package guard intent is preserved for unaffected packages
+
+## Out of Scope
+- Adding config provider abstractions (for example viper loader interfaces) beyond accepting `config.Config`.
+- Constructing JWT/security validators inside `app` (validator construction remains external).
+- Introducing advanced lifecycle orchestration (graceful shutdown coordinator, DI container, middleware registry).

--- a/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/tasks.md
+++ b/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: issue-18-app-bootstrap
+
+## Phase 1: Application foundation
+
+- [x] 1.1 Create `app/application.go` with package imports, constructor `NewApplication()`, and package sentinel errors (`ErrServerNotConfigured`, `ErrValidatorNotConfigured`, `ErrNilHandler`, `ErrInvalidPath`, `ErrNilListener`).
+- [x] 1.2 Define `Application` struct in `app/application.go` with fields: `cfg config.Config`, `server http.Server`, `handler *gin.Engine`, `validator security.Validator`, `serverReady bool`, `securityReady bool`. (depends on 1.1)
+- [x] 1.3 Initialize default engine/state in `NewApplication()` so a new instance is safe for fluent chaining and later route registration. (depends on 1.2)
+
+## Phase 2: Fluent bootstrap methods
+
+- [x] 2.1 Implement `UseConfig(cfg config.Config) *Application` to set config on the same instance and return receiver for chaining in `app/application.go`. (depends on 1.3)
+- [x] 2.2 Implement `UseServer() *Application` to initialize server/handler wiring and set `serverReady=true`; return same instance. (depends on 2.1)
+- [x] 2.3 Implement `UseServerSecurity(v security.Validator) *Application` to store validator, set `securityReady=true`, and return same instance. (depends on 2.2)
+
+## Phase 3: Route and run operations
+
+- [x] 3.1 Implement shared guards/helpers in `app/application.go` for path validation, nil handler validation, and server/security readiness checks with deterministic errors. (depends on 2.3)
+- [x] 3.2 Implement `RegisterGET(path string, h gin.HandlerFunc) error` with guard checks and `handler.GET(...)` registration. (depends on 3.1)
+- [x] 3.3 Implement `RegisterPOST(path string, h gin.HandlerFunc) error` with guard checks and `handler.POST(...)` registration. (depends on 3.1)
+- [x] 3.4 Implement `RegisterProtectedGET(path string, h gin.HandlerFunc) error`, wiring `http/gin.NewAuthMiddleware(a.validator)` before handler. (depends on 3.1)
+- [x] 3.5 Implement `Run() error` as blocking startup (`ListenAndServe`) with precondition checks and error returns only. (depends on 2.2)
+- [x] 3.6 Implement `RunListener(l net.Listener) error` with nil-listener guard and `server.Serve(l)` for testable runtime path. (depends on 2.2)
+
+## Phase 4: Tests by scenario
+
+- [x] 4.1 Create `app/application_test.go` test group: bootstrap chain (`UseConfig().UseServer().UseServerSecurity()`) preserves same pointer and marks readiness state. (depends on 2.3)
+- [x] 4.2 Add test group: route registration (`RegisterGET`, `RegisterPOST`, `RegisterProtectedGET`) succeeds after full bootstrap and mounts distinct paths. (depends on 3.2, 3.3, 3.4)
+- [x] 4.3 Add protected-enforcement tests: missing token returns 401 and invalid token returns 401 on `RegisterProtectedGET` routes. (depends on 3.4)
+- [x] 4.4 Add ordering-guard tests: calling `Register*`, `RegisterProtectedGET`, and `Run` before prerequisites returns expected sentinel errors. (depends on 3.1, 3.5)
+- [x] 4.5 Add run-path tests: `RunListener` serves a request on ephemeral listener and returns runtime/startup errors cleanly. (depends on 3.6)
+- [x] 4.6 Add `Run()` behavior test using controlled server setup to verify blocking path delegates to configured server and propagates errors. (depends on 3.5)

--- a/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/verify-report.md
+++ b/openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/verify-report.md
@@ -1,0 +1,144 @@
+# Verification Report
+
+**Change**: issue-18-app-bootstrap  
+**Version**: N/A  
+**Mode**: Standard (`strict_tdd=false`)  
+**Date**: 2026-05-01
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 18 |
+| Tasks complete | 18 |
+| Tasks incomplete | 0 |
+
+All `tasks.md` items are checked off, and follow-up guard fix is complete in `apply-progress.md`:
+- `bootstrap_guard_test.go` no longer treats `app` as structural-only bootstrap package.
+- `TestAppPackageCanEvolveBeyondBootstrapDocs` exists and passes.
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed
+```bash
+go build ./...
+```
+
+**Targeted tests (app package)**: ✅ 7 passed / ❌ 0 failed / ⚠️ 0 skipped
+```bash
+go test ./app/... -v
+=== RUN   TestBootstrapChain_PreservesPointerAndReadiness
+--- PASS: TestBootstrapChain_PreservesPointerAndReadiness (0.00s)
+=== RUN   TestRouteRegistration_SucceedsAfterFullBootstrap
+--- PASS: TestRouteRegistration_SucceedsAfterFullBootstrap (0.00s)
+=== RUN   TestRegisterProtectedGET_Enforcement_MissingAndInvalidToken
+--- PASS: TestRegisterProtectedGET_Enforcement_MissingAndInvalidToken (0.00s)
+=== RUN   TestOrderingGuards_ReturnExpectedErrors
+=== RUN   TestOrderingGuards_ReturnExpectedErrors/register_get_before_server
+=== RUN   TestOrderingGuards_ReturnExpectedErrors/register_post_before_server
+=== RUN   TestOrderingGuards_ReturnExpectedErrors/protected_route_before_security
+=== RUN   TestOrderingGuards_ReturnExpectedErrors/invalid_path
+=== RUN   TestOrderingGuards_ReturnExpectedErrors/nil_handler
+=== RUN   TestOrderingGuards_ReturnExpectedErrors/run_before_server
+=== RUN   TestOrderingGuards_ReturnExpectedErrors/run_listener_nil_before_server
+=== RUN   TestOrderingGuards_ReturnExpectedErrors/run_listener_nil_after_server
+--- PASS: TestOrderingGuards_ReturnExpectedErrors (0.00s)
+    --- PASS: TestOrderingGuards_ReturnExpectedErrors/register_get_before_server (0.00s)
+    --- PASS: TestOrderingGuards_ReturnExpectedErrors/register_post_before_server (0.00s)
+    --- PASS: TestOrderingGuards_ReturnExpectedErrors/protected_route_before_security (0.00s)
+    --- PASS: TestOrderingGuards_ReturnExpectedErrors/invalid_path (0.00s)
+    --- PASS: TestOrderingGuards_ReturnExpectedErrors/nil_handler (0.00s)
+    --- PASS: TestOrderingGuards_ReturnExpectedErrors/run_before_server (0.00s)
+    --- PASS: TestOrderingGuards_ReturnExpectedErrors/run_listener_nil_before_server (0.00s)
+    --- PASS: TestOrderingGuards_ReturnExpectedErrors/run_listener_nil_after_server (0.00s)
+=== RUN   TestRunListener_ServesRequestAndStopsCleanly
+--- PASS: TestRunListener_ServesRequestAndStopsCleanly (0.00s)
+=== RUN   TestRunListener_ReturnsStartupErrors
+--- PASS: TestRunListener_ReturnsStartupErrors (0.00s)
+=== RUN   TestRun_DelegatesToListenAndServeAndPropagatesErrors
+--- PASS: TestRun_DelegatesToListenAndServeAndPropagatesErrors (0.00s)
+PASS
+ok  github.com/matiasmartin-labs/common-fwk/app (cached)
+```
+
+**Full suite**: ✅ Passed
+```bash
+go test ./...
+ok  github.com/matiasmartin-labs/common-fwk
+ok  github.com/matiasmartin-labs/common-fwk/app
+ok  github.com/matiasmartin-labs/common-fwk/config
+ok  github.com/matiasmartin-labs/common-fwk/config/viper
+ok  github.com/matiasmartin-labs/common-fwk/errors
+ok  github.com/matiasmartin-labs/common-fwk/http/gin
+?   github.com/matiasmartin-labs/common-fwk/security [no test files]
+ok  github.com/matiasmartin-labs/common-fwk/security/claims
+ok  github.com/matiasmartin-labs/common-fwk/security/jwt
+ok  github.com/matiasmartin-labs/common-fwk/security/keys
+```
+
+**Coverage**: ➖ Not available / not required (`coverage_threshold: 0`)
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| app-bootstrap | Happy path bootstrap chain | `app/application_test.go > TestBootstrapChain_PreservesPointerAndReadiness` | ✅ COMPLIANT |
+| app-bootstrap | Route registration for GET, POST, and protected GET | `app/application_test.go > TestRouteRegistration_SucceedsAfterFullBootstrap` | ✅ COMPLIANT |
+| app-bootstrap | Protected route enforcement for missing token | `app/application_test.go > TestRegisterProtectedGET_Enforcement_MissingAndInvalidToken` | ✅ COMPLIANT |
+| app-bootstrap | Protected route enforcement for invalid token | `app/application_test.go > TestRegisterProtectedGET_Enforcement_MissingAndInvalidToken` | ✅ COMPLIANT |
+| app-bootstrap | Method ordering guard | `app/application_test.go > TestOrderingGuards_ReturnExpectedErrors` | ✅ COMPLIANT |
+| app-bootstrap | Run behavior | `app/application_test.go > TestRun_DelegatesToListenAndServeAndPropagatesErrors`, `TestRunListener_ServesRequestAndStopsCleanly`, `TestRunListener_ReturnsStartupErrors` | ✅ COMPLIANT |
+| framework-bootstrap (modified) | Bootstrap guard allows approved config and app evolution | `bootstrap_guard_test.go > TestAppPackageCanEvolveBeyondBootstrapDocs` | ✅ COMPLIANT |
+
+**Compliance summary**: 7/7 scenarios compliant.
+
+---
+
+### Correctness (Static — Structural Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Instance-scoped `Application`; no global singleton required | ✅ Implemented | `app/application.go` defines instance struct; repository search found no `var App *Application` |
+| Fluent `UseConfig`, `UseServer`, `UseServerSecurity` chaining | ✅ Implemented | Methods return same `*Application`; pointer/readiness test passes |
+| `RegisterGET`, `RegisterPOST`, `RegisterProtectedGET` APIs | ✅ Implemented | All registration methods implemented and tested |
+| Protected route auth wiring through `http/gin.NewAuthMiddleware` | ✅ Implemented | `RegisterProtectedGET` calls `httpgin.NewAuthMiddleware(a.validator)` |
+| Deterministic misordering failures | ✅ Implemented | Guard methods return sentinels (`ErrServerNotReady`, `ErrSecurityNotReady`, etc.), tested with `errors.Is` |
+| `Run()` returns errors (no process exit) | ✅ Implemented | Returns `ListenAndServe` error; bind error propagation covered by test |
+| `RunListener(net.Listener)` testable serving path | ✅ Implemented | Nil listener guard and serve path both tested |
+
+---
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Instance-owned bootstrap object (no globals) | ✅ Yes | Implemented as `Application` instance with constructor |
+| Explicit error-return ordering guards | ✅ Yes | No panics/silent behavior; deterministic sentinel errors |
+| Protected route middleware reuse via `http/gin` adapter | ✅ Yes | `RegisterProtectedGET` delegates to `http/gin.NewAuthMiddleware` |
+| Keep `Run()` plus `RunListener(net.Listener)` for testability | ✅ Yes | Both implemented and behaviorally tested |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive): None
+
+**WARNING** (should fix):
+1. Design/tasks mention sentinel names `ErrServerNotConfigured` / `ErrValidatorNotConfigured`, while implementation uses `ErrServerNotReady` / `ErrSecurityNotReady`. Behavior and tests are correct; naming alignment in docs would improve audit consistency.
+
+**SUGGESTION** (nice to have):
+1. Keep the guard-policy regression test (`TestAppPackageCanEvolveBeyondBootstrapDocs`) as part of future bootstrap-spec evolution checks.
+
+---
+
+### Verdict
+
+**PASS**
+
+All requested verification checks pass: requirements are implemented, task checklist is complete (18/18 + guard fix), targeted and full test suites pass, and spec scenarios are behaviorally compliant.

--- a/openspec/specs/app-bootstrap/spec.md
+++ b/openspec/specs/app-bootstrap/spec.md
@@ -1,0 +1,81 @@
+# App Bootstrap Specification
+
+## Purpose
+
+Define the runtime application bootstrap API in `app` for composing config, server, protected routing, and run behavior without global singletons.
+
+## Requirements
+
+### Requirement: Instance-scoped bootstrap API
+
+The framework MUST provide an instance-scoped `Application` bootstrap API in `app` and MUST NOT require any package-global singleton (for example, no global `App` variable).
+
+#### Scenario: Happy path bootstrap chain
+
+- GIVEN a new `Application` instance
+- WHEN the caller chains `UseConfig(...).UseServer().UseServerSecurity(...)`
+- THEN each step succeeds on the same instance
+- AND the application becomes ready for route registration and run
+
+### Requirement: Fluent setup methods
+
+`UseConfig(cfg config.Config)`, `UseServer()`, and `UseServerSecurity(v security.Validator)` MUST support fluent chaining on the same `Application` instance.
+
+### Requirement: Route registration API
+
+The API MUST provide `RegisterGET`, `RegisterPOST`, and `RegisterProtectedGET` for route registration.
+
+#### Scenario: Route registration for GET, POST, and protected GET
+
+- GIVEN an application with config, server, and validator already configured
+- WHEN `RegisterGET`, `RegisterPOST`, and `RegisterProtectedGET` are invoked for distinct paths
+- THEN all routes are registered successfully
+- AND the protected route is registered with auth middleware
+
+### Requirement: Protected route auth middleware wiring
+
+`RegisterProtectedGET` MUST wire authentication through `http/gin.NewAuthMiddleware` using the validator configured by `UseServerSecurity`.
+
+#### Scenario: Protected route enforcement for missing token
+
+- GIVEN a protected GET route registered through `RegisterProtectedGET`
+- WHEN a request is sent without an authorization token
+- THEN the response status is `401 Unauthorized`
+
+#### Scenario: Protected route enforcement for invalid token
+
+- GIVEN a protected GET route registered through `RegisterProtectedGET`
+- WHEN a request is sent with an invalid authorization token
+- THEN the response status is `401 Unauthorized`
+
+### Requirement: Deterministic ordering guards
+
+Misordered usage (for example registering routes before server setup, or protected routes before validator setup) MUST fail deterministically with an error and MUST NOT silently succeed.
+
+#### Scenario: Method ordering guard
+
+- GIVEN an `Application` where server and/or validator prerequisites are not configured
+- WHEN protected or regular route registration (or `Run`) is called out of order
+- THEN the call returns an explicit error
+- AND no implicit partial startup is performed
+
+### Requirement: Run behavior and error propagation
+
+`Run()` MUST start application serving via configured framework components and MUST return execution/startup errors instead of terminating the process directly.
+
+#### Scenario: Run behavior
+
+- GIVEN an `Application` with required bootstrap steps completed
+- WHEN `Run()` is invoked
+- THEN serving is started through framework wiring
+- AND startup/runtime failures are returned as errors to the caller
+
+### Requirement: Testability and explicit dependencies
+
+The bootstrap API SHOULD remain test-friendly: behavior MUST be verifiable through automated tests without requiring process-level exits. Startup wiring MUST preserve explicit dependency injection boundaries (config and validator are provided by caller). Route registration behavior MUST be deterministic and reproducible across test runs.
+
+## Out of Scope
+
+- Adding config provider abstractions (for example viper loader interfaces) beyond accepting `config.Config`.
+- Constructing JWT/security validators inside `app` (validator construction remains external).
+- Introducing advanced lifecycle orchestration (graceful shutdown coordinator, DI container, middleware registry).

--- a/openspec/specs/framework-bootstrap/spec.md
+++ b/openspec/specs/framework-bootstrap/spec.md
@@ -25,7 +25,7 @@ The repository MUST declare module path `github.com/matiasmartin-labs/common-fwk
 
 ### Requirement: Bootstrap contains no business logic
 
-Bootstrap artifacts created for the initial bootstrap phase MUST NOT include runtime/business behavior; they SHALL be limited to module metadata, package declarations/docs, and CI wiring needed for compile/test validation. This guard SHALL remain applicable to bootstrap-only packages, and SHALL NOT prevent implementation growth in packages explicitly evolved by later approved capabilities (including `config` for `config-core`).
+Bootstrap artifacts created for the initial bootstrap phase MUST NOT include runtime/business behavior; they SHALL be limited to module metadata, package declarations/docs, and CI wiring needed for compile/test validation. This guard SHALL remain applicable to bootstrap-only packages, and SHALL NOT prevent implementation growth in packages explicitly evolved by later approved capabilities (including `config` for `config-core` and `app` for `app-bootstrap`).
 
 #### Scenario: Bootstrap files are structural only
 
@@ -40,9 +40,9 @@ Bootstrap artifacts created for the initial bootstrap phase MUST NOT include run
 - WHEN evaluating conformance to this specification
 - THEN the change is considered non-compliant for phase `sdd-spec`
 
-#### Scenario: Bootstrap guard allows approved config evolution
+#### Scenario: Bootstrap guard allows approved config and app evolution
 
-- GIVEN change `issue-2-config-core` includes implementation files in `config/`
+- GIVEN change `issue-2-config-core` or `issue-18-app-bootstrap` includes implementation files in `config/` or `app/`
 - WHEN bootstrap structural guards are evaluated
-- THEN those guards do not fail solely because `config/` contains non-doc implementation files
+- THEN those guards do not fail solely because those packages contain non-doc implementation files
 - AND bootstrap-only package guard intent is preserved for unaffected packages


### PR DESCRIPTION
Closes #18

## Type of change
- [x] New feature

## Summary
- Implements the full `Application` bootstrap layer in `common-fwk/app` ported from `auth-provider-ms/pkg` with clean-room design
- No package-level global `App` variable — instance-based fluent API (`UseConfig → UseServer → UseServerSecurity`)
- `RegisterProtectedGET` wires `common-fwk/http/gin.NewAuthMiddleware` for JWT-protected routes

## Changes

| File | Change |
|------|--------|
| `app/application.go` | New — `Application` struct, `NewApplication`, `UseConfig`, `UseServer`, `UseServerSecurity`, `RegisterGET`, `RegisterPOST`, `RegisterProtectedGET`, `Run`, `RunListener`, sentinel errors |
| `app/application_test.go` | New — full BDD coverage: bootstrap chain, route registration, 401 enforcement, ordering guards, run behavior |
| `bootstrap_guard_test.go` | Updated — remove `app` from structural-only list, add `TestAppPackageCanEvolveBeyondBootstrapDocs` |
| `openspec/specs/framework-bootstrap/spec.md` | Updated — document `app` as approved evolution exception |
| `openspec/specs/app-bootstrap/spec.md` | New — source-of-truth spec for app bootstrap |
| `openspec/changes/archived/2026-05-01-issue-18-app-bootstrap/` | New — archived SDD artifacts |

## Test Plan
- [x] `go build ./...` — passes
- [x] `go test ./app/... -v` — all tests pass
- [x] `go test ./...` — full suite green across all packages

## Contributor Checklist
- [x] Linked an approved issue (`status:approved` on #18)
- [x] Conventional commit format used
- [x] No package-level global state introduced
- [x] `RegisterProtectedGET` wired to `http/gin.NewAuthMiddleware`
- [x] Tests cover all acceptance criteria from issue