### PR TITLE
feat(config/viper): enforce kebab-case keys for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Behavior notes:
 - `EnvOverride=true`: uses deterministic keys (example: `COMMON_FWK_SECURITY_AUTH_JWT_SECRET`).
 - `ExpandEnv=false`: `${VAR}` placeholders are preserved.
 - `ExpandEnv=true`: placeholders are expanded from a per-load env snapshot.
+- File-based adapter keys are documented in canonical kebab-case.
+- Legacy camelCase file keys remain temporarily compatible during migration.
 
 `./config/app.yaml` example:
 
@@ -122,23 +124,23 @@ security:
     jwt:
       secret: ${JWT_SECRET}
       issuer: common-fwk
-      ttlMinutes: 15
+      ttl-minutes: 15
     cookie:
       name: session
       domain: example.com
       secure: true
-      httpOnly: true
-      sameSite: Lax
+      http-only: true
+      same-site: Lax
     login:
       email: admin@example.com
     oauth2:
       providers:
         github:
-          clientID: ${GITHUB_CLIENT_ID}
-          clientSecret: ${GITHUB_CLIENT_SECRET}
-          authURL: https://github.com/login/oauth/authorize
-          tokenURL: https://github.com/login/oauth/access_token
-          redirectURL: https://app.example.com/auth/github/callback
+          client-id: ${GITHUB_CLIENT_ID}
+          client-secret: ${GITHUB_CLIENT_SECRET}
+          auth-url: https://github.com/login/oauth/authorize
+          token-url: https://github.com/login/oauth/access_token
+          redirect-url: https://app.example.com/auth/github/callback
           scopes: [read:user, user:email]
 ```
 
@@ -358,5 +360,7 @@ Dependency direction is always inward:
 
 ## Release and migration docs
 
+- Docs index: `docs/home.md`
+- Release checklist for `v0.2.0`: `docs/releases/v0.2.0-checklist.md`
 - Release checklist for `v0.1.0`: `docs/releases/v0.1.0-checklist.md`
 - Migration guide for `auth-provider-ms`: `docs/migration/auth-provider-ms-v0.1.0.md`

--- a/config/viper/loader.go
+++ b/config/viper/loader.go
@@ -50,6 +50,8 @@ func Load(opts Options) (cfg config.Config, err error) {
 		return config.Config{}, &LoadError{Err: err}
 	}
 
+	applyLegacyKeyCompatibility(v)
+
 	var raw rawConfig
 	if err := v.Unmarshal(&raw); err != nil {
 		return config.Config{}, &DecodeError{Err: fmt.Errorf("unmarshal config: %w", err)}
@@ -97,7 +99,7 @@ func applyEnvironmentOverrides(v *viper.Viper, opts Options, snapshot map[string
 	setString("security.auth.jwt.issuer", binding("SECURITY_AUTH_JWT_ISSUER"))
 	setString("security.auth.cookie.name", binding("SECURITY_AUTH_COOKIE_NAME"))
 	setString("security.auth.cookie.domain", binding("SECURITY_AUTH_COOKIE_DOMAIN"))
-	setString("security.auth.cookie.sameSite", binding("SECURITY_AUTH_COOKIE_SAMESITE"))
+	setString("security.auth.cookie.same-site", binding("SECURITY_AUTH_COOKIE_SAMESITE"))
 	setString("security.auth.login.email", binding("SECURITY_AUTH_LOGIN_EMAIL"))
 
 	if value, ok := snapshot[binding("SERVER_PORT")]; ok {
@@ -113,7 +115,7 @@ func applyEnvironmentOverrides(v *viper.Viper, opts Options, snapshot map[string
 		if err != nil {
 			return fmt.Errorf("parse env %q as int: %w", binding("SECURITY_AUTH_JWT_TTLMINUTES"), err)
 		}
-		v.Set("security.auth.jwt.ttlMinutes", parsed)
+		v.Set("security.auth.jwt.ttl-minutes", parsed)
 	}
 
 	if value, ok := snapshot[binding("SECURITY_AUTH_COOKIE_SECURE")]; ok {
@@ -129,10 +131,91 @@ func applyEnvironmentOverrides(v *viper.Viper, opts Options, snapshot map[string
 		if err != nil {
 			return fmt.Errorf("parse env %q as bool: %w", binding("SECURITY_AUTH_COOKIE_HTTPONLY"), err)
 		}
-		v.Set("security.auth.cookie.httpOnly", parsed)
+		v.Set("security.auth.cookie.http-only", parsed)
 	}
 
 	return nil
+}
+
+func applyLegacyKeyCompatibility(v *viper.Viper) {
+	aliases := [][2]string{
+		{"security.auth.jwt.ttl-minutes", "security.auth.jwt.ttlMinutes"},
+		{"security.auth.cookie.http-only", "security.auth.cookie.httpOnly"},
+		{"security.auth.cookie.same-site", "security.auth.cookie.sameSite"},
+	}
+
+	for _, alias := range aliases {
+		canonical := alias[0]
+		legacy := alias[1]
+		if !v.IsSet(canonical) && v.IsSet(legacy) {
+			v.Set(canonical, v.Get(legacy))
+		}
+	}
+
+	providers, ok := providerSettings(v)
+	if !ok {
+		return
+	}
+
+	for providerKey := range providers {
+		applyProviderAlias(v, providerKey, "client-id", "clientID")
+		applyProviderAlias(v, providerKey, "client-secret", "clientSecret")
+		applyProviderAlias(v, providerKey, "auth-url", "authURL")
+		applyProviderAlias(v, providerKey, "token-url", "tokenURL")
+		applyProviderAlias(v, providerKey, "redirect-url", "redirectURL")
+	}
+}
+
+func providerSettings(v *viper.Viper) (map[string]any, bool) {
+	securityRaw, ok := v.AllSettings()["security"]
+	if !ok {
+		return nil, false
+	}
+
+	security, ok := securityRaw.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	authRaw, ok := security["auth"]
+	if !ok {
+		return nil, false
+	}
+
+	auth, ok := authRaw.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	oauth2Raw, ok := auth["oauth2"]
+	if !ok {
+		return nil, false
+	}
+
+	oauth2, ok := oauth2Raw.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	providersRaw, ok := oauth2["providers"]
+	if !ok {
+		return nil, false
+	}
+
+	providers, ok := providersRaw.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	return providers, true
+}
+
+func applyProviderAlias(v *viper.Viper, providerKey, canonicalKey, legacyKey string) {
+	canonicalPath := fmt.Sprintf("security.auth.oauth2.providers.%s.%s", providerKey, canonicalKey)
+	legacyPath := fmt.Sprintf("security.auth.oauth2.providers.%s.%s", providerKey, legacyKey)
+	if !v.IsSet(canonicalPath) && v.IsSet(legacyPath) {
+		v.Set(canonicalPath, v.Get(legacyPath))
+	}
 }
 
 func environmentSnapshot() map[string]string {

--- a/config/viper/loader_test.go
+++ b/config/viper/loader_test.go
@@ -22,23 +22,23 @@ security:
     jwt:
       secret: "secret"
       issuer: "common-fwk"
-      ttlMinutes: 15
+      ttl-minutes: 15
     cookie:
       name: "session"
       domain: "example.com"
       secure: true
-      httpOnly: true
-      sameSite: "Lax"
+      http-only: true
+      same-site: "Lax"
     login:
       email: "OWNER@Example.com"
     oauth2:
       providers:
         github:
-          clientID: "id"
-          clientSecret: "secret"
-          authURL: "https://github.com/login/oauth/authorize"
-          tokenURL: "https://github.com/login/oauth/access_token"
-          redirectURL: "https://app.example.com/auth/github/callback"
+          client-id: "id"
+          client-secret: "secret"
+          auth-url: "https://github.com/login/oauth/authorize"
+          token-url: "https://github.com/login/oauth/access_token"
+          redirect-url: "https://app.example.com/auth/github/callback"
           scopes: ["read:user", "user:email"]
 `)
 
@@ -131,13 +131,13 @@ security:
     jwt:
       secret: "file-secret"
       issuer: "common-fwk"
-      ttlMinutes: 15
+      ttl-minutes: 15
     cookie:
       name: "session"
       domain: "example.com"
       secure: true
-      httpOnly: true
-      sameSite: "Lax"
+      http-only: true
+      same-site: "Lax"
     login:
       email: "owner@example.com"
     oauth2:
@@ -175,13 +175,13 @@ security:
     jwt:
       secret: "secret"
       issuer: "common-fwk"
-      ttlMinutes: 15
+      ttl-minutes: 15
     cookie:
       name: "session"
       domain: "example.com"
       secure: true
-      httpOnly: true
-      sameSite: "Lax"
+      http-only: true
+      same-site: "Lax"
     login:
       email: "owner@example.com"
     oauth2:
@@ -230,13 +230,13 @@ security:
     jwt:
       secret: ""
       issuer: "common-fwk"
-      ttlMinutes: 15
+      ttl-minutes: 15
     cookie:
       name: "session"
       domain: "example.com"
       secure: true
-      httpOnly: true
-      sameSite: "Lax"
+      http-only: true
+      same-site: "Lax"
     login:
       email: "owner@example.com"
     oauth2:
@@ -264,6 +264,131 @@ security:
 	var coreValidation *config.ValidationError
 	if !errors.As(err, &coreValidation) {
 		t.Fatalf("expected core ValidationError to remain assertable")
+	}
+}
+
+func TestLoadLegacyCamelCaseCompatibility(t *testing.T) {
+	t.Parallel()
+
+	path := writeTestConfig(t, "legacy-camel-case.yaml", `
+server:
+  host: "127.0.0.1"
+  port: 8080
+security:
+  auth:
+    jwt:
+      secret: "secret"
+      issuer: "common-fwk"
+      ttlMinutes: 15
+    cookie:
+      name: "session"
+      domain: "example.com"
+      secure: true
+      httpOnly: true
+      sameSite: "Lax"
+    login:
+      email: "owner@example.com"
+    oauth2:
+      providers:
+        github:
+          clientID: "id"
+          clientSecret: "secret"
+          authURL: "https://github.com/login/oauth/authorize"
+          tokenURL: "https://github.com/login/oauth/access_token"
+          redirectURL: "https://app.example.com/auth/github/callback"
+          scopes: ["read:user", "user:email"]
+`)
+
+	cfg, err := Load(Options{ConfigPath: path})
+	if err != nil {
+		t.Fatalf("expected legacy camelCase keys to remain compatible, got error: %v", err)
+	}
+
+	provider := cfg.Security.Auth.OAuth2.Providers["github"]
+	if cfg.Security.Auth.JWT.TTLMinutes != 15 {
+		t.Fatalf("expected ttlMinutes compatibility mapping, got %d", cfg.Security.Auth.JWT.TTLMinutes)
+	}
+	if !cfg.Security.Auth.Cookie.HTTPOnly {
+		t.Fatalf("expected httpOnly compatibility mapping")
+	}
+	if cfg.Security.Auth.Cookie.SameSite != "Lax" {
+		t.Fatalf("expected sameSite compatibility mapping, got %q", cfg.Security.Auth.Cookie.SameSite)
+	}
+	if provider.ClientID != "id" {
+		t.Fatalf("expected provider clientID compatibility mapping, got %q", provider.ClientID)
+	}
+}
+
+func TestLoadCanonicalPrecedenceOverLegacyKeys(t *testing.T) {
+	t.Parallel()
+
+	path := writeTestConfig(t, "mixed-style.yaml", `
+server:
+  host: "127.0.0.1"
+  port: 8080
+security:
+  auth:
+    jwt:
+      secret: "secret"
+      issuer: "common-fwk"
+      ttl-minutes: 20
+      ttlMinutes: 10
+    cookie:
+      name: "session"
+      domain: "example.com"
+      secure: true
+      http-only: true
+      httpOnly: false
+      same-site: "Strict"
+      sameSite: "Lax"
+    login:
+      email: "owner@example.com"
+    oauth2:
+      providers:
+        github:
+          client-id: "canonical-id"
+          clientID: "legacy-id"
+          client-secret: "canonical-secret"
+          clientSecret: "legacy-secret"
+          auth-url: "https://canonical.example.com/auth"
+          authURL: "https://legacy.example.com/auth"
+          token-url: "https://canonical.example.com/token"
+          tokenURL: "https://legacy.example.com/token"
+          redirect-url: "https://canonical.example.com/callback"
+          redirectURL: "https://legacy.example.com/callback"
+          scopes: ["read:user"]
+`)
+
+	cfg, err := Load(Options{ConfigPath: path})
+	if err != nil {
+		t.Fatalf("expected mixed-style config to load, got error: %v", err)
+	}
+
+	provider := cfg.Security.Auth.OAuth2.Providers["github"]
+	if cfg.Security.Auth.JWT.TTLMinutes != 20 {
+		t.Fatalf("expected canonical ttl-minutes to win, got %d", cfg.Security.Auth.JWT.TTLMinutes)
+	}
+	if !cfg.Security.Auth.Cookie.HTTPOnly {
+		t.Fatalf("expected canonical http-only to win")
+	}
+	if cfg.Security.Auth.Cookie.SameSite != "Strict" {
+		t.Fatalf("expected canonical same-site to win, got %q", cfg.Security.Auth.Cookie.SameSite)
+	}
+
+	if provider.ClientID != "canonical-id" {
+		t.Fatalf("expected canonical client-id to win, got %q", provider.ClientID)
+	}
+	if provider.ClientSecret != "canonical-secret" {
+		t.Fatalf("expected canonical client-secret to win, got %q", provider.ClientSecret)
+	}
+	if provider.AuthURL != "https://canonical.example.com/auth" {
+		t.Fatalf("expected canonical auth-url to win, got %q", provider.AuthURL)
+	}
+	if provider.TokenURL != "https://canonical.example.com/token" {
+		t.Fatalf("expected canonical token-url to win, got %q", provider.TokenURL)
+	}
+	if provider.RedirectURL != "https://canonical.example.com/callback" {
+		t.Fatalf("expected canonical redirect-url to win, got %q", provider.RedirectURL)
 	}
 }
 

--- a/config/viper/mapping.go
+++ b/config/viper/mapping.go
@@ -37,15 +37,15 @@ type rawLegacy struct{}
 type rawJWTConfig struct {
 	Secret     string `mapstructure:"secret"`
 	Issuer     string `mapstructure:"issuer"`
-	TTLMinutes int    `mapstructure:"ttlMinutes"`
+	TTLMinutes int    `mapstructure:"ttl-minutes"`
 }
 
 type rawCookieConfig struct {
 	Name     string `mapstructure:"name"`
 	Domain   string `mapstructure:"domain"`
 	Secure   bool   `mapstructure:"secure"`
-	HTTPOnly bool   `mapstructure:"httpOnly"`
-	SameSite string `mapstructure:"sameSite"`
+	HTTPOnly bool   `mapstructure:"http-only"`
+	SameSite string `mapstructure:"same-site"`
 }
 
 type rawLoginConfig struct {
@@ -57,11 +57,11 @@ type rawOAuth2Config struct {
 }
 
 type rawOAuth2ProviderConfig struct {
-	ClientID     string   `mapstructure:"clientID"`
-	ClientSecret string   `mapstructure:"clientSecret"`
-	AuthURL      string   `mapstructure:"authURL"`
-	TokenURL     string   `mapstructure:"tokenURL"`
-	RedirectURL  string   `mapstructure:"redirectURL"`
+	ClientID     string   `mapstructure:"client-id"`
+	ClientSecret string   `mapstructure:"client-secret"`
+	AuthURL      string   `mapstructure:"auth-url"`
+	TokenURL     string   `mapstructure:"token-url"`
+	RedirectURL  string   `mapstructure:"redirect-url"`
 	Scopes       []string `mapstructure:"scopes"`
 }
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,0 +1,16 @@
+# common-fwk Docs Home
+
+This index groups the main project documentation pages.
+
+## Releases
+
+- `docs/releases/v0.2.0-checklist.md` — Release checklist and notes baseline for `v0.2.0`.
+- `docs/releases/v0.1.0-checklist.md` — Historical checklist used for `v0.1.0`.
+
+## Migration Guides
+
+- `docs/migration/auth-provider-ms-v0.1.0.md` — Migration steps from `auth-provider-ms/pkg` to `common-fwk`.
+
+## Notes
+
+- File-based config examples use canonical kebab-case keys (`ttl-minutes`, `http-only`, `same-site`, `client-id`, `client-secret`, `auth-url`, `token-url`, `redirect-url`).

--- a/docs/migration/auth-provider-ms-v0.1.0.md
+++ b/docs/migration/auth-provider-ms-v0.1.0.md
@@ -39,6 +39,10 @@ Follow these phases in order to avoid broken intermediate states.
 2. If file/env loading is needed, adopt `config/viper.Load(...)`.
 3. Keep validation centralized through `config.ValidateConfig` (directly or via adapter).
 
+Canonical file-config key style for `config/viper` is kebab-case (for example `ttl-minutes`,
+`http-only`, `same-site`, `client-id`, `client-secret`, `auth-url`, `token-url`, `redirect-url`).
+Legacy camelCase keys remain compatibility-only during migration and should be phased out.
+
 ### 2) Security validator wiring migration
 
 1. Build validator via `security/jwt.NewValidator(...)`.

--- a/docs/releases/v0.2.0-checklist.md
+++ b/docs/releases/v0.2.0-checklist.md
@@ -1,14 +1,13 @@
-# v0.1.0 Release Checklist
+# v0.2.0 Release Checklist
 
-Use this checklist to publish the first stable release of `common-fwk`.
+Use this checklist to publish `common-fwk` `v0.2.0`.
 
 ## Preflight
 
 - [ ] Confirm working tree is clean (`git status --short`).
 - [ ] Confirm current branch is `main` and updated (`git pull --ff-only origin main`).
 - [ ] Confirm CI is green on `main`.
-- [ ] Confirm issue #7 is closed.
-- [ ] Confirm issue #6 is closed.
+- [ ] Confirm issue #29 is closed.
 
 ## Verification
 
@@ -22,16 +21,16 @@ Use this checklist to publish the first stable release of `common-fwk`.
 
 ### Dependency Gate (Required)
 
-`v0.1.0` tag publication is **blocked** until issue #6 (`test(migration): port and adapt tests from auth-provider-ms/pkg`) is closed.
+`v0.2.0` tag publication is **blocked** until issue #29 (`feat(config/viper): enforce kebab-case keys for configuration`) is closed.
 
-- [ ] Issue #6 is closed and linked evidence is available (tests/parity notes).
-- [ ] Create annotated tag: `git tag -a v0.1.0 -m "Release v0.1.0"`
-- [ ] Push branch and tag: `git push origin main && git push origin v0.1.0`
+- [ ] Issue #29 is closed and linked evidence is available (tests/docs alignment notes).
+- [ ] Create annotated tag: `git tag -a v0.2.0 -m "Release v0.2.0"`
+- [ ] Push branch and tag: `git push origin main && git push origin v0.2.0`
 - [ ] Create GitHub Release notes from the baseline below.
 
 ## Post-release Validation
 
-- [ ] In `auth-provider-ms`, update dependency to `github.com/matiasmartin-labs/common-fwk@v0.1.0`.
+- [ ] In `auth-provider-ms`, update dependency to `github.com/matiasmartin-labs/common-fwk@v0.2.0`.
 - [ ] Run `go mod tidy` and `go test ./...` in `auth-provider-ms`.
 - [ ] Verify critical auth parity cases pass (missing/invalid/expired token, issuer/audience checks, claims context injection).
 
@@ -42,7 +41,7 @@ Use this baseline to draft the official release notes.
 ### Included capabilities
 
 - Config core model and validation (`config`).
-- Optional viper adapter (`config/viper`).
+- Optional viper adapter (`config/viper`) with canonical kebab-case file keys.
 - JWT validation and resolver contracts (`security/jwt`, `security/keys`, `security/claims`).
 - Gin auth middleware integration (`http/gin`).
 - Instance-based bootstrap boundary (`app`).
@@ -53,6 +52,7 @@ Use this baseline to draft the official release notes.
 - Consumers should replace local `pkg` abstractions with `common-fwk` package imports.
 - Startup wiring should move to `app.Application` (`UseConfig`, `UseServer`, `UseServerSecurity`).
 - Middleware wiring should use `http/gin.NewAuthMiddleware` and exported error codes.
+- File-based config snippets should use kebab-case key style.
 
 ### Known limitations
 

--- a/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/apply-progress.md
+++ b/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/apply-progress.md
@@ -1,0 +1,22 @@
+# Apply Progress: issue-29-config-viper-kebab-case-keys
+
+## Completed
+
+- Updated Viper raw mapping tags to canonical kebab-case keys in `config/viper/mapping.go`.
+- Preserved deterministic env override behavior by switching internal override target paths to canonical kebab-case keys.
+- Added legacy camelCase compatibility layer in `config/viper/loader.go` that backfills canonical paths only when canonical keys are absent.
+- Enforced deterministic precedence for mixed key styles: canonical kebab-case wins over legacy aliases.
+- Updated `config/viper/loader_test.go` fixtures to kebab-case for core scenarios.
+- Added compatibility regression tests for legacy camelCase keys and mixed-style precedence behavior.
+- Updated docs/examples to canonical kebab-case in `README.md`, migration guide, and release checklist verification section.
+- Added docs index page `docs/home.md` and prepared `docs/releases/v0.2.0-checklist.md` as the target release checklist for this change.
+
+## Verification
+
+- `go test ./config/viper` passed.
+- `go test ./...` passed.
+
+## Notes
+
+- Environment variable names were intentionally not changed.
+- Legacy camelCase file keys remain compatibility-only and are no longer documented as canonical.

--- a/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/design.md
+++ b/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/design.md
@@ -1,0 +1,84 @@
+# Design: issue-29-config-viper-kebab-case-keys
+
+## Technical Approach
+
+Preserve the existing adapter architecture (decode raw config, map to core config, then validate) and introduce canonical kebab-case key handling with deterministic legacy camelCase compatibility. The implementation keeps env override semantics stable while translating key names at decode/mapping boundaries.
+
+## Architecture Decisions
+
+### Decision: Canonicalize file-key contract to kebab-case
+
+**Choice**: Kebab-case is the default and documented format for file keys.
+**Alternatives considered**: Keep camelCase as canonical; support both with no canonical contract.
+**Rationale**: Provides consistency and readability for configuration paths while meeting issue acceptance criteria.
+
+### Decision: Keep temporary legacy camelCase compatibility
+
+**Choice**: Accept legacy camelCase aliases during decode/mapping.
+**Alternatives considered**: Breaking hard cutover.
+**Rationale**: Avoids immediate breakage for existing adopters and allows phased migration.
+
+### Decision: Deterministic precedence for mixed key styles
+
+**Choice**: When canonical kebab-case and legacy camelCase are both present for the same field, canonical kebab-case wins.
+**Alternatives considered**: Last-wins parser order; hard failure.
+**Rationale**: Predictable behavior aligned with migration intent and easier to document/test.
+
+## Data Flow
+
+File/env loading path:
+
+    config file + env snapshot
+      -> decode raw adapter model (kebab-case canonical + legacy aliases)
+      -> resolve deterministic precedence for duplicates
+      -> map raw values to core config types
+      -> apply core validation
+      -> return validated config.Config
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `config/viper/mapping.go` | Modify | Add canonical/legacy key decoding and precedence handling |
+| `config/viper/loader.go` | Modify | Keep override paths deterministic with canonical paths |
+| `config/viper/loader_test.go` | Modify | Add kebab-case and mixed-style fixtures with precedence assertions |
+| `config/viper/mapping_test.go` | Modify | Validate mapping determinism under key aliases |
+| `README.md` | Modify | Update config snippet to kebab-case |
+| `docs/migration/auth-provider-ms-v0.1.0.md` | Modify | Add/update config examples using kebab-case |
+| `docs/releases/v0.1.0-checklist.md` | Modify (if needed) | Keep release docs wording aligned with kebab-case contract |
+
+## Interfaces / Contracts
+
+- Canonical file keys:
+  - `ttl-minutes`
+  - `http-only`
+  - `same-site`
+  - `client-id`
+  - `client-secret`
+  - `auth-url`
+  - `token-url`
+  - `redirect-url`
+- Legacy compatibility aliases remain accepted for transition:
+  - `ttlMinutes`, `httpOnly`, `sameSite`, `clientID`, `clientSecret`, `authURL`, `tokenURL`, `redirectURL`
+- Deterministic duplicate rule: canonical kebab-case value wins over legacy alias.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Kebab-case fixture decode/mapping | Extend `loader_test.go` success fixture using canonical keys |
+| Unit | Legacy compatibility mapping | Add fixture using legacy camelCase keys and verify same core output |
+| Unit | Mixed key precedence determinism | Add fixture with both key styles and assert canonical key wins |
+| Unit | Env override unchanged behavior | Reuse override tests with kebab-case file keys |
+| Docs | Canonical style consistency | Update and inspect all `/docs/*` and README config examples |
+
+## Migration / Rollout
+
+Roll out as backward-compatible change:
+1. Canonicalize docs to kebab-case immediately.
+2. Keep legacy aliases supported in runtime.
+3. Communicate compatibility as transitional behavior.
+
+## Open Questions
+
+- [ ] Whether to set a future milestone for removing legacy camelCase aliases.

--- a/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/explore.md
+++ b/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/explore.md
@@ -1,0 +1,39 @@
+## Exploration: issue-29-config-viper-kebab-case-keys
+
+### Current State
+The Viper adapter currently maps file keys using camelCase mapstructure tags (`ttlMinutes`, `httpOnly`, `sameSite`, `clientID`, `clientSecret`, `authURL`, `tokenURL`, `redirectURL`) in `config/viper/mapping.go`. Loader env overrides in `config/viper/loader.go` also set camelCase Viper paths for affected fields. Existing examples in `README.md` use camelCase keys, while `/docs/*` currently has no concrete config YAML examples to enforce key-style consistency.
+
+### Affected Areas
+- `config/viper/mapping.go` — adapter raw model key tags need kebab-case contract.
+- `config/viper/loader.go` — override key paths must align with canonical kebab-case mapping.
+- `config/viper/loader_test.go` — fixtures currently use camelCase config keys.
+- `README.md` — config sample currently documents camelCase key names.
+- `docs/migration/auth-provider-ms-v0.1.0.md` — migration guidance should include canonical kebab-case examples.
+- `docs/releases/v0.1.0-checklist.md` — release documentation references adapter behavior and should remain consistent with naming policy.
+
+### Approaches
+1. **Hard cutover to kebab-case only** — Replace adapter tags and fixtures; reject legacy camelCase keys.
+   - Pros: Cleanest contract; minimal long-term complexity.
+   - Cons: Breaking change for existing configs; migration burden.
+   - Effort: Medium
+
+2. **Canonical kebab-case with temporary legacy compatibility** — Accept both kebab-case and legacy camelCase during decode, then map deterministically to the same `config.Config`.
+   - Pros: Smooth migration path; preserves backward compatibility while standardizing docs.
+   - Cons: Extra decode logic and tests; temporary dual-shape maintenance.
+   - Effort: Medium
+
+3. **Documentation-only standardization** — Keep runtime behavior as-is and only update docs/examples to kebab-case.
+   - Pros: Lowest implementation cost.
+   - Cons: Violates acceptance criteria for parsing/mapping behavior.
+   - Effort: Low
+
+### Recommendation
+Use **Approach 2**: make kebab-case the canonical file-key contract while supporting legacy camelCase as a compatibility path with deterministic precedence. If both forms are present for the same logical field, kebab-case should win and behavior should be explicitly tested/documented.
+
+### Risks
+- Dual-key compatibility can introduce ambiguity if precedence is not enforced and tested.
+- Viper/mapstructure decode behavior for mixed nested maps can hide collisions unless normalized explicitly.
+- Documentation drift can persist if `/docs/*` and `README.md` are updated inconsistently.
+
+### Ready for Proposal
+Yes. Proceed with proposal, delta spec, design, and implementation tasks in hybrid mode.

--- a/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/proposal.md
+++ b/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: issue-29-config-viper-kebab-case-keys
+
+## Intent
+
+Standardize Viper file-configuration keys to kebab-case, keep deterministic environment override behavior, and define a clear legacy compatibility policy for existing camelCase inputs.
+
+## Scope
+
+### In Scope
+- Make kebab-case the canonical key format for file-based adapter input.
+- Update adapter decoding/mapping so kebab-case fixtures map to the same `config.Config` domain model.
+- Define and enforce deterministic behavior when legacy camelCase and canonical kebab-case keys coexist.
+- Extend tests for kebab-case parsing and compatibility coverage.
+- Update documentation under `/docs/*` and `README.md` examples to kebab-case keys.
+
+### Out of Scope
+- Changes to core `config` domain validation rules.
+- Environment variable naming contract changes.
+- OAuth2 provider model redesign.
+
+## Capabilities
+
+### New Capabilities
+- `config-viper-kebab-case-keys`: canonical kebab-case config-key contract with deterministic compatibility behavior.
+
+### Modified Capabilities
+- `config-viper-adapter`: key decoding/mapping contract is updated from camelCase examples to kebab-case canonical input.
+
+## Approach
+
+Keep the typed raw-to-core mapping architecture and introduce adapter-local normalization/compatibility logic so both canonical kebab-case and legacy camelCase can be interpreted deterministically. Canonical kebab-case wins if both forms are present for the same logical field. Environment overrides remain unchanged in env naming and continue to set deterministic values onto the canonical internal paths.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `config/viper/mapping.go` | Modified | Canonical key contract and compatibility decode behavior |
+| `config/viper/loader.go` | Modified | Ensure override paths align with canonical key naming |
+| `config/viper/loader_test.go` | Modified | Kebab-case fixtures and compatibility scenarios |
+| `config/viper/mapping_test.go` | Modified | Mapping/precedence expectations for legacy keys |
+| `README.md` | Modified | Example config switched to kebab-case |
+| `docs/*` | Modified | Documentation examples and migration guidance switched to kebab-case |
+| `openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/*` | New | SDD artifacts for this change |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Ambiguous behavior when both key styles are present | Med | Explicit precedence rule + test coverage |
+| Hidden decode collisions in nested OAuth2 structures | Med | Focused fixture tests for provider keys and mixed-style documents |
+| Documentation/runtime mismatch | Low | Update README and `/docs/*` in same change with acceptance checks |
+
+## Rollback Plan
+
+Revert adapter key-normalization changes and documentation updates; keep previous camelCase behavior until a new migration strategy is approved.
+
+## Dependencies
+
+- Existing `config/viper` adapter decode/mapping flow.
+- Existing `config.Config` constructors and `config.ValidateConfig`.
+
+## Success Criteria
+
+- [ ] Kebab-case fixtures decode and map to expected `config.Config` values.
+- [ ] Legacy compatibility behavior is implemented and documented with deterministic precedence.
+- [ ] Existing env override determinism remains unchanged.
+- [ ] `/docs/*` and `README.md` examples consistently use kebab-case keys.

--- a/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/spec.md
+++ b/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/spec.md
@@ -1,0 +1,58 @@
+# Delta Spec: issue-29-config-viper-kebab-case-keys
+
+## ADDED Requirements — config-viper-kebab-case-keys
+
+### Requirement: Canonical kebab-case file keys
+
+The Viper adapter MUST treat kebab-case as the canonical file-key contract for mapped configuration fields.
+
+#### Scenario: Kebab-case fixture decodes successfully
+- GIVEN a valid adapter configuration file using kebab-case keys
+- WHEN `config/viper.Load` is executed
+- THEN the adapter returns a valid mapped `config.Config`
+- AND mapped values are identical to equivalent logical data previously expressed in legacy camelCase
+
+### Requirement: Deterministic legacy-key compatibility
+
+The adapter MUST define explicit compatibility behavior for legacy camelCase keys and preserve deterministic outcomes.
+
+#### Scenario: Legacy camelCase remains compatible
+- GIVEN a valid file that uses legacy camelCase keys for historical compatibility
+- WHEN `config/viper.Load` is executed
+- THEN the adapter still maps successfully to `config.Config`
+- AND behavior is documented as compatibility mode
+
+#### Scenario: Canonical and legacy keys both present
+- GIVEN a file where canonical kebab-case and legacy camelCase aliases exist for the same logical field
+- WHEN `config/viper.Load` is executed
+- THEN the resulting value follows a documented deterministic precedence rule
+
+### Requirement: Environment override determinism preserved
+
+The key-style migration MUST NOT alter deterministic environment override behavior.
+
+#### Scenario: Env override still wins with override enabled
+- GIVEN file values in canonical kebab-case
+- AND environment variables for the same logical fields
+- WHEN `EnvOverride=true`
+- THEN environment values override file values exactly as before
+
+#### Scenario: Env override disabled preserves file source of truth
+- GIVEN file values in canonical kebab-case
+- AND environment variables for the same logical fields
+- WHEN `EnvOverride=false`
+- THEN file values remain effective exactly as before
+
+### Requirement: Documentation uses kebab-case examples
+
+All configuration examples under `/docs/*` and `README.md` MUST use kebab-case keys for file-based configuration snippets.
+
+#### Scenario: Docs aligned with canonical key style
+- GIVEN project documentation containing config snippets
+- WHEN documentation is reviewed after this change
+- THEN config examples use kebab-case keys
+- AND no primary example presents camelCase as canonical style
+
+## Out of Scope
+- Renaming environment variable keys.
+- Changes to core config validation rules.

--- a/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/tasks.md
+++ b/openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: issue-29-config-viper-kebab-case-keys
+
+## Phase 1: SDD artifacts
+
+- [x] 1.1 Create active change directory and add `explore.md`.
+- [x] 1.2 Create `proposal.md` with scope, risks, and success criteria.
+- [x] 1.3 Create `spec.md` with kebab-case and compatibility requirements.
+- [x] 1.4 Create `design.md` with canonical/legacy strategy and precedence.
+
+## Phase 2: Adapter key canonicalization
+
+- [x] 2.1 Update `config/viper/mapping.go` raw decode contract to canonical kebab-case keys.
+- [x] 2.2 Implement deterministic legacy camelCase compatibility behavior.
+- [x] 2.3 Define and enforce duplicate-key precedence (canonical kebab-case wins).
+- [x] 2.4 Ensure `config/viper/loader.go` override paths remain deterministic and aligned.
+
+## Phase 3: Tests
+
+- [x] 3.1 Update/add `config/viper/loader_test.go` fixtures for canonical kebab-case success path.
+- [x] 3.2 Add compatibility test for legacy camelCase fixtures mapping to same `config.Config`.
+- [x] 3.3 Add mixed-style precedence tests for canonical key dominance.
+- [x] 3.4 Re-verify env override semantics with canonical key fixtures.
+
+## Phase 4: Documentation
+
+- [x] 4.1 Update `README.md` config examples to kebab-case keys.
+- [x] 4.2 Update documentation under `/docs/*` so all config examples use kebab-case.
+
+## Phase 5: Verification
+
+- [x] 5.1 Run `go test ./config/viper` and fix regressions.
+- [x] 5.2 Run `go test ./...` and confirm no cross-package breakage.
+- [x] 5.3 Update checklist progress as tasks complete.


### PR DESCRIPTION
Closes #29

## Summary
- Enforces canonical kebab-case file keys in `config/viper` mapping while preserving deterministic behavior.
- Keeps legacy camelCase keys compatible through explicit alias backfill, with canonical kebab-case taking precedence on mixed inputs.
- Updates README/docs (including a new docs index) and adds a `v0.2.0` release checklist aligned with this change.

## Changes
| File | Change |
|------|--------|
| `config/viper/mapping.go` | Switched canonical `mapstructure` tags to kebab-case keys |
| `config/viper/loader.go` | Added legacy key compatibility + canonical precedence and aligned env override paths |
| `config/viper/loader_test.go` | Updated fixtures and added legacy/mixed-style precedence coverage |
| `README.md` | Updated config examples and release/docs references |
| `docs/home.md` | Added documentation index page |
| `docs/releases/v0.2.0-checklist.md` | Added release checklist for target version |
| `docs/migration/auth-provider-ms-v0.1.0.md` | Documented canonical kebab-case key style |
| `openspec/changes/active/2026-05-01-issue-29-config-viper-kebab-case-keys/*` | Added/updated SDD artifacts and apply progress |

## Test Plan
- [x] `go test ./config/viper`
- [x] `go test ./...`