### PR TITLE
feat: automate semantic release preview and publish

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,163 @@
+name: release-preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Preview next release version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute preview version
+        id: compute
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t release_labels < <(
+            jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH" \
+              | grep -E '^release-type/(patch|minor|major)$' || true
+          )
+
+          if [[ ${#release_labels[@]} -ne 1 ]]; then
+            reason="Expected exactly one release label (release-type/patch|minor|major); found ${#release_labels[@]}: ${release_labels[*]:-(none)}"
+            echo "status=blocked" >> "$GITHUB_OUTPUT"
+            echo "reason=$reason" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Release Preview"
+              echo ""
+              echo ":warning: $reason"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          bump_type="${release_labels[0]#release-type/}"
+
+          baseline="$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)"
+          if [[ -z "$baseline" ]]; then
+            baseline="v0.0.0"
+          fi
+
+          raw="${baseline#v}"
+          IFS='.' read -r major minor patch <<< "$raw"
+
+          case "$bump_type" in
+            patch)
+              next_version="v${major}.${minor}.$((patch + 1))"
+              ;;
+            minor)
+              next_version="v${major}.$((minor + 1)).0"
+              ;;
+            major)
+              next_version="v$((major + 1)).0.0"
+              ;;
+            *)
+              reason="Unsupported bump type: $bump_type"
+              echo "status=blocked" >> "$GITHUB_OUTPUT"
+              echo "reason=$reason" >> "$GITHUB_OUTPUT"
+              {
+                echo "## Release Preview"
+                echo ""
+                echo ":warning: $reason"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+          esac
+
+          echo "status=ready" >> "$GITHUB_OUTPUT"
+          echo "baseline=$baseline" >> "$GITHUB_OUTPUT"
+          echo "bump_type=$bump_type" >> "$GITHUB_OUTPUT"
+          echo "next_version=$next_version" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Release Preview"
+            echo ""
+            echo "- Baseline: \\`$baseline\\`"
+            echo "- Bump type: \\`$bump_type\\`"
+            echo "- Next version: \\`$next_version\\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upsert preview PR comment
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_STATUS: ${{ steps.compute.outputs.status }}
+          PREVIEW_REASON: ${{ steps.compute.outputs.reason }}
+          PREVIEW_BASELINE: ${{ steps.compute.outputs.baseline }}
+          PREVIEW_BUMP_TYPE: ${{ steps.compute.outputs.bump_type }}
+          PREVIEW_NEXT_VERSION: ${{ steps.compute.outputs.next_version }}
+        with:
+          script: |
+            const marker = '<!-- release-preview -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+            const status = process.env.PREVIEW_STATUS || 'blocked';
+            const reason = process.env.PREVIEW_REASON || 'Unable to compute preview.';
+            const baseline = process.env.PREVIEW_BASELINE || 'n/a';
+            const bumpType = process.env.PREVIEW_BUMP_TYPE || 'n/a';
+            const nextVersion = process.env.PREVIEW_NEXT_VERSION || 'n/a';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            let body;
+            if (status === 'ready') {
+              body = [
+                marker,
+                '### Release Preview',
+                `- Baseline: \`${baseline}\``,
+                `- Bump type: \`${bumpType}\``,
+                `- Next version: **\`${nextVersion}\`**`,
+                '',
+                `[View workflow run](${runUrl})`,
+              ].join('\n');
+            } else {
+              body = [
+                marker,
+                '### Release Preview',
+                `:warning: ${reason}`,
+                '',
+                'Add exactly one label: `release-type/patch`, `release-type/minor`, or `release-type/major`.',
+                '',
+                `[View workflow run](${runUrl})`,
+              ].join('\n');
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment?.body?.includes(marker) &&
+              (comment.user?.type === 'Bot' || comment.user?.login?.endsWith('[bot]'))
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated release preview comment #${existing.id}`);
+            } else {
+              const created = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+              core.info(`Created release preview comment #${created.data.id}`);
+            }

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,104 @@
+name: release-publish
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  publish:
+    name: Publish semantic release
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute release version
+        id: compute
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t release_labels < <(
+            jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH" \
+              | grep -E '^release-type/(patch|minor|major)$' || true
+          )
+
+          if [[ ${#release_labels[@]} -ne 1 ]]; then
+            echo "Expected exactly one release label (release-type/patch|minor|major); found ${#release_labels[@]}: ${release_labels[*]:-(none)}"
+            exit 1
+          fi
+
+          bump_type="${release_labels[0]#release-type/}"
+
+          baseline="$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)"
+          if [[ -z "$baseline" ]]; then
+            baseline="v0.0.0"
+          fi
+
+          raw="${baseline#v}"
+          IFS='.' read -r major minor patch <<< "$raw"
+
+          case "$bump_type" in
+            patch)
+              next_version="v${major}.${minor}.$((patch + 1))"
+              ;;
+            minor)
+              next_version="v${major}.$((minor + 1)).0"
+              ;;
+            major)
+              next_version="v$((major + 1)).0.0"
+              ;;
+            *)
+              echo "Unsupported bump type: $bump_type"
+              exit 1
+              ;;
+          esac
+
+          echo "baseline=$baseline" >> "$GITHUB_OUTPUT"
+          echo "bump_type=$bump_type" >> "$GITHUB_OUTPUT"
+          echo "next_version=$next_version" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Release Publish"
+            echo ""
+            echo "- Baseline: \\`$baseline\\`"
+            echo "- Bump type: \\`$bump_type\\`"
+            echo "- Next version: \\`$next_version\\`"
+            echo "- Target SHA: \\`${{ github.event.pull_request.merge_commit_sha }}\\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_VERSION: ${{ steps.compute.outputs.next_version }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$NEXT_VERSION" ]]; then
+            echo "Computed version is empty"
+            exit 1
+          fi
+
+          if git rev-parse "$NEXT_VERSION" >/dev/null 2>&1; then
+            echo "Tag $NEXT_VERSION already exists"
+            exit 1
+          fi
+
+          git tag "$NEXT_VERSION" "$MERGE_SHA"
+          git push origin "$NEXT_VERSION"
+
+          gh release create "$NEXT_VERSION" \
+            --target "$MERGE_SHA" \
+            --title "$NEXT_VERSION" \
+            --notes "Automated release from merged PR #$PR_NUMBER"

--- a/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/apply-progress.md
+++ b/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/apply-progress.md
@@ -1,0 +1,51 @@
+# Apply Progress: issue-26-semantic-release-automation
+
+Mode: Standard (strict_tdd=false)
+
+## Task Checklist
+
+### Phase 1: SDD artifacts
+- ✅ 1.1 Create active change directory and add `explore.md`.
+- ✅ 1.2 Create `proposal.md` with scope, risks, and success criteria.
+- ✅ 1.3 Create `spec.md` with publish and preview requirements/scenarios.
+- ✅ 1.4 Create `design.md` with architecture decisions and data flow.
+
+### Phase 2: Preview workflow
+- ✅ 2.1 Added `.github/workflows/release-preview.yml` with PR event triggers.
+- ✅ 2.2 Implemented exact-one `release-type/*` validation.
+- ✅ 2.3 Implemented strict baseline lookup (`vX.Y.Z`) and semver bump logic.
+- ✅ 2.4 Added success/failure output in `GITHUB_STEP_SUMMARY`.
+- ✅ 2.5 Implemented marker-based idempotent PR comment upsert via `actions/github-script`.
+
+### Phase 3: Publish workflow
+- ✅ 3.1 Added `.github/workflows/release-publish.yml` on `pull_request.closed` with merged/main guard.
+- ✅ 3.2 Implemented exact-one `release-type/*` validation.
+- ✅ 3.3 Implemented strict baseline lookup and semver bump logic.
+- ✅ 3.4 Implemented tag push and `gh release create` for merge commit SHA.
+
+### Phase 4: Verification
+- ✅ 4.1 Parsed workflow YAML successfully using Ruby YAML parser.
+- ✅ 4.2 Verified preview success/failure paths in script logic and comment upsert behavior.
+- ✅ 4.3 Validated acceptance bump matrix with local shell harness:
+  - `v0.0.0 + patch -> v0.0.1`
+  - `v0.0.0 + minor -> v0.1.0`
+  - `v0.0.0 + major -> v1.0.0`
+  - `v1.0.0 + patch -> v1.0.1`
+  - `v1.0.0 + minor -> v1.1.0`
+  - `v1.0.0 + major -> v2.0.0`
+  - `v1.0.1 + minor -> v1.1.0`
+  - `v1.0.1 + patch -> v1.0.2`
+  - `v1.0.1 + major -> v2.0.0`
+
+## Decisions / Notes
+
+- Preview comment is mandatory and implemented as a single updatable comment with marker `<!-- release-preview -->`.
+- Baseline resolution is tag-driven with strict semver filtering to ignore non-conforming tags.
+- Publish workflow uses least privilege required for tag/release creation.
+
+## Follow-ups
+
+- Ensure repository labels exist before relying on workflows:
+  - `release-type/patch`
+  - `release-type/minor`
+  - `release-type/major`

--- a/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/design.md
+++ b/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/design.md
@@ -1,0 +1,89 @@
+# Design: issue-26-semantic-release-automation
+
+## Technical Approach
+
+Implement two GitHub Actions workflows with aligned versioning logic:
+- `release-preview.yml` computes and reports the next version on PR lifecycle events.
+- `release-publish.yml` computes and publishes the version when a PR is merged into `main`.
+
+Both workflows use shell scripts for deterministic label filtering and semantic bump calculation.
+
+## Architecture Decisions
+
+### Decision: Separate preview and publish workflows
+
+**Choice**: Two dedicated workflows.
+**Alternatives considered**: Single workflow with conditional jobs.
+**Rationale**: Clear permissions boundaries and easier maintenance/debugging.
+
+### Decision: Baseline from strict SemVer tags
+
+**Choice**: Resolve latest baseline from `git tag --list 'v*'` filtered by strict regex `^v[0-9]+\.[0-9]+\.[0-9]+$` and version sort.
+**Alternatives considered**: Query latest GitHub release only.
+**Rationale**: Tags are source of truth for version graph and remain available even if release metadata changes.
+
+### Decision: Idempotent PR comment for preview
+
+**Choice**: Upsert a single bot comment using marker `<!-- release-preview -->` via `actions/github-script`.
+**Alternatives considered**: New comment every run.
+**Rationale**: Avoid comment spam while keeping reviewers informed.
+
+## Data Flow
+
+Preview path:
+
+    PR event
+      -> collect labels
+      -> validate exactly one release-type/*
+      -> resolve baseline tag (or v0.0.0)
+      -> compute next version
+      -> write summary
+      -> upsert PR comment
+
+Publish path:
+
+    PR closed event
+      -> guard: merged == true && base == main
+      -> collect labels
+      -> validate exactly one release-type/*
+      -> resolve baseline tag (or v0.0.0)
+      -> compute next version
+      -> create tag and GitHub Release at merge SHA
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `.github/workflows/release-preview.yml` | Create | PR preview calculation + summary + comment upsert |
+| `.github/workflows/release-publish.yml` | Create | Merge-to-main release publication |
+| `openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/*` | Create | SDD artifacts |
+
+## Interfaces / Contracts
+
+- Input labels contract: exactly one of
+  - `release-type/patch`
+  - `release-type/minor`
+  - `release-type/major`
+- Version baseline contract: latest strict `vX.Y.Z` tag, else `v0.0.0`.
+- Preview comment contract: single bot comment containing marker `<!-- release-preview -->`.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Static | Workflow syntax | `gh workflow`/YAML lint via CI parse on PR |
+| Logic | Label validation and version bump branches | Manual dry-run reasoning and explicit summary output checks |
+| Integration | Release creation path | Validate commands in workflow (`git tag`, `gh release create`) against merge SHA |
+
+## Migration / Rollout
+
+Before relying on the workflows, ensure repository labels exist:
+- `release-type/patch`
+- `release-type/minor`
+- `release-type/major`
+
+No code migration is required; rollout is workflow-only.
+
+## Open Questions
+
+- [ ] Whether to also post/update preview as a check-run output for branch protection UX.

--- a/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/explore.md
+++ b/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/explore.md
@@ -1,0 +1,28 @@
+## Exploration: issue-26-semantic-release-automation
+
+### Current State
+The repository has CI and PR validation workflows (`ci.yml`, `pr-validation.yml`) but no automation for semantic releases on merge and no release preview feedback during PR lifecycle. Current PR policy validates `type:*` labels, while the requested release flow needs a separate and explicit `release-type/*` label contract.
+
+### Affected Areas
+- `.github/workflows/` — add new workflows for preview and publish.
+- GitHub PR metadata — read `release-type/*` labels and comment preview output.
+- Release/tag stream — compute next semantic version from existing `vX.Y.Z` tags/releases.
+- `openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/` — SDD artifacts for this change.
+
+### Constraints
+- Publish is triggered by `pull_request.closed` only when merged into `main`.
+- Preview runs on PR events only and MUST NOT publish tags/releases.
+- Exactly one release label is required: `release-type/patch`, `release-type/minor`, or `release-type/major`.
+- Version baseline uses latest strict SemVer tag/release (`vX.Y.Z`) or `v0.0.0` if none exist.
+- Preview output must be visible in workflow summary and as a PR comment.
+
+### Recommendation
+Implement two dedicated workflows and keep the version-resolution logic consistent in both. For preview comments, use one idempotent bot comment updated on each run (marker-based) to avoid PR noise while preserving visibility.
+
+### Risks
+- Missing repository labels can cause repeated preview failures/noise.
+- Ambiguous label state (multiple `release-type/*`) can block publish.
+- If only releases or only tags are considered, baseline selection can drift.
+
+### Ready for Proposal
+Yes. Proceed with proposal, spec, design, tasks, workflow implementation, and verification in hybrid mode.

--- a/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/proposal.md
+++ b/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: issue-26-semantic-release-automation
+
+## Intent
+
+Automate semantic version release publication when pull requests are merged to `main`, and provide a non-publishing preview during PR lifecycle that clearly communicates the next computed version.
+
+## Scope
+
+### In Scope
+- Add publish workflow to create tag and GitHub Release on merged PRs targeting `main`.
+- Add preview workflow on PR events to compute and report next version.
+- Require exactly one `release-type/*` label for both preview and publish paths.
+- Compute next version from latest strict SemVer baseline (`vX.Y.Z`) or `v0.0.0` when none exists.
+- Post preview result to workflow summary and PR comment.
+
+### Out of Scope
+- Branch-name-based preview triggers (for example `release/*` push events).
+- Dependency on issue/task lifecycle labels for publish eligibility.
+- Changelog generation or release-note synthesis automation.
+
+## Capabilities
+
+### New Capabilities
+- `semantic-release-publish`: deterministic release/tag creation tied to merged PR intent.
+- `semantic-release-preview`: pre-merge visibility of computed next version with actionable feedback.
+
+### Modified Capabilities
+- None.
+
+## Approach
+
+Introduce two independent workflows under `.github/workflows/`:
+1. `release-publish.yml` for merged PRs to `main`.
+2. `release-preview.yml` for PR activity events.
+
+Both workflows validate release labels, resolve version baseline from existing tags, compute semantic bump, and present explicit error output for invalid label states. Preview also maintains a single bot comment in the PR using an internal marker to avoid duplicated comments.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `.github/workflows/release-publish.yml` | New | Publish release/tag after merged PR to `main` |
+| `.github/workflows/release-preview.yml` | New | PR-only preview computation and PR comment |
+| `openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/*` | New | SDD artifacts for this implementation |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Missing release-type labels in repo | Med | Fail with explicit instructions in preview/publish output |
+| Multiple release-type labels on PR | Med | Hard fail with detected label list |
+| Incorrect baseline due to non-semver tags | Low | Strict `^v[0-9]+\.[0-9]+\.[0-9]+$` filtering and version sort |
+
+## Rollback Plan
+
+Remove the two added workflows and associated SDD artifacts if maintainers choose manual releases.
+
+## Dependencies
+
+- Repository labels must exist: `release-type/patch`, `release-type/minor`, `release-type/major`.
+
+## Success Criteria
+
+- [ ] Merged PRs to `main` with valid release label publish correct semantic version release.
+- [ ] PR preview always reports computed version or explicit blocking reason.
+- [ ] Preview updates one bot comment instead of creating duplicates.
+- [ ] Workflows enforce least-privilege permissions aligned with behavior.

--- a/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/spec.md
+++ b/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/spec.md
@@ -1,0 +1,87 @@
+# Delta Spec: issue-26-semantic-release-automation
+
+## ADDED Requirements — semantic-release-publish
+
+### Requirement: Publish on merged PR to main
+
+The repository MUST provide a publish workflow that runs on pull request close events and only proceeds when the PR is merged into `main`.
+
+#### Scenario: Publish gating on merge target
+- GIVEN a pull request close event
+- WHEN the pull request is not merged OR target branch is not `main`
+- THEN release publication steps are skipped
+
+#### Scenario: Publish on valid merged PR
+- GIVEN a pull request merged into `main`
+- WHEN exactly one valid `release-type/*` label exists
+- THEN the workflow computes next semantic version
+- AND creates a tag and GitHub Release pointing at the merge commit SHA
+
+### Requirement: Enforce exactly one release-type label
+
+The publish workflow MUST require exactly one of `release-type/patch`, `release-type/minor`, or `release-type/major`.
+
+#### Scenario: No release-type label
+- GIVEN a merged PR to `main`
+- WHEN none of the allowed release labels are present
+- THEN the workflow fails with a clear message indicating a required label is missing
+
+#### Scenario: Multiple release-type labels
+- GIVEN a merged PR to `main`
+- WHEN more than one allowed release label is present
+- THEN the workflow fails with a clear message indicating label ambiguity
+
+### Requirement: Resolve SemVer baseline and compute bump
+
+The workflow MUST resolve baseline from latest strict SemVer tag matching `vX.Y.Z`; if none exist, baseline is `v0.0.0`.
+
+#### Scenario: No prior release baseline
+- GIVEN the repository has no strict SemVer tags
+- WHEN a merged PR with release-type/patch is published
+- THEN computed version is `v0.0.1`
+
+#### Scenario: Prior baseline with minor bump
+- GIVEN latest strict SemVer tag is `v1.0.1`
+- WHEN a merged PR has `release-type/minor`
+- THEN computed version is `v1.1.0`
+
+## ADDED Requirements — semantic-release-preview
+
+### Requirement: Preview on PR activity without publishing
+
+The repository MUST provide a preview workflow for pull request activity events (opened, synchronize, reopened, labeled, unlabeled, edited) that never creates tags or releases.
+
+#### Scenario: Preview computes version
+- GIVEN a PR activity event
+- WHEN exactly one valid `release-type/*` label exists
+- THEN the workflow computes and reports the next version
+- AND does not publish tag or release
+
+#### Scenario: Preview reports blocking reason
+- GIVEN a PR activity event
+- WHEN valid release labels are missing or ambiguous
+- THEN the workflow reports a clear reason that version cannot be computed
+
+### Requirement: Preview output visibility
+
+Preview results MUST be visible in both the workflow summary and a PR comment.
+
+#### Scenario: Summary and PR comment output
+- GIVEN preview workflow has executed
+- WHEN result is success or failure
+- THEN `GITHUB_STEP_SUMMARY` includes human-readable details
+- AND the PR contains a bot comment with the same outcome
+
+### Requirement: PR comment is idempotent
+
+The preview workflow MUST update a single existing bot comment instead of posting duplicates on repeated runs.
+
+#### Scenario: Existing preview comment is updated
+- GIVEN a PR already contains a preview bot comment marker
+- WHEN preview runs again
+- THEN the workflow updates the existing comment body
+- AND does not create a new preview comment
+
+## Out of Scope
+- Release automation triggered by branch naming conventions.
+- Automatic changelog generation.

--- a/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/tasks.md
+++ b/openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: issue-26-semantic-release-automation
+
+## Phase 1: SDD artifacts
+
+- [x] 1.1 Create active change directory and add `explore.md`.
+- [x] 1.2 Create `proposal.md` with scope, risks, and success criteria.
+- [x] 1.3 Create `spec.md` with publish and preview requirements/scenarios.
+- [x] 1.4 Create `design.md` with architecture decisions and data flow.
+
+## Phase 2: Preview workflow
+
+- [x] 2.1 Create `.github/workflows/release-preview.yml` with PR event triggers and read/write permissions (`contents: read`, `pull-requests: write`).
+- [x] 2.2 Implement label validation requiring exactly one `release-type/*` label.
+- [x] 2.3 Implement baseline resolution (`vX.Y.Z` strict) and semver bump logic.
+- [x] 2.4 Write preview output to `GITHUB_STEP_SUMMARY` for both success and failure states.
+- [x] 2.5 Upsert marker-based PR comment (`<!-- release-preview -->`) with computed version or blocking reason.
+
+## Phase 3: Publish workflow
+
+- [x] 3.1 Create `.github/workflows/release-publish.yml` on `pull_request.closed` with gate `merged && base == main`.
+- [x] 3.2 Implement label validation requiring exactly one `release-type/*` label.
+- [x] 3.3 Implement baseline resolution (`vX.Y.Z` strict) and semver bump logic.
+- [x] 3.4 Create git tag and GitHub Release for merge commit SHA.
+
+## Phase 4: Verification
+
+- [x] 4.1 Validate workflow YAML and shell logic syntax.
+- [x] 4.2 Verify preview output and PR comment behavior for valid/invalid label states.
+- [x] 4.3 Verify publish path matches acceptance examples from issue #26.
+- [x] 4.4 Update this checklist and create `apply-progress.md` with implementation details.


### PR DESCRIPTION
## Summary
- Add `release-preview` workflow for PR events that validates exactly one `release-type/*` label, computes the next semantic version from strict `vX.Y.Z` tags, writes a workflow summary, and upserts a single PR comment.
- Add `release-publish` workflow for merged PRs to `main` that enforces the same label contract and creates tag + GitHub Release from the merge commit SHA.
- Add full SDD hybrid artifacts for issue #26 under `openspec/changes/active/2026-05-01-issue-26-semantic-release-automation/` including exploration, proposal, spec, design, tasks, and apply-progress.

Closes #26