### PR TITLE
docs(release): add v0.1.0 checklist and migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,3 +355,8 @@ Dependency direction is always inward:
 - **Google provider implementation is intentionally outside this framework**.
   - This repo provides generic OAuth2 config fields.
   - Concrete Google OAuth flows, APIs, and provider-specific behavior belong to the consuming application/service layer.
+
+## Release and migration docs
+
+- Release checklist for `v0.1.0`: `docs/releases/v0.1.0-checklist.md`
+- Migration guide for `auth-provider-ms`: `docs/migration/auth-provider-ms-v0.1.0.md`

--- a/docs/migration/auth-provider-ms-v0.1.0.md
+++ b/docs/migration/auth-provider-ms-v0.1.0.md
@@ -1,0 +1,90 @@
+# Migration Guide: auth-provider-ms -> common-fwk v0.1.0
+
+This guide explains how to replace legacy `auth-provider-ms/pkg` usage with `common-fwk` packages.
+
+## Scope
+
+- Consumer repository: `auth-provider-ms`
+- Target dependency: `github.com/matiasmartin-labs/common-fwk@v0.1.0`
+- Migration goal: remove framework-level logic from `pkg` and adopt `common-fwk` contracts.
+
+## Prerequisites
+
+- `common-fwk` release gate satisfied (issue #6 closed).
+- `auth-provider-ms` branch created for migration.
+- Existing auth and middleware tests available in `auth-provider-ms`.
+
+## Import Mapping
+
+Use this table as the primary replacement map from legacy `pkg` responsibilities.
+
+| Legacy responsibility in `pkg` | Replace with `common-fwk` package |
+|---|---|
+| Typed app config and validation | `github.com/matiasmartin-labs/common-fwk/config` |
+| File/env loading facade | `github.com/matiasmartin-labs/common-fwk/config/viper` |
+| JWT claims model helpers | `github.com/matiasmartin-labs/common-fwk/security/claims` |
+| JWT key resolution contracts | `github.com/matiasmartin-labs/common-fwk/security/keys` |
+| JWT validator runtime | `github.com/matiasmartin-labs/common-fwk/security/jwt` |
+| Gin auth middleware | `github.com/matiasmartin-labs/common-fwk/http/gin` |
+| Auth error code constants | `github.com/matiasmartin-labs/common-fwk/errors` |
+| App bootstrap boundary | `github.com/matiasmartin-labs/common-fwk/app` |
+
+## Ordered Refactor Sequence
+
+Follow these phases in order to avoid broken intermediate states.
+
+### 1) Config boundary migration
+
+1. Replace custom config structs used for framework concerns with `config.Config` constructors.
+2. If file/env loading is needed, adopt `config/viper.Load(...)`.
+3. Keep validation centralized through `config.ValidateConfig` (directly or via adapter).
+
+### 2) Security validator wiring migration
+
+1. Build validator via `security/jwt.NewValidator(...)`.
+2. Provide resolver through `security/keys` (for example `NewStaticResolver`, RSA resolver variants).
+3. Keep token issuing concerns in service code; validator options cover runtime token validation.
+
+### 3) Middleware migration
+
+1. Replace service-local auth middleware wiring with `http/gin.NewAuthMiddleware(validator, opts...)`.
+2. Preserve expected claims context key and token source precedence (header over cookie).
+3. Replace hardcoded auth code strings with constants from `errors` package.
+
+### 4) Application bootstrap migration
+
+1. Move server startup wiring to `app.NewApplication()`.
+2. Use fluent setup: `UseConfig(...).UseServer().UseServerSecurity(...)`.
+3. Register routes via `RegisterGET`, `RegisterPOST`, and `RegisterProtectedGET`.
+4. Use `Run()` or `RunListener(...)` depending on runtime/test context.
+
+## Compatibility and Breaking Changes
+
+### Expected compatibility
+
+- Protected routes keep `401` behavior for missing/invalid token.
+- Validator and middleware remain explicit dependency injections (no hidden global state).
+
+### Known breaking or behavior-sensitive areas
+
+- Legacy `pkg` global/singleton access patterns are not supported.
+- Error code handling should reference exported constants, not duplicated literal strings.
+- Route registration order is enforced; misordered setup returns explicit errors.
+
+## Consumer Verification Commands
+
+Run from `auth-provider-ms` root after migration changes:
+
+```bash
+go mod tidy
+go test ./...
+```
+
+Recommended parity checks:
+
+- Missing token -> `401` with `auth_token_missing`
+- Invalid token -> `401` with `auth_token_invalid`
+- Expired token -> `401`
+- Invalid issuer/audience -> `401`
+- Header token precedence over cookie token
+- Valid token injects claims into Gin context

--- a/docs/releases/v0.1.0-checklist.md
+++ b/docs/releases/v0.1.0-checklist.md
@@ -1,0 +1,60 @@
+# v0.1.0 Release Checklist
+
+Use this checklist to publish the first stable release of `common-fwk`.
+
+## Preflight
+
+- [ ] Confirm working tree is clean (`git status --short`).
+- [ ] Confirm current branch is `main` and updated (`git pull --ff-only origin main`).
+- [ ] Confirm CI is green on `main`.
+- [ ] Confirm issue #7 is closed.
+- [ ] Confirm issue #6 is closed.
+
+## Verification
+
+- [ ] Run full test suite: `go test ./...`
+- [ ] Run build validation: `go build ./...`
+- [ ] Validate README quickstart snippets remain aligned with public API.
+- [ ] Validate migration guide at `docs/migration/auth-provider-ms-v0.1.0.md` is complete.
+
+## Publication
+
+### Dependency Gate (Required)
+
+`v0.1.0` tag publication is **blocked** until issue #6 (`test(migration): port and adapt tests from auth-provider-ms/pkg`) is closed.
+
+- [ ] Issue #6 is closed and linked evidence is available (tests/parity notes).
+- [ ] Create annotated tag: `git tag -a v0.1.0 -m "Release v0.1.0"`
+- [ ] Push branch and tag: `git push origin main && git push origin v0.1.0`
+- [ ] Create GitHub Release notes from the baseline below.
+
+## Post-release Validation
+
+- [ ] In `auth-provider-ms`, update dependency to `github.com/matiasmartin-labs/common-fwk@v0.1.0`.
+- [ ] Run `go mod tidy` and `go test ./...` in `auth-provider-ms`.
+- [ ] Verify critical auth parity cases pass (missing/invalid/expired token, issuer/audience checks, claims context injection).
+
+## Release Notes Baseline
+
+Use this baseline to draft the official release notes.
+
+### Included capabilities
+
+- Config core model and validation (`config`).
+- Optional viper adapter (`config/viper`).
+- JWT validation and resolver contracts (`security/jwt`, `security/keys`, `security/claims`).
+- Gin auth middleware integration (`http/gin`).
+- Instance-based bootstrap boundary (`app`).
+- Exported auth error code constants (`errors`).
+
+### Migration impact
+
+- Consumers should replace local `pkg` abstractions with `common-fwk` package imports.
+- Startup wiring should move to `app.Application` (`UseConfig`, `UseServer`, `UseServerSecurity`).
+- Middleware wiring should use `http/gin.NewAuthMiddleware` and exported error codes.
+
+### Known limitations
+
+- No provider-specific Google OAuth implementation in this framework.
+- No app-global singleton model.
+- No advanced lifecycle orchestrator (DI container, centralized shutdown coordinator).

--- a/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/archive-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/archive-report.md
@@ -1,0 +1,56 @@
+# Archive Report
+
+**Change**: issue-8-release-v0-1-0  
+**Date**: 2026-05-01  
+**Mode**: hybrid (OpenSpec + Engram)  
+**Source Active Dir**: `openspec/changes/active/2026-05-01-issue-8-release-v0-1-0/`  
+**Archive Dir**: `openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/`
+
+## Summary
+
+Archived change `issue-8-release-v0-1-0` after successful verification (PASS, no CRITICAL issues). Synced new domain specs into source-of-truth specs and moved active change artifacts into archive.
+
+## Spec Sync Results
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| `release-readiness-docs` | Created | Added main spec at `openspec/specs/release-readiness-docs/spec.md` |
+| `adoption-migration-guide` | Created | Added main spec at `openspec/specs/adoption-migration-guide/spec.md` |
+
+## Verification Gate
+
+- Verification report: `openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/verify-report.md`
+- Verdict: **PASS**
+- CRITICAL issues: **0**
+
+## Archive Contents
+
+- `explore.md`
+- `proposal.md`
+- `specs/`
+- `design.md`
+- `tasks.md`
+- `verify-report.md`
+- `archive-report.md`
+
+## Engram References
+
+| Artifact | Topic Key |
+|----------|-----------|
+| Explore | `sdd/issue-8-release-v0-1-0/explore` |
+| Proposal | `sdd/issue-8-release-v0-1-0/proposal` |
+| Spec | `sdd/issue-8-release-v0-1-0/spec` |
+| Design | `sdd/issue-8-release-v0-1-0/design` |
+| Tasks | `sdd/issue-8-release-v0-1-0/tasks` |
+| Verify Report | `sdd/issue-8-release-v0-1-0/verify-report` |
+| Archive Report | `sdd/issue-8-release-v0-1-0/archive-report` |
+
+## Source of Truth Updated
+
+- `openspec/specs/release-readiness-docs/spec.md`
+- `openspec/specs/adoption-migration-guide/spec.md`
+
+## Post-Archive Checks
+
+- `openspec/changes/active/` no longer contains this change.
+- Archived folder is present and complete.

--- a/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/design.md
+++ b/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/design.md
@@ -1,0 +1,67 @@
+# Design: issue-8-release-v0-1-0
+
+## Technical Approach
+
+Implement docs-first release readiness by adding two focused documents (release checklist and migration guide) and linking them from `README.md`. Treat issue #6 as a hard gate in release publication instructions.
+
+## Architecture Decisions
+
+### Decision: Split release and migration docs
+
+**Choice**: Two documents under `docs/releases/` and `docs/migration/`.
+**Alternatives considered**: Single expanded `README.md` section.
+**Rationale**: Keeps README concise and makes operational docs maintainable.
+
+### Decision: Encode blocker dependency in checklist
+
+**Choice**: Add explicit "do not tag" guard until issue #6 closes.
+**Alternatives considered**: Mention blockers only in issue text.
+**Rationale**: Ensures maintainers see gate in execution flow, reducing accidental release.
+
+### Decision: Consumer migration expressed as mapping + sequence
+
+**Choice**: Include import mapping table and ordered refactor phases.
+**Alternatives considered**: Narrative-only migration notes.
+**Rationale**: Reduces ambiguity and speeds adoption in `auth-provider-ms`.
+
+## Data Flow
+
+Maintainer workflow:
+
+    Issue #8 scope
+        -> docs/releases/v0.1.0-checklist.md
+        -> docs/migration/auth-provider-ms-v0.1.0.md
+        -> README links
+        -> maintainer executes checklist
+        -> (if #6 closed) publish tag
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docs/releases/v0.1.0-checklist.md` | Create | Release gate, checklist, notes baseline |
+| `docs/migration/auth-provider-ms-v0.1.0.md` | Create | Migration mapping, sequence, compatibility notes |
+| `README.md` | Modify | Add discoverability links to new docs |
+| `openspec/changes/active/2026-05-01-issue-8-release-v0-1-0/*` | Create | SDD change artifacts |
+
+## Interfaces / Contracts
+
+No runtime code interfaces are introduced. Contract is documentation behavior enforced by specs:
+- Release checklist completeness and dependency gate presence.
+- Migration guide completeness, mapping clarity, and compatibility section.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | N/A | Documentation-only change |
+| Integration | N/A | Validate commands are accurate and executable textually |
+| E2E | N/A | Manual checklist review against issue acceptance criteria |
+
+## Migration / Rollout
+
+No migration required in this repository. Consumer migration instructions are documented for `auth-provider-ms` maintainers.
+
+## Open Questions
+
+- [ ] Whether to add a formal `CHANGELOG.md` in a follow-up before `v0.2.0`.

--- a/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/explore.md
+++ b/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/explore.md
@@ -1,0 +1,33 @@
+## Exploration: issue-8-release-v0-1-0
+
+### Current State
+Issue #8 requests release readiness for `v0.1.0` and adoption guidance for `auth-provider-ms`. The repository has robust package docs in `README.md`, but no release checklist, no migration guide, and no changelog/release-notes template. Dependency check shows issue #7 is closed, while issue #6 remains open, so final tag publication should remain gated.
+
+### Affected Areas
+- `README.md` — currently documents usage but not migration from legacy `pkg` imports.
+- `openspec/specs/` — no spec defines release/adoption documentation behavior.
+- `openspec/changes/active/2026-05-01-issue-8-release-v0-1-0/` — new SDD artifacts for this change.
+- `docs/releases/` (new) — release checklist and release notes template.
+- `docs/migration/` (new) — migration guide for `auth-provider-ms`.
+
+### Approaches
+1. **Single README expansion** — put release checklist and migration steps in `README.md`.
+   - Pros: One file, simple discoverability.
+   - Cons: README becomes overloaded; release-specific process gets buried.
+   - Effort: Low.
+
+2. **Docs split by concern** — keep README high-level, add `docs/releases/*` and `docs/migration/*` with explicit links.
+   - Pros: Clear boundaries, reusable for future releases, easier maintenance.
+   - Cons: More files to maintain.
+   - Effort: Medium.
+
+### Recommendation
+Adopt **Approach 2**. Keep quickstart and architecture in README, and add focused docs for release operations and migration. Add release gating notes that explicitly reference blockers, so maintainers avoid premature tag publication.
+
+### Risks
+- Release docs can become stale if post-release updates are not tracked.
+- Migration guide may diverge from `auth-provider-ms` implementation details.
+- Teams may misinterpret "ready" as "tag now" while issue #6 is still open.
+
+### Ready for Proposal
+Yes. Proceed with proposal/spec/design/tasks in hybrid mode, with explicit dependency gate for tag publishing.

--- a/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/proposal.md
+++ b/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: issue-8-release-v0-1-0
+
+## Intent
+
+Prepare `common-fwk` for the first public release (`v0.1.0`) with explicit release gating and migration guidance for `auth-provider-ms` to replace legacy `pkg` usage with `common-fwk` packages.
+
+## Scope
+
+### In Scope
+- Add a reusable release checklist for `v0.1.0` readiness and publication steps.
+- Add migration guide documenting import replacements, refactor sequence, and validation commands for `auth-provider-ms`.
+- Document compatibility notes and known breaking changes tied to the migration path.
+
+### Out of Scope
+- Publishing the actual git tag while dependency issue #6 is still open.
+- Implementing code changes inside `auth-provider-ms` from this repository.
+
+## Capabilities
+
+### New Capabilities
+- `release-readiness-docs`: version release checklist, gating rules, and release-notes baseline for this framework.
+- `adoption-migration-guide`: actionable migration path from `auth-provider-ms/pkg` to `common-fwk` modules.
+
+### Modified Capabilities
+- None.
+
+## Approach
+
+Create dedicated docs under `docs/releases/` and `docs/migration/`, then link them from `README.md`. Include a dependency gate section that blocks tag publication until issue #6 is closed.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `docs/releases/v0.1.0-checklist.md` | New | Release readiness + publication checklist |
+| `docs/migration/auth-provider-ms-v0.1.0.md` | New | Migration and compatibility guidance |
+| `README.md` | Modified | Add links to release/migration docs |
+| `openspec/specs/` | New | Specs for release docs and migration docs |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Docs drift from real consumer state | Med | Keep commands and mapping table testable and explicit |
+| Premature release tagging | Med | Checklist includes explicit blocker gate (#6) |
+| Ambiguous breaking-change communication | Low | Add dedicated compatibility notes section |
+
+## Rollback Plan
+
+Revert added docs and README links, and remove new specs if review determines release scope should be handled elsewhere.
+
+## Dependencies
+
+- Issue #6 (`test(migration): port and adapt tests from auth-provider-ms/pkg`) must be closed before publishing `v0.1.0` tag.
+
+## Success Criteria
+
+- [ ] Release checklist exists with clear preflight, validation, and publication steps.
+- [ ] Migration guide is actionable with import mapping and refactor sequence.
+- [ ] Known breaking changes and compatibility notes are explicitly documented.
+- [ ] README links to new docs for discoverability.

--- a/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/specs/adoption-migration-guide/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/specs/adoption-migration-guide/spec.md
@@ -1,0 +1,38 @@
+# adoption-migration-guide Specification
+
+## Purpose
+
+Define the migration documentation contract for adopting `common-fwk` in `auth-provider-ms`.
+
+## Requirements
+
+### Requirement: Publish actionable migration guide
+
+The repository MUST provide a migration guide under `docs/migration/` for replacing `auth-provider-ms/pkg` usage with `common-fwk` imports and APIs.
+
+#### Scenario: Migration guide includes import mapping
+
+- GIVEN `docs/migration/auth-provider-ms-v0.1.0.md` exists
+- WHEN a maintainer reads the guide
+- THEN it includes a mapping table from legacy `pkg` paths/usages to `common-fwk` packages
+- AND mapping entries are concrete and copyable
+
+### Requirement: Document expected refactor sequence
+
+The migration guide MUST define a step-by-step refactor sequence covering config, security validator wiring, middleware adoption, and app bootstrap boundaries.
+
+#### Scenario: Refactor sequence can be followed end-to-end
+
+- GIVEN an `auth-provider-ms` branch preparing migration
+- WHEN a maintainer executes the sequence in order
+- THEN all required replacement areas are addressed without undefined intermediate steps
+
+### Requirement: Declare compatibility and breaking changes
+
+The migration guide MUST include a compatibility section that lists known breaking changes and expected verification commands in the consumer repository.
+
+#### Scenario: Compatibility notes support validation
+
+- GIVEN migration changes were applied in `auth-provider-ms`
+- WHEN maintainers run the documented verification commands
+- THEN compatibility expectations and breaking-change impacts are explicit in the guide

--- a/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/specs/release-readiness-docs/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/specs/release-readiness-docs/spec.md
@@ -1,0 +1,39 @@
+# release-readiness-docs Specification
+
+## Purpose
+
+Define the release-readiness documentation contract for framework version publication.
+
+## Requirements
+
+### Requirement: Provide release checklist document
+
+The repository MUST provide a release checklist document for `v0.1.0` under `docs/releases/` with ordered sections for preflight, verification, publication, and post-release validation.
+
+#### Scenario: Checklist sections are present
+
+- GIVEN `docs/releases/v0.1.0-checklist.md` exists
+- WHEN maintainers review the document
+- THEN it contains preflight, verification, publication, and post-release sections
+- AND each section contains actionable checklist items
+
+### Requirement: Enforce dependency gate for tag publication
+
+Release instructions MUST state that publishing `v0.1.0` is blocked until issue #6 is closed.
+
+#### Scenario: Blocker is explicit
+
+- GIVEN a maintainer follows the release checklist
+- WHEN the maintainer reaches publication steps
+- THEN the checklist explicitly references issue #6 as a required closed dependency
+- AND it prevents proceeding as "ready to tag" while the issue is open
+
+### Requirement: Include release notes baseline
+
+The release documentation MUST include a release notes baseline that identifies included capabilities, migration impact, and known limitations.
+
+#### Scenario: Release notes baseline is consumable
+
+- GIVEN the release checklist document is read before tagging
+- WHEN release notes are prepared
+- THEN the maintainer can derive capability summary, migration impact, and limitations from the documented baseline

--- a/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/tasks.md
+++ b/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: issue-8-release-v0-1-0
+
+## Phase 1: Release documentation foundation
+
+- [x] 1.1 Create `docs/releases/v0.1.0-checklist.md` with preflight, verification, publication, and post-release sections.
+- [x] 1.2 Add explicit issue dependency gate in `docs/releases/v0.1.0-checklist.md` stating issue #6 must be closed before tagging.
+- [x] 1.3 Add release-notes baseline section in `docs/releases/v0.1.0-checklist.md` covering capabilities, migration impact, and known limitations.
+
+## Phase 2: Migration guide for auth-provider-ms
+
+- [x] 2.1 Create `docs/migration/auth-provider-ms-v0.1.0.md` with scope and prerequisites.
+- [x] 2.2 Add legacy-to-new import mapping table in `docs/migration/auth-provider-ms-v0.1.0.md` for `pkg` replacements.
+- [x] 2.3 Add ordered refactor sequence (config, security validator, middleware, app bootstrap) in `docs/migration/auth-provider-ms-v0.1.0.md`.
+- [x] 2.4 Add compatibility and breaking-changes section with consumer verification commands (`go mod tidy`, `go test ./...`).
+
+## Phase 3: Discoverability and consistency
+
+- [x] 3.1 Update `README.md` with a "Release and migration docs" section linking both new docs.
+- [x] 3.2 Review both docs for language consistency with existing README package names and examples.
+
+## Phase 4: Verification
+
+- [x] 4.1 Verify release checklist satisfies `release-readiness-docs` scenarios in `openspec/changes/active/2026-05-01-issue-8-release-v0-1-0/specs/release-readiness-docs/spec.md`.
+- [x] 4.2 Verify migration guide satisfies `adoption-migration-guide` scenarios in `openspec/changes/active/2026-05-01-issue-8-release-v0-1-0/specs/adoption-migration-guide/spec.md`.
+- [x] 4.3 Run `go test ./...` to confirm no regressions from documentation updates.

--- a/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/verify-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/verify-report.md
@@ -1,0 +1,87 @@
+# Verification Report
+
+**Change**: issue-8-release-v0-1-0  
+**Version**: N/A  
+**Mode**: Standard (`strict_tdd=false`)  
+**Date**: 2026-05-01
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 12 |
+| Tasks complete | 12 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/active/2026-05-01-issue-8-release-v0-1-0/tasks.md` are checked (`[x]`).
+
+---
+
+### Build & Tests Execution
+
+**Build**: Passed
+```bash
+go build ./...
+```
+
+**Full suite**: Passed
+```bash
+go test ./...
+ok  github.com/matiasmartin-labs/common-fwk
+ok  github.com/matiasmartin-labs/common-fwk/app
+ok  github.com/matiasmartin-labs/common-fwk/config
+ok  github.com/matiasmartin-labs/common-fwk/config/viper
+ok  github.com/matiasmartin-labs/common-fwk/errors
+ok  github.com/matiasmartin-labs/common-fwk/http/gin
+?   github.com/matiasmartin-labs/common-fwk/security [no test files]
+ok  github.com/matiasmartin-labs/common-fwk/security/claims
+ok  github.com/matiasmartin-labs/common-fwk/security/jwt
+ok  github.com/matiasmartin-labs/common-fwk/security/keys
+```
+
+**Coverage**: Not required (`coverage_threshold: 0` in `openspec/config.yaml`)
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Evidence | Result |
+|-------------|----------|----------|--------|
+| release-readiness-docs | Checklist sections are present | `docs/releases/v0.1.0-checklist.md` includes preflight/verification/publication/post-release sections with checklist actions | COMPLIANT |
+| release-readiness-docs | Blocker is explicit | `docs/releases/v0.1.0-checklist.md` publication section states tag is blocked until issue #6 is closed | COMPLIANT |
+| release-readiness-docs | Release notes baseline is consumable | `docs/releases/v0.1.0-checklist.md` has baseline for capabilities, migration impact, limitations | COMPLIANT |
+| adoption-migration-guide | Migration guide includes import mapping | `docs/migration/auth-provider-ms-v0.1.0.md` includes mapping table from legacy responsibilities to `common-fwk` packages | COMPLIANT |
+| adoption-migration-guide | Refactor sequence can be followed end-to-end | `docs/migration/auth-provider-ms-v0.1.0.md` has ordered phases: config, validator, middleware, bootstrap | COMPLIANT |
+| adoption-migration-guide | Compatibility notes support validation | `docs/migration/auth-provider-ms-v0.1.0.md` defines compatibility/breaking changes and verification commands | COMPLIANT |
+
+**Compliance summary**: 6/6 scenarios compliant.
+
+---
+
+### Correctness (Static)
+
+| Check | Status | Notes |
+|------|--------|-------|
+| Release checklist exists in expected path | Implemented | `docs/releases/v0.1.0-checklist.md` |
+| Migration guide exists in expected path | Implemented | `docs/migration/auth-provider-ms-v0.1.0.md` |
+| Dependency gate references issue #6 | Implemented | Explicit blocking note included |
+| README discoverability links added | Implemented | `README.md` has "Release and migration docs" section |
+
+---
+
+### Issues Found
+
+**CRITICAL**: None
+
+**WARNING**:
+1. Release checklist and migration guide are static docs; maintainers should keep them synchronized with future capability changes.
+
+---
+
+### Verdict
+
+**PASS**
+
+Change is compliant with all declared spec scenarios and verification rules.

--- a/openspec/specs/adoption-migration-guide/spec.md
+++ b/openspec/specs/adoption-migration-guide/spec.md
@@ -1,0 +1,38 @@
+# adoption-migration-guide Specification
+
+## Purpose
+
+Define the migration documentation contract for adopting `common-fwk` in `auth-provider-ms`.
+
+## Requirements
+
+### Requirement: Publish actionable migration guide
+
+The repository MUST provide a migration guide under `docs/migration/` for replacing `auth-provider-ms/pkg` usage with `common-fwk` imports and APIs.
+
+#### Scenario: Migration guide includes import mapping
+
+- GIVEN `docs/migration/auth-provider-ms-v0.1.0.md` exists
+- WHEN a maintainer reads the guide
+- THEN it includes a mapping table from legacy `pkg` paths/usages to `common-fwk` packages
+- AND mapping entries are concrete and copyable
+
+### Requirement: Document expected refactor sequence
+
+The migration guide MUST define a step-by-step refactor sequence covering config, security validator wiring, middleware adoption, and app bootstrap boundaries.
+
+#### Scenario: Refactor sequence can be followed end-to-end
+
+- GIVEN an `auth-provider-ms` branch preparing migration
+- WHEN a maintainer executes the sequence in order
+- THEN all required replacement areas are addressed without undefined intermediate steps
+
+### Requirement: Declare compatibility and breaking changes
+
+The migration guide MUST include a compatibility section that lists known breaking changes and expected verification commands in the consumer repository.
+
+#### Scenario: Compatibility notes support validation
+
+- GIVEN migration changes were applied in `auth-provider-ms`
+- WHEN maintainers run the documented verification commands
+- THEN compatibility expectations and breaking-change impacts are explicit in the guide

--- a/openspec/specs/release-readiness-docs/spec.md
+++ b/openspec/specs/release-readiness-docs/spec.md
@@ -1,0 +1,39 @@
+# release-readiness-docs Specification
+
+## Purpose
+
+Define the release-readiness documentation contract for framework version publication.
+
+## Requirements
+
+### Requirement: Provide release checklist document
+
+The repository MUST provide a release checklist document for `v0.1.0` under `docs/releases/` with ordered sections for preflight, verification, publication, and post-release validation.
+
+#### Scenario: Checklist sections are present
+
+- GIVEN `docs/releases/v0.1.0-checklist.md` exists
+- WHEN maintainers review the document
+- THEN it contains preflight, verification, publication, and post-release sections
+- AND each section contains actionable checklist items
+
+### Requirement: Enforce dependency gate for tag publication
+
+Release instructions MUST state that publishing `v0.1.0` is blocked until issue #6 is closed.
+
+#### Scenario: Blocker is explicit
+
+- GIVEN a maintainer follows the release checklist
+- WHEN the maintainer reaches publication steps
+- THEN the checklist explicitly references issue #6 as a required closed dependency
+- AND it prevents proceeding as "ready to tag" while the issue is open
+
+### Requirement: Include release notes baseline
+
+The release documentation MUST include a release notes baseline that identifies included capabilities, migration impact, and known limitations.
+
+#### Scenario: Release notes baseline is consumable
+
+- GIVEN the release checklist document is read before tagging
+- WHEN release notes are prepared
+- THEN the maintainer can derive capability summary, migration impact, and limitations from the documented baseline


### PR DESCRIPTION
Closes #8

## Summary
- Adds a release checklist for `v0.1.0` with explicit dependency gating on issue #6 before tag publication.
- Adds an actionable migration guide for adopting `common-fwk` in `auth-provider-ms` with mapping and ordered refactor phases.
- Completes and archives the full SDD cycle artifacts, and syncs new specs into `openspec/specs/`.

## Changes
| File | Change |
|------|--------|
| `docs/releases/v0.1.0-checklist.md` | Added release readiness checklist, publication gate, and release notes baseline |
| `docs/migration/auth-provider-ms-v0.1.0.md` | Added migration mapping, refactor sequence, compatibility notes, and verification commands |
| `README.md` | Added release/migration docs links |
| `openspec/specs/release-readiness-docs/spec.md` | Added source-of-truth spec for release readiness docs |
| `openspec/specs/adoption-migration-guide/spec.md` | Added source-of-truth spec for migration guide docs |
| `openspec/changes/archive/2026-05-01-issue-8-release-v0-1-0/*` | Added full archived SDD artifacts (explore/proposal/spec/design/tasks/verify/archive-report) |

## Test Plan
- [x] `go test ./...`
- [x] `go build ./...`
- [x] Manual verification against all scenarios in both new specs

## Checklist
- [x] Linked approved issue (`#8`)
- [x] Added exactly one `type:*` label (`type:docs`)
- [x] Updated documentation for behavior/process changes
- [x] Commit message follows conventional format