### PR TITLE
feat(config): add server runtime limits and app wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,23 @@ Behavior notes:
 - File-based adapter keys are documented in canonical kebab-case.
 - Legacy camelCase file keys remain temporarily compatible during migration.
 
+Server runtime limits (core + adapter):
+- File keys: `server.read-timeout`, `server.write-timeout`, `server.max-header-bytes`
+- Defaults: `10s`, `10s`, `1048576` (1 MiB)
+- Env override keys:
+  - `COMMON_FWK_SERVER_READ_TIMEOUT`
+  - `COMMON_FWK_SERVER_WRITE_TIMEOUT`
+  - `COMMON_FWK_SERVER_MAX_HEADER_BYTES`
+
 `./config/app.yaml` example:
 
 ```yaml
 server:
   host: 127.0.0.1
   port: 8080
+  read-timeout: 10s
+  write-timeout: 10s
+  max-header-bytes: 1048576
 security:
   auth:
     jwt:

--- a/app/application.go
+++ b/app/application.go
@@ -53,6 +53,9 @@ func (a *Application) UseServer() *Application {
 	}
 
 	a.server.Handler = a.handler
+	a.server.ReadTimeout = a.cfg.Server.ReadTimeout
+	a.server.WriteTimeout = a.cfg.Server.WriteTimeout
+	a.server.MaxHeaderBytes = a.cfg.Server.MaxHeaderBytes
 	a.serverReady = true
 
 	return a

--- a/app/application_test.go
+++ b/app/application_test.go
@@ -36,7 +36,7 @@ func (f *fakeValidator) Validate(ctx context.Context, raw string) (claims.Claims
 
 func testConfig() config.Config {
 	return config.Config{
-		Server: config.ServerConfig{Host: "127.0.0.1", Port: 0},
+		Server: config.ServerConfig{Host: "127.0.0.1", Port: 0, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, MaxHeaderBytes: 1 << 20},
 	}
 }
 
@@ -61,6 +61,63 @@ func TestBootstrapChain_PreservesPointerAndReadiness(t *testing.T) {
 	}
 	if a.server.Handler == nil {
 		t.Fatalf("expected server handler wiring")
+	}
+	if a.server.ReadTimeout != 10*time.Second {
+		t.Fatalf("expected server read timeout to be wired, got %s", a.server.ReadTimeout)
+	}
+	if a.server.WriteTimeout != 10*time.Second {
+		t.Fatalf("expected server write timeout to be wired, got %s", a.server.WriteTimeout)
+	}
+	if a.server.MaxHeaderBytes != 1<<20 {
+		t.Fatalf("expected server max header bytes to be wired, got %d", a.server.MaxHeaderBytes)
+	}
+}
+
+func TestUseServer_WiresRuntimeLimitsFromConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		serverConfig     config.ServerConfig
+		wantReadTimeout  time.Duration
+		wantWriteTimeout time.Duration
+		wantHeaderBytes  int
+	}{
+		{
+			name: "explicit values",
+			serverConfig: config.ServerConfig{
+				Host:           "127.0.0.1",
+				Port:           8080,
+				ReadTimeout:    2 * time.Second,
+				WriteTimeout:   5 * time.Second,
+				MaxHeaderBytes: 4096,
+			},
+			wantReadTimeout:  2 * time.Second,
+			wantWriteTimeout: 5 * time.Second,
+			wantHeaderBytes:  4096,
+		},
+		{
+			name:             "defaults from constructor",
+			serverConfig:     config.NewServerConfig("127.0.0.1", 8080),
+			wantReadTimeout:  10 * time.Second,
+			wantWriteTimeout: 10 * time.Second,
+			wantHeaderBytes:  1 << 20,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewApplication().UseConfig(config.Config{Server: tc.serverConfig}).UseServer()
+
+			if a.server.ReadTimeout != tc.wantReadTimeout {
+				t.Fatalf("expected read timeout %s, got %s", tc.wantReadTimeout, a.server.ReadTimeout)
+			}
+			if a.server.WriteTimeout != tc.wantWriteTimeout {
+				t.Fatalf("expected write timeout %s, got %s", tc.wantWriteTimeout, a.server.WriteTimeout)
+			}
+			if a.server.MaxHeaderBytes != tc.wantHeaderBytes {
+				t.Fatalf("expected max header bytes %d, got %d", tc.wantHeaderBytes, a.server.MaxHeaderBytes)
+			}
+		})
 	}
 }
 

--- a/bootstrap_guard_test.go
+++ b/bootstrap_guard_test.go
@@ -252,3 +252,65 @@ func TestCIBaselineRemainsBootstrapMinimal(t *testing.T) {
 		}
 	}
 }
+
+func TestDocsRuntimeLimitsContract(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name      string
+		path      string
+		fragments []string
+	}{
+		{
+			name: "README includes runtime-limit keys defaults env and example",
+			path: "README.md",
+			fragments: []string{
+				"read-timeout",
+				"write-timeout",
+				"max-header-bytes",
+				"10s",
+				"1048576",
+				"COMMON_FWK_SERVER_READ_TIMEOUT",
+				"COMMON_FWK_SERVER_WRITE_TIMEOUT",
+				"COMMON_FWK_SERVER_MAX_HEADER_BYTES",
+				"```yaml",
+				"server:",
+			},
+		},
+		{
+			name: "docs home includes runtime-limit keys defaults env and example",
+			path: filepath.Join("docs", "home.md"),
+			fragments: []string{
+				"read-timeout",
+				"write-timeout",
+				"max-header-bytes",
+				"10s",
+				"1048576",
+				"COMMON_FWK_SERVER_READ_TIMEOUT",
+				"COMMON_FWK_SERVER_WRITE_TIMEOUT",
+				"COMMON_FWK_SERVER_MAX_HEADER_BYTES",
+				"```yaml",
+				"server:",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Helper()
+
+			content, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatalf("read docs file %q: %v", tc.path, err)
+			}
+
+			doc := string(content)
+			for _, fragment := range tc.fragments {
+				if !strings.Contains(doc, fragment) {
+					t.Fatalf("docs file %q missing required runtime-limit contract fragment %q", tc.path, fragment)
+				}
+			}
+		})
+	}
+}

--- a/config/constructors.go
+++ b/config/constructors.go
@@ -1,8 +1,14 @@
 package config
 
+import "time"
+
 const (
 	defaultServerHost = "127.0.0.1"
 	defaultServerPort = 8080
+
+	defaultServerReadTimeout    = 10 * time.Second
+	defaultServerWriteTimeout   = 10 * time.Second
+	defaultServerMaxHeaderBytes = 1 << 20
 
 	defaultJWTTTLMinutes = 60
 
@@ -19,7 +25,12 @@ func NewConfig(server ServerConfig, security SecurityConfig) Config {
 }
 
 // NewServerConfig returns a server config with useful defaults.
-func NewServerConfig(host string, port int) ServerConfig {
+func NewServerConfig(host string, port int, limits ...ServerRuntimeLimits) ServerConfig {
+	runtime := ServerRuntimeLimits{}
+	if len(limits) > 0 {
+		runtime = limits[0]
+	}
+
 	if host == "" {
 		host = defaultServerHost
 	}
@@ -28,9 +39,24 @@ func NewServerConfig(host string, port int) ServerConfig {
 		port = defaultServerPort
 	}
 
+	if runtime.ReadTimeout == 0 {
+		runtime.ReadTimeout = defaultServerReadTimeout
+	}
+
+	if runtime.WriteTimeout == 0 {
+		runtime.WriteTimeout = defaultServerWriteTimeout
+	}
+
+	if runtime.MaxHeaderBytes == 0 {
+		runtime.MaxHeaderBytes = defaultServerMaxHeaderBytes
+	}
+
 	return ServerConfig{
-		Host: host,
-		Port: port,
+		Host:           host,
+		Port:           port,
+		ReadTimeout:    runtime.ReadTimeout,
+		WriteTimeout:   runtime.WriteTimeout,
+		MaxHeaderBytes: runtime.MaxHeaderBytes,
 	}
 }
 

--- a/config/constructors_test.go
+++ b/config/constructors_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNewServerConfig(t *testing.T) {
@@ -12,22 +13,34 @@ func TestNewServerConfig(t *testing.T) {
 		name     string
 		host     string
 		port     int
+		limits   ServerRuntimeLimits
 		expected ServerConfig
 	}{
 		{
 			name: "uses defaults when zero values are provided",
 			expected: ServerConfig{
-				Host: defaultServerHost,
-				Port: defaultServerPort,
+				Host:           defaultServerHost,
+				Port:           defaultServerPort,
+				ReadTimeout:    defaultServerReadTimeout,
+				WriteTimeout:   defaultServerWriteTimeout,
+				MaxHeaderBytes: defaultServerMaxHeaderBytes,
 			},
 		},
 		{
 			name: "keeps explicit values",
 			host: "0.0.0.0",
 			port: 9090,
+			limits: ServerRuntimeLimits{
+				ReadTimeout:    3 * time.Second,
+				WriteTimeout:   7 * time.Second,
+				MaxHeaderBytes: 2048,
+			},
 			expected: ServerConfig{
-				Host: "0.0.0.0",
-				Port: 9090,
+				Host:           "0.0.0.0",
+				Port:           9090,
+				ReadTimeout:    3 * time.Second,
+				WriteTimeout:   7 * time.Second,
+				MaxHeaderBytes: 2048,
 			},
 		},
 	}
@@ -37,7 +50,7 @@ func TestNewServerConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual := NewServerConfig(tc.host, tc.port)
+			actual := NewServerConfig(tc.host, tc.port, tc.limits)
 			if actual != tc.expected {
 				t.Fatalf("unexpected server config: want %+v, got %+v", tc.expected, actual)
 			}

--- a/config/types.go
+++ b/config/types.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // Config is the root configuration model for common-fwk.
 type Config struct {
 	Server   ServerConfig
@@ -8,8 +10,18 @@ type Config struct {
 
 // ServerConfig contains HTTP server settings.
 type ServerConfig struct {
-	Host string
-	Port int
+	Host           string
+	Port           int
+	ReadTimeout    time.Duration
+	WriteTimeout   time.Duration
+	MaxHeaderBytes int
+}
+
+// ServerRuntimeLimits groups HTTP runtime limits for server construction.
+type ServerRuntimeLimits struct {
+	ReadTimeout    time.Duration
+	WriteTimeout   time.Duration
+	MaxHeaderBytes int
 }
 
 // SecurityConfig groups security-related settings.

--- a/config/validate.go
+++ b/config/validate.go
@@ -49,6 +49,18 @@ func validateServer(cfg ServerConfig) error {
 		return invalidAt("server.port", fmt.Errorf("%w: must be between 1 and 65535", ErrOutOfRange))
 	}
 
+	if cfg.ReadTimeout <= 0 {
+		return invalidAt("server.readTimeout", fmt.Errorf("%w: must be positive", ErrOutOfRange))
+	}
+
+	if cfg.WriteTimeout <= 0 {
+		return invalidAt("server.writeTimeout", fmt.Errorf("%w: must be positive", ErrOutOfRange))
+	}
+
+	if cfg.MaxHeaderBytes <= 0 {
+		return invalidAt("server.maxHeaderBytes", fmt.Errorf("%w: must be positive", ErrOutOfRange))
+	}
+
 	return nil
 }
 

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -47,6 +47,60 @@ func TestValidateConfigInvalid(t *testing.T) {
 			wantPath:     "server.port",
 		},
 		{
+			name: "server read timeout zero",
+			mutate: func(cfg Config) Config {
+				cfg.Server.ReadTimeout = 0
+				return cfg
+			},
+			wantSentinel: ErrOutOfRange,
+			wantPath:     "server.readTimeout",
+		},
+		{
+			name: "server read timeout negative",
+			mutate: func(cfg Config) Config {
+				cfg.Server.ReadTimeout = -1
+				return cfg
+			},
+			wantSentinel: ErrOutOfRange,
+			wantPath:     "server.readTimeout",
+		},
+		{
+			name: "server write timeout zero",
+			mutate: func(cfg Config) Config {
+				cfg.Server.WriteTimeout = 0
+				return cfg
+			},
+			wantSentinel: ErrOutOfRange,
+			wantPath:     "server.writeTimeout",
+		},
+		{
+			name: "server write timeout negative",
+			mutate: func(cfg Config) Config {
+				cfg.Server.WriteTimeout = -1
+				return cfg
+			},
+			wantSentinel: ErrOutOfRange,
+			wantPath:     "server.writeTimeout",
+		},
+		{
+			name: "server max header bytes zero",
+			mutate: func(cfg Config) Config {
+				cfg.Server.MaxHeaderBytes = 0
+				return cfg
+			},
+			wantSentinel: ErrOutOfRange,
+			wantPath:     "server.maxHeaderBytes",
+		},
+		{
+			name: "server max header bytes negative",
+			mutate: func(cfg Config) Config {
+				cfg.Server.MaxHeaderBytes = -1
+				return cfg
+			},
+			wantSentinel: ErrOutOfRange,
+			wantPath:     "server.maxHeaderBytes",
+		},
+		{
 			name: "missing jwt secret",
 			mutate: func(cfg Config) Config {
 				cfg.Security.Auth.JWT.Secret = ""

--- a/config/viper/loader.go
+++ b/config/viper/loader.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/matiasmartin-labs/common-fwk/config"
 	"github.com/spf13/viper"
@@ -108,6 +109,30 @@ func applyEnvironmentOverrides(v *viper.Viper, opts Options, snapshot map[string
 			return fmt.Errorf("parse env %q as int: %w", binding("SERVER_PORT"), err)
 		}
 		v.Set("server.port", parsed)
+	}
+
+	if value, ok := snapshot[binding("SERVER_READ_TIMEOUT")]; ok {
+		parsed, err := time.ParseDuration(strings.TrimSpace(value))
+		if err != nil {
+			return fmt.Errorf("parse env %q as duration: %w", binding("SERVER_READ_TIMEOUT"), err)
+		}
+		v.Set("server.read-timeout", parsed)
+	}
+
+	if value, ok := snapshot[binding("SERVER_WRITE_TIMEOUT")]; ok {
+		parsed, err := time.ParseDuration(strings.TrimSpace(value))
+		if err != nil {
+			return fmt.Errorf("parse env %q as duration: %w", binding("SERVER_WRITE_TIMEOUT"), err)
+		}
+		v.Set("server.write-timeout", parsed)
+	}
+
+	if value, ok := snapshot[binding("SERVER_MAX_HEADER_BYTES")]; ok {
+		parsed, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return fmt.Errorf("parse env %q as int: %w", binding("SERVER_MAX_HEADER_BYTES"), err)
+		}
+		v.Set("server.max-header-bytes", parsed)
 	}
 
 	if value, ok := snapshot[binding("SECURITY_AUTH_JWT_TTLMINUTES")]; ok {

--- a/config/viper/loader_test.go
+++ b/config/viper/loader_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/matiasmartin-labs/common-fwk/config"
 )
@@ -17,6 +19,9 @@ func TestLoadSuccessAndDeterminism(t *testing.T) {
 server:
   host: "127.0.0.1"
   port: 8080
+  read-timeout: 4s
+  write-timeout: 6s
+  max-header-bytes: 8192
 security:
   auth:
     jwt:
@@ -58,6 +63,18 @@ security:
 
 	if first.Security.Auth.Login.Email != "owner@example.com" {
 		t.Fatalf("expected normalized email from core validation, got %q", first.Security.Auth.Login.Email)
+	}
+
+	if first.Server.ReadTimeout != 4*time.Second {
+		t.Fatalf("expected read-timeout mapping, got %s", first.Server.ReadTimeout)
+	}
+
+	if first.Server.WriteTimeout != 6*time.Second {
+		t.Fatalf("expected write-timeout mapping, got %s", first.Server.WriteTimeout)
+	}
+
+	if first.Server.MaxHeaderBytes != 8192 {
+		t.Fatalf("expected max-header-bytes mapping, got %d", first.Server.MaxHeaderBytes)
 	}
 }
 
@@ -126,6 +143,9 @@ func TestLoadEnvOverrideSemantics(t *testing.T) {
 server:
   host: "127.0.0.1"
   port: 8080
+  read-timeout: 2s
+  write-timeout: 3s
+  max-header-bytes: 4096
 security:
   auth:
     jwt:
@@ -145,6 +165,9 @@ security:
 `)
 
 	t.Setenv(defaultEnvPrefix+"_SECURITY_AUTH_JWT_SECRET", "env-secret")
+	t.Setenv(defaultEnvPrefix+"_SERVER_READ_TIMEOUT", "8s")
+	t.Setenv(defaultEnvPrefix+"_SERVER_WRITE_TIMEOUT", "9s")
+	t.Setenv(defaultEnvPrefix+"_SERVER_MAX_HEADER_BYTES", "16384")
 
 	withoutOverride, err := Load(Options{ConfigPath: path, EnvOverride: false})
 	if err != nil {
@@ -156,12 +179,103 @@ security:
 		t.Fatalf("unexpected load error with EnvOverride=true: %v", err)
 	}
 
+	withOverrideSecond, err := Load(Options{ConfigPath: path, EnvOverride: true})
+	if err != nil {
+		t.Fatalf("unexpected repeated load error with EnvOverride=true: %v", err)
+	}
+
 	if withoutOverride.Security.Auth.JWT.Secret != "file-secret" {
 		t.Fatalf("expected file value when EnvOverride=false, got %q", withoutOverride.Security.Auth.JWT.Secret)
 	}
 
 	if withOverride.Security.Auth.JWT.Secret != "env-secret" {
 		t.Fatalf("expected env value when EnvOverride=true, got %q", withOverride.Security.Auth.JWT.Secret)
+	}
+
+	if withoutOverride.Server.ReadTimeout != 2*time.Second || withoutOverride.Server.WriteTimeout != 3*time.Second || withoutOverride.Server.MaxHeaderBytes != 4096 {
+		t.Fatalf("expected file server runtime limits when EnvOverride=false")
+	}
+
+	if withOverride.Server.ReadTimeout != 8*time.Second || withOverride.Server.WriteTimeout != 9*time.Second || withOverride.Server.MaxHeaderBytes != 16384 {
+		t.Fatalf("expected env server runtime limits when EnvOverride=true")
+	}
+
+	if !reflect.DeepEqual(withOverride, withOverrideSecond) {
+		t.Fatalf("expected deterministic output for identical env snapshot when EnvOverride=true")
+	}
+}
+
+func TestLoadEnvOverrideTypedFailuresForServerRuntimeLimits(t *testing.T) {
+	tests := []struct {
+		name       string
+		envKey     string
+		envValue   string
+		wantSubstr string
+	}{
+		{
+			name:       "invalid server read timeout format",
+			envKey:     defaultEnvPrefix + "_SERVER_READ_TIMEOUT",
+			envValue:   "not-a-duration",
+			wantSubstr: "SERVER_READ_TIMEOUT",
+		},
+		{
+			name:       "invalid server write timeout format",
+			envKey:     defaultEnvPrefix + "_SERVER_WRITE_TIMEOUT",
+			envValue:   "still-not-a-duration",
+			wantSubstr: "SERVER_WRITE_TIMEOUT",
+		},
+		{
+			name:       "invalid max header bytes format",
+			envKey:     defaultEnvPrefix + "_SERVER_MAX_HEADER_BYTES",
+			envValue:   "NaN",
+			wantSubstr: "SERVER_MAX_HEADER_BYTES",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTestConfig(t, "env-typed-failure.yaml", `
+server:
+  host: "127.0.0.1"
+  port: 8080
+  read-timeout: 2s
+  write-timeout: 3s
+  max-header-bytes: 4096
+security:
+  auth:
+    jwt:
+      secret: "file-secret"
+      issuer: "common-fwk"
+      ttl-minutes: 15
+    cookie:
+      name: "session"
+      domain: "example.com"
+      secure: true
+      http-only: true
+      same-site: "Lax"
+    login:
+      email: "owner@example.com"
+    oauth2:
+      providers: {}
+`)
+
+			t.Setenv(tc.envKey, tc.envValue)
+
+			_, err := Load(Options{ConfigPath: path, EnvOverride: true})
+			if err == nil {
+				t.Fatalf("expected load error")
+			}
+
+			var loadErr *LoadError
+			if !errors.As(err, &loadErr) {
+				t.Fatalf("expected LoadError, got %T", err)
+			}
+
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("expected error to mention %q, got %v", tc.wantSubstr, err)
+			}
+		})
 	}
 }
 

--- a/config/viper/mapping.go
+++ b/config/viper/mapping.go
@@ -3,6 +3,7 @@ package viper
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/matiasmartin-labs/common-fwk/config"
 )
@@ -15,8 +16,11 @@ type rawConfig struct {
 }
 
 type rawServerConfig struct {
-	Host string `mapstructure:"host"`
-	Port int    `mapstructure:"port"`
+	Host           string        `mapstructure:"host"`
+	Port           int           `mapstructure:"port"`
+	ReadTimeout    time.Duration `mapstructure:"read-timeout"`
+	WriteTimeout   time.Duration `mapstructure:"write-timeout"`
+	MaxHeaderBytes int           `mapstructure:"max-header-bytes"`
 }
 
 type rawSecurityConfig struct {
@@ -66,7 +70,15 @@ type rawOAuth2ProviderConfig struct {
 }
 
 func mapRawToCore(raw rawConfig) (config.Config, error) {
-	server := config.NewServerConfig(raw.Server.Host, raw.Server.Port)
+	server := config.NewServerConfig(
+		raw.Server.Host,
+		raw.Server.Port,
+		config.ServerRuntimeLimits{
+			ReadTimeout:    raw.Server.ReadTimeout,
+			WriteTimeout:   raw.Server.WriteTimeout,
+			MaxHeaderBytes: raw.Server.MaxHeaderBytes,
+		},
+	)
 	jwt := config.NewJWTConfig(raw.Security.Auth.JWT.Secret, raw.Security.Auth.JWT.Issuer, raw.Security.Auth.JWT.TTLMinutes)
 	cookie := config.NewCookieConfig(
 		raw.Security.Auth.Cookie.Name,

--- a/config/viper/mapping_test.go
+++ b/config/viper/mapping_test.go
@@ -4,13 +4,14 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestMappingReturnsTypedErrorForInvalidProviderKey(t *testing.T) {
 	t.Parallel()
 
 	_, err := mapRawToCore(rawConfig{
-		Server: rawServerConfig{Host: "127.0.0.1", Port: 8080},
+		Server: rawServerConfig{Host: "127.0.0.1", Port: 8080, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, MaxHeaderBytes: 1024},
 		Security: rawSecurityConfig{Auth: rawAuthConfig{
 			JWT:    rawJWTConfig{Secret: "secret", Issuer: "issuer", TTLMinutes: 15},
 			Cookie: rawCookieConfig{Name: "session", SameSite: "Lax"},
@@ -48,7 +49,7 @@ func TestMappingDeterministicAndDefensiveCopies(t *testing.T) {
 	t.Parallel()
 
 	raw := rawConfig{
-		Server: rawServerConfig{Host: "127.0.0.1", Port: 8080},
+		Server: rawServerConfig{Host: "127.0.0.1", Port: 8080, ReadTimeout: 9 * time.Second, WriteTimeout: 11 * time.Second, MaxHeaderBytes: 2048},
 		Security: rawSecurityConfig{Auth: rawAuthConfig{
 			JWT:    rawJWTConfig{Secret: "secret", Issuer: "issuer", TTLMinutes: 15},
 			Cookie: rawCookieConfig{Name: "session", Domain: "example.com", Secure: true, HTTPOnly: true, SameSite: "Lax"},
@@ -78,6 +79,16 @@ func TestMappingDeterministicAndDefensiveCopies(t *testing.T) {
 
 	if !reflect.DeepEqual(first, second) {
 		t.Fatalf("expected deterministic mapping outputs")
+	}
+
+	if first.Server.ReadTimeout != 9*time.Second {
+		t.Fatalf("expected read timeout to be mapped, got %s", first.Server.ReadTimeout)
+	}
+	if first.Server.WriteTimeout != 11*time.Second {
+		t.Fatalf("expected write timeout to be mapped, got %s", first.Server.WriteTimeout)
+	}
+	if first.Server.MaxHeaderBytes != 2048 {
+		t.Fatalf("expected max header bytes to be mapped, got %d", first.Server.MaxHeaderBytes)
 	}
 
 	raw.Security.Auth.OAuth2.Providers["github"] = rawOAuth2ProviderConfig{}

--- a/docs/home.md
+++ b/docs/home.md
@@ -14,3 +14,19 @@ This index groups the main project documentation pages.
 ## Notes
 
 - File-based config examples use canonical kebab-case keys (`ttl-minutes`, `http-only`, `same-site`, `client-id`, `client-secret`, `auth-url`, `token-url`, `redirect-url`).
+- Server runtime-limit contract:
+  - `server.read-timeout` (default `10s`)
+  - `server.write-timeout` (default `10s`)
+  - `server.max-header-bytes` (default `1048576`)
+  - Env overrides: `COMMON_FWK_SERVER_READ_TIMEOUT`, `COMMON_FWK_SERVER_WRITE_TIMEOUT`, `COMMON_FWK_SERVER_MAX_HEADER_BYTES`
+
+Example:
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8080
+  read-timeout: 10s
+  write-timeout: 10s
+  max-header-bytes: 1048576
+```

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/apply-progress.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/apply-progress.md
@@ -1,0 +1,78 @@
+# Apply Progress: issue-28-http-server-timeout-header-size
+
+## Mode
+
+Standard (strict_tdd: false)
+
+## Completed Tasks (Merged Cumulative State)
+
+- [x] 1.1 Modify `config/types.go` to extend `ServerConfig` with `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`.
+- [x] 1.2 Modify `config/constructors.go` so `NewServerConfig` sets defaults (`10s`, `10s`, `1048576`) when runtime-limit inputs are omitted.
+- [x] 1.3 Update `config/constructors.go` call sites impacted by constructor signature changes to keep compilation green.
+- [x] 1.4 Extend `config/validate.go` (`validateServer`) to reject zero/negative timeout and header-size values with contextual validation errors.
+- [x] 2.1 Modify `config/viper/mapping.go` to map `server.read-timeout`, `server.write-timeout`, and `server.max-header-bytes` into core config.
+- [x] 2.2 Modify `config/viper/loader.go` to support env overrides `COMMON_FWK_SERVER_READ_TIMEOUT`, `COMMON_FWK_SERVER_WRITE_TIMEOUT`, and `COMMON_FWK_SERVER_MAX_HEADER_BYTES`.
+- [x] 2.3 In `config/viper/loader.go`, parse env runtime limits explicitly (`time.ParseDuration`, `strconv.Atoi`) and return adapter-typed decode/load errors on invalid values.
+- [x] 2.4 Modify `app/application.go` so `UseServer()` applies `a.cfg.Server.ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes` to the underlying `http.Server` while preserving fluent chaining.
+- [x] 3.1 Extend `config/constructors_test.go` with table-driven `t.Run` cases for default application and explicit runtime-limit preservation.
+- [x] 3.2 Extend `config/validate_test.go` with table-driven positive/zero/negative runtime-limit cases and assertable validation error checks.
+- [x] 3.3 Extend `config/viper/mapping_test.go` to verify deterministic file-key mapping for all three runtime-limit fields.
+- [x] 3.4 Extend `config/viper/loader_test.go` to verify env precedence, deterministic override behavior, and typed failures for invalid duration/int inputs.
+- [x] 3.5 Extend `app/application_test.go` to verify fluent chain behavior and `UseServer()` runtime-limit wiring (explicit values and defaults).
+- [x] 4.1 Update `README.md` with server runtime-limit keys, defaults, env variable names, and at least one configuration example.
+- [x] 4.2 Update `docs/home.md` and related config docs under `docs/` to include the same keys/defaults/example and keep wording aligned with README.
+- [x] 5.1 Run `go test ./...` and confirm all updated tests pass.
+- [x] 5.2 Run `go build ./...` to verify no integration/build regressions.
+- [x] 5.3 Verify completion against spec scenarios (defaults, explicit preservation, validation failures, adapter mapping/overrides, typed decode failures, app wiring, docs sync).
+
+## Continuation Batch — Verify Findings Remediation
+
+- [x] Added automated docs contract test evidence for required runtime-limit contract in both `README.md` and `docs/home.md`.
+- [x] Strengthened env override determinism assertions for runtime-limit override path.
+- [x] Re-ran `go test ./...` and `go build ./...` after remediation.
+
+## Files Changed In This Continuation Batch
+
+- `bootstrap_guard_test.go`
+  - Added `TestDocsRuntimeLimitsContract` with table-driven `t.Run` cases for `README.md` and `docs/home.md`.
+  - Asserts required runtime-limit keys (`read-timeout`, `write-timeout`, `max-header-bytes`), defaults (`10s`, `1048576`), env vars (`COMMON_FWK_SERVER_*`), and YAML example markers are present.
+- `config/viper/loader_test.go`
+  - Updated `TestLoadEnvOverrideSemantics` to load with `EnvOverride=true` twice and assert deterministic output using `reflect.DeepEqual` for identical env snapshots.
+
+## Validation Evidence (Current Batch)
+
+### `go test ./...`
+
+Passed:
+
+- `github.com/matiasmartin-labs/common-fwk`
+- `github.com/matiasmartin-labs/common-fwk/app`
+- `github.com/matiasmartin-labs/common-fwk/config`
+- `github.com/matiasmartin-labs/common-fwk/config/viper`
+- `github.com/matiasmartin-labs/common-fwk/errors`
+- `github.com/matiasmartin-labs/common-fwk/http/gin`
+- `github.com/matiasmartin-labs/common-fwk/security/claims`
+- `github.com/matiasmartin-labs/common-fwk/security/jwt`
+- `github.com/matiasmartin-labs/common-fwk/security/keys`
+
+No tests:
+
+- `github.com/matiasmartin-labs/common-fwk/security`
+
+### `go build ./...`
+
+Passed (no build errors).
+
+## Spec Scenario Traceability (Updated)
+
+- Config core defaults + explicit preservation: covered via constructor changes and `config/constructors_test.go` table-driven cases.
+- Runtime-limit validation failures: covered in `config/validate.go` and `config/validate_test.go` zero/negative cases.
+- Viper mapping and env precedence: covered in `config/viper/mapping.go`, `config/viper/loader.go`, and expanded tests.
+- Typed adapter failures for env decoding: covered by explicit parse branches and `TestLoadEnvOverrideTypedFailuresForServerRuntimeLimits`.
+- App runtime wiring + fluent chaining: covered in `app/application.go` and `app/application_test.go`.
+- Docs runtime-limit contract scenario: now backed by automated test evidence in `bootstrap_guard_test.go` (`TestDocsRuntimeLimitsContract`).
+- Env override precedence + deterministic behavior scenario: now explicitly asserts deterministic repeated `EnvOverride=true` output in `config/viper/loader_test.go` (`TestLoadEnvOverrideSemantics`).
+
+## Status
+
+18/18 original tasks remain complete. Verify-blocking findings addressed. Ready for re-verify.

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/archive-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/archive-report.md
@@ -1,0 +1,64 @@
+# Archive Report
+
+**Change**: 2026-05-01-issue-28-http-server-timeout-header-size  
+**Date**: 2026-05-01  
+**Mode**: hybrid (OpenSpec + Engram)  
+**Issue**: #28  
+**Source Active Dir**: `openspec/changes/active/2026-05-01-issue-28-http-server-timeout-header-size/`  
+**Archive Dir**: `openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/`
+
+## Summary
+
+Archived change `2026-05-01-issue-28-http-server-timeout-header-size` after verification passed with no CRITICAL or WARNING findings. Synced delta specs into source-of-truth specs, then moved the active change folder into the archive audit trail.
+
+## Verification Gate
+
+- Verification report: `openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/verify-report.md`
+- Verdict: **PASS**
+- CRITICAL issues: **0**
+- WARNING issues: **0**
+- Task completion: **18/18** complete
+
+## Spec Sync Results
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| `config-core` | Updated | Added 3 requirements: runtime-limit model/defaults, runtime-limit validation, docs synchronization contract |
+| `config-viper-adapter` | Updated | Added 2 requirements: runtime-limit mapping/env overrides and typed runtime-limit decode/mapping failures |
+| `app-bootstrap` | Updated | Modified `Fluent setup methods` requirement to require `UseServer()` runtime-limit wiring; added scenarios for explicit/default runtime-limit propagation |
+
+## Archive Contents
+
+- `explore.md` ✅
+- `proposal.md` ✅
+- `spec.md` ✅
+- `specs/` ✅
+- `design.md` ✅
+- `tasks.md` ✅
+- `apply-progress.md` ✅
+- `verify-report.md` ✅
+- `archive-report.md` ✅
+
+## Engram Traceability (Dependency Artifacts)
+
+| Artifact | Topic Key | Observation ID |
+|----------|-----------|----------------|
+| Explore | `sdd/2026-05-01-issue-28-http-server-timeout-header-size/explore` | `#387` |
+| Proposal | `sdd/2026-05-01-issue-28-http-server-timeout-header-size/proposal` | `#390` |
+| Spec | `sdd/2026-05-01-issue-28-http-server-timeout-header-size/spec` | `#394` |
+| Design | `sdd/2026-05-01-issue-28-http-server-timeout-header-size/design` | `#396` |
+| Tasks | `sdd/2026-05-01-issue-28-http-server-timeout-header-size/tasks` | `#400` |
+| Apply Progress | `sdd/2026-05-01-issue-28-http-server-timeout-header-size/apply-progress` | `#403` |
+| Verify Report | `sdd/2026-05-01-issue-28-http-server-timeout-header-size/verify-report` | `#408` |
+
+## Source of Truth Updated
+
+- `openspec/specs/config-core/spec.md`
+- `openspec/specs/config-viper-adapter/spec.md`
+- `openspec/specs/app-bootstrap/spec.md`
+
+## Post-Archive Checks
+
+- Active change path removed: `openspec/changes/active/2026-05-01-issue-28-http-server-timeout-header-size/` ✅
+- Archive path exists and contains expected artifacts ✅
+- Main specs include merged runtime-limit requirements and scenarios ✅

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/design.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/design.md
@@ -1,0 +1,111 @@
+# Design: issue-28-http-server-timeout-header-size
+
+## Technical Approach
+
+Implement issue #28 as a flat, incremental extension of existing server config flow: `config` owns model/defaults/validation, `config/viper` maps file+env into typed core values, and `app.Application.UseServer()` wires validated values into `http.Server`. This preserves dependency direction (adapter → core, app → core/contracts) and avoids new capabilities.
+
+## Architecture Decisions
+
+### Decision: Extend `ServerConfig` directly
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Add nested runtime struct (`Server.Runtime.*`) | More churn in constructors/mapping/tests/docs; unnecessary indirection | ❌ |
+| Add flat fields on `ServerConfig` | Minimal API change; aligns with existing `Host`/`Port` style | ✅ |
+
+Rationale: lowest-risk change that matches proposal/spec and current constructor conventions.
+
+### Decision: Keep validation in `config.ValidateConfig`
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Validate in adapter only | Core contract can be bypassed by non-viper callers | ❌ |
+| Validate in core (`validateServer`) | Single enforcement point for all call paths | ✅ |
+
+Rationale: core remains source of truth for invariants (`>0` timeouts and header bytes).
+
+### Decision: Explicit env parsing in loader override path
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Rely on generic unmarshal coercion | Less explicit failure classification | ❌ |
+| Parse env values explicitly before `v.Set` | Deterministic typed failures and testable behavior | ✅ |
+
+Rationale: follows existing `SERVER_PORT` / `TTLMINUTES` parsing pattern and supports adapter-typed errors.
+
+## Data Flow
+
+```text
+config file + env snapshot
+        │
+        ▼
+config/viper.Load
+  - decode yaml/json
+  - apply env overrides
+  - unmarshal rawConfig
+        │
+        ▼
+mapRawToCore -> config.NewServerConfig(...)
+        │
+        ▼
+config.ValidateConfig
+  - validateServer host/port/read/write/header
+        │
+        ▼
+app.UseConfig(cfg).UseServer()
+        │
+        ▼
+http.Server{Addr, ReadTimeout, WriteTimeout, MaxHeaderBytes}
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `config/types.go` | Modify | Add `ReadTimeout time.Duration`, `WriteTimeout time.Duration`, `MaxHeaderBytes int` to `ServerConfig`. |
+| `config/constructors.go` | Modify | Add defaults (`10s`, `10s`, `1048576`) and update `NewServerConfig` signature to accept optional explicit runtime-limit values. |
+| `config/validate.go` | Modify | Extend `validateServer` with `>0` checks for the 3 runtime-limit fields. |
+| `config/viper/mapping.go` | Modify | Extend `rawServerConfig` with `read-timeout`, `write-timeout`, `max-header-bytes`; map into core constructor. |
+| `config/viper/loader.go` | Modify | Add env override keys for runtime limits and typed parsing (`time.ParseDuration`, `strconv.Atoi`). |
+| `app/application.go` | Modify | In `UseServer`, set `a.server.ReadTimeout`, `WriteTimeout`, `MaxHeaderBytes` from `a.cfg.Server`. |
+| `config/constructors_test.go` | Modify | Cover defaults + explicit runtime-limit preservation. |
+| `config/validate_test.go` | Modify | Cover valid positive values and invalid zero/negative runtime limits with assertable paths. |
+| `config/viper/loader_test.go` | Modify | Cover file mapping, env precedence, invalid duration/int typed failures. |
+| `config/viper/mapping_test.go` | Modify | Verify deterministic mapping includes server runtime-limit values. |
+| `app/application_test.go` | Modify | Verify fluent chain unchanged and `UseServer` wires runtime limits to embedded `http.Server`. |
+| `README.md` | Modify | Document server keys, defaults, env names, and example config snippet. |
+| `docs/home.md` (and related config docs under `docs/`) | Modify | Add canonical runtime-limit key references to keep docs synchronized. |
+
+## Interfaces / Contracts
+
+```go
+type ServerConfig struct {
+    Host           string
+    Port           int
+    ReadTimeout    time.Duration
+    WriteTimeout   time.Duration
+    MaxHeaderBytes int
+}
+```
+
+Adapter keys:
+- File: `server.read-timeout`, `server.write-timeout`, `server.max-header-bytes`
+- Env override: `COMMON_FWK_SERVER_READ_TIMEOUT`, `COMMON_FWK_SERVER_WRITE_TIMEOUT`, `COMMON_FWK_SERVER_MAX_HEADER_BYTES`
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Constructor defaults + explicit preservation | Table-driven tests in `config/constructors_test.go`. |
+| Unit | Validation invariants and error paths | Extend `config/validate_test.go` with positive/zero/negative cases and `errors.Is/As` assertions. |
+| Unit | Adapter mapping + override precedence + typed failures | Extend `config/viper/loader_test.go` and `mapping_test.go` for duration parse errors and non-int header bytes. |
+| Integration-ish (package) | App wiring into runtime server | Extend `app/application_test.go` to assert server field assignments after `UseConfig(...).UseServer()`. |
+| E2E | Not required for this change | Existing package-level tests sufficiently verify contract boundaries. |
+
+## Migration / Rollout
+
+No migration required. Existing users without new keys receive defaults. Rollout is backward-compatible, incremental, and can be reverted by restoring prior config fields/wiring.
+
+## Open Questions
+
+- [ ] Should `NewServerConfig` keep backward compatibility via variadic options to avoid touching external callsites, or accept a direct signature update as a minor API adjustment?

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/explore.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/explore.md
@@ -1,0 +1,59 @@
+## Exploration: issue-28-http-server-timeout-header-size
+
+### Current State
+The core server configuration currently includes only `Host` and `Port` in `config.ServerConfig` (`config/types.go`), with defaults applied through `config.NewServerConfig(host, port)` (`config/constructors.go`). Validation only enforces host presence and port range (`config/validate.go`).
+
+The Viper adapter maps and overrides only `server.host` and `server.port` for server settings (`config/viper/mapping.go`, `config/viper/loader.go`), then always runs `config.ValidateConfig` before returning (`config/viper/loader.go`).
+
+At runtime, `app.Application` owns an embedded `http.Server` but currently only wires `Handler` and `Addr`; timeout and header-size fields are not configured from `config` (`app/application.go`). Existing tests already assert constructor defaults, config validation behavior, Viper env/file precedence, and app startup/serving behavior (`config/*_test.go`, `config/viper/*_test.go`, `app/application_test.go`).
+
+Documentation structure exists in `README.md` (quickstart + config example) and `/docs/*` (home index, migration guide, release checklists). Config key style guidance is already documented as canonical kebab-case for file-backed config.
+
+### Affected Areas
+- `config/types.go` — extend `ServerConfig` with timeout and max-header-size fields.
+- `config/constructors.go` — extend `NewServerConfig` defaults and signature/assembly policy.
+- `config/validate.go` — add boundary validation for new server fields.
+- `config/constructors_test.go` — cover defaulting/explicit preservation for new fields.
+- `config/validate_test.go` — cover invalid timeout/header-size scenarios.
+- `config/viper/mapping.go` — map new `server` keys into core config constructor.
+- `config/viper/loader.go` — add env overrides for new server keys with typed parse errors.
+- `config/viper/loader_test.go` — verify file/env behavior for new fields and deterministic output.
+- `app/application.go` — apply config values to `http.Server` (`ReadTimeout`, `WriteTimeout`, `MaxHeaderBytes`) when server wiring occurs.
+- `app/application_test.go` — verify effective application of configured values to runtime server.
+- `README.md` and `docs/*` — document new keys, defaults, and env override behavior.
+
+### Approaches
+1. **Flat extension on existing `ServerConfig` + explicit wiring in `UseServer`** — Add `ReadTimeoutSeconds`, `WriteTimeoutSeconds`, and `MaxHeaderBytes` to current struct/constructor, wire directly into embedded `http.Server` in bootstrap path.
+   - Pros: Minimal surface-area change; consistent with existing explicit constructor and validation patterns; no new abstractions.
+   - Cons: Constructor signature grows; timeout units represented as ints rather than `time.Duration` in core.
+   - Effort: Low
+
+2. **Introduce nested server tuning struct and duration types** — Add nested type(s) (for example `ServerRuntimeConfig`) and use `time.Duration` in core, with adapter parsing from file/env.
+   - Pros: Semantically richer model and clearer runtime intent.
+   - Cons: Higher migration and parser complexity; broader API/doc churn; less aligned with current simple scalar config conventions.
+   - Effort: Medium
+
+3. **App-only defaults without config model changes** — Keep config unchanged and set hardcoded server timeout/header defaults in `app` only.
+   - Pros: Fastest change in code footprint.
+   - Cons: Fails acceptance criteria (no config/env override support; no validation contract in config layer).
+   - Effort: Low
+
+### Recommendation
+Use **Approach 1**.
+
+It best matches existing project patterns: explicit typed config in `config`, adapter translation in `config/viper`, validation in core, and application of values at the `app` boundary. Implement new fields as scalar seconds/bytes with defaults `10s/10s/1048576`, validate strictly positive ranges, and wire into `http.Server` at server setup so both `Run` and `RunListener` share deterministic behavior.
+
+### Risks
+- **Constructor/API churn risk**: Extending `NewServerConfig` may require updates across tests/examples and consumer code.
+- **Unit mismatch risk**: Using seconds in config but durations in runtime can cause conversion mistakes unless naming is explicit and tests assert exact `time.Duration` results.
+- **Override coverage risk**: Missing env key wiring/tests could create inconsistent behavior between file and env sources.
+- **Doc drift risk**: README and `/docs/*` can diverge if key names/defaults are updated in only one location.
+
+### Ready for Proposal
+Yes — proceed to proposal/spec/design/tasks with this baseline:
+- Extend server config model with read/write timeout and max-header-bytes.
+- Add defaults + validation in core config.
+- Add Viper file/env support for new keys.
+- Apply values to runtime `http.Server` in app bootstrap.
+- Add tests for defaults, validation failures, adapter overrides, and effective runtime wiring.
+- Update README and `/docs/*` references to keep documentation synchronized.

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/proposal.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/proposal.md
@@ -1,0 +1,70 @@
+# Proposal: issue-28-http-server-timeout-header-size
+
+## Intent
+
+Enable validated HTTP server runtime limits from framework config for timeout and header-size tuning.
+
+## Scope
+
+### In Scope
+- Extend `config.ServerConfig` with `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`.
+- Define defaults: `10s`, `10s`, and `1048576`.
+- Validate range/type rules for these fields in core validation.
+- Support loading from config file and env overrides in `config/viper`.
+- Apply configured values to `http.Server` in `app.Application` bootstrap.
+- Add tests for defaults, validation failures, adapter overrides, and runtime wiring.
+- Update `/docs/*` and `README.md` with new fields, defaults, and examples.
+
+### Out of Scope
+- New lifecycle features (graceful shutdown, connection draining).
+- Provider-specific abstractions or global singleton changes.
+- Security/auth behavior changes.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `config-core`: `ServerConfig` adds timeout/header-size fields with defaults and validation.
+- `config-viper-adapter`: loader/mapping adds file + env support for new server keys with typed errors.
+- `app-bootstrap`: `UseServer` applies configured timeout and header-size values deterministically.
+
+## Approach
+
+Use a flat extension of the existing server config model (no nested runtime type). Keep boundaries unchanged: core defines types/validation, Viper translates file/env inputs, and `app` maps validated config into `http.Server` (`ReadTimeout`, `WriteTimeout`, `MaxHeaderBytes`). This minimizes churn while meeting issue #28 acceptance criteria.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `config/types.go` | Modified | Add server timeout/header-size fields |
+| `config/constructors.go` | Modified | Default values and constructor assembly |
+| `config/validate.go` | Modified | Range/type validation for new fields |
+| `config/viper/mapping.go`, `config/viper/loader.go` | Modified | File/env loading + mapping for new keys |
+| `app/application.go` | Modified | Apply values to embedded `http.Server` |
+| `config/*_test.go`, `config/viper/*_test.go`, `app/application_test.go` | Modified | Coverage for defaults, validation, and wiring |
+| `README.md`, `docs/*` | Modified | Sync docs for new config contract |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Duration parsing ambiguity across file/env | Med | Canonical key names + explicit parse/validation tests |
+| Backward-compatibility break from constructor/model updates | Med | Update all call sites/tests in same change |
+| Documentation drift | Low | Update docs in same PR; treat stale docs as defect |
+
+## Rollback Plan
+
+Revert `config` model/validation, Viper mapping/overrides, and app server wiring; restore prior tests/docs.
+
+## Dependencies
+
+- Issue #28 approved scope and acceptance criteria.
+
+## Success Criteria
+
+- [ ] `read-timeout`, `write-timeout`, and `max-header-bytes` are validated with correct types/ranges.
+- [ ] Config file values and env overrides load deterministically for all three fields.
+- [ ] Runtime `http.Server` reflects configured/default values in tests.
+- [ ] `/docs/*` and `README.md` are updated with fields, defaults, and usage examples.

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/spec.md
@@ -1,0 +1,99 @@
+# Spec Artifact: 2026-05-01-issue-28-http-server-timeout-header-size
+
+## Delta: config-core
+
+### ADDED Requirement: Server runtime limits model and defaults
+
+The config core MUST extend `ServerConfig` with `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`. Core constructors SHALL default these fields to `10s`, `10s`, and `1048576` when callers do not provide explicit values.
+
+#### Scenario: Defaults are applied deterministically
+- GIVEN a server config created without explicit runtime-limit values
+- WHEN the core constructor assembles `ServerConfig`
+- THEN `ReadTimeout` equals `10s`
+- AND `WriteTimeout` equals `10s`
+- AND `MaxHeaderBytes` equals `1048576`
+
+#### Scenario: Explicit values are preserved
+- GIVEN explicit runtime-limit values in constructor inputs
+- WHEN the core constructor assembles `ServerConfig`
+- THEN the resulting fields equal the explicit inputs without mutation
+
+### ADDED Requirement: Server runtime limits validation
+
+Core validation MUST reject non-positive timeout values and non-positive `MaxHeaderBytes` with assertable validation errors.
+
+#### Scenario: Validation succeeds for positive values
+- GIVEN a config with positive `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`
+- WHEN `ValidateConfig` runs
+- THEN validation succeeds
+
+#### Scenario: Validation fails for invalid runtime limits
+- GIVEN a config where any runtime-limit field is zero or negative
+- WHEN `ValidateConfig` runs
+- THEN validation fails with contextual, assertable validation errors
+
+### ADDED Requirement: Public docs stay synchronized with server runtime limits
+
+When server runtime-limit fields are part of the public configuration contract, repository documentation MUST include field names, defaults, and at least one usage example in `README.md` and `/docs/*`.
+
+#### Scenario: Docs reflect runtime-limit contract
+- GIVEN this capability is released
+- WHEN maintainers review `README.md` and configuration docs under `/docs`
+- THEN both sources include `read-timeout`, `write-timeout`, and `max-header-bytes`
+- AND both sources show defaults and an example configuration
+
+## Delta: config-viper-adapter
+
+### ADDED Requirement: Server runtime limits mapping and env overrides
+
+The Viper adapter MUST load `server.read-timeout`, `server.write-timeout`, and `server.max-header-bytes` from configuration files and MUST support deterministic environment overrides for the same keys.
+
+#### Scenario: File values are mapped into core config
+- GIVEN a valid config file containing the three server runtime-limit keys
+- WHEN the adapter loader runs
+- THEN returned `config.Config.Server` contains mapped values for all three keys
+
+#### Scenario: Env overrides take precedence when enabled
+- GIVEN file values and environment values for the same runtime-limit keys
+- WHEN env override is enabled
+- THEN returned server runtime-limit values come from environment inputs
+- AND behavior is deterministic for identical input snapshots
+
+### ADDED Requirement: Typed failures for runtime-limit decoding and mapping
+
+The adapter MUST return adapter-typed errors when runtime-limit values cannot be decoded or mapped into core types.
+
+#### Scenario: Invalid duration format returns decode-typed error
+- GIVEN `server.read-timeout` or `server.write-timeout` has an invalid duration string
+- WHEN loading/decoding runs
+- THEN the adapter returns a decode-typed error
+
+#### Scenario: Invalid max-header-bytes type returns mapping/decode typed error
+- GIVEN `server.max-header-bytes` is not representable as the required numeric type
+- WHEN decoding/mapping runs
+- THEN the adapter returns an adapter-typed error identifying load failure
+
+## Delta: app-bootstrap
+
+### MODIFIED Requirement: Fluent setup methods
+
+`UseConfig(cfg config.Config)`, `UseServer()`, and `UseServerSecurity(v security.Validator)` MUST support fluent chaining on the same `Application` instance. `UseServer()` MUST apply `cfg.Server.ReadTimeout`, `cfg.Server.WriteTimeout`, and `cfg.Server.MaxHeaderBytes` to the underlying `http.Server` created for application runtime.
+
+(Previously: Fluent chaining was required, but `UseServer()` did not explicitly require applying server timeout/header-size config.)
+
+#### Scenario: Fluent chain remains supported
+- GIVEN an application instance
+- WHEN caller chains `UseConfig(...).UseServer().UseServerSecurity(...)`
+- THEN each method returns the same instance for continued chaining
+
+#### Scenario: Server runtime limits are applied from config
+- GIVEN `UseConfig` receives server runtime-limit values
+- WHEN `UseServer()` initializes runtime server wiring
+- THEN `http.Server.ReadTimeout` equals `cfg.Server.ReadTimeout`
+- AND `http.Server.WriteTimeout` equals `cfg.Server.WriteTimeout`
+- AND `http.Server.MaxHeaderBytes` equals `cfg.Server.MaxHeaderBytes`
+
+#### Scenario: Default runtime limits are applied when config uses defaults
+- GIVEN `UseConfig` receives a config built with core default server runtime limits
+- WHEN `UseServer()` initializes runtime server wiring
+- THEN `http.Server` runtime-limit fields equal the documented defaults

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/specs/app-bootstrap/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/specs/app-bootstrap/spec.md
@@ -1,0 +1,29 @@
+# Delta for app-bootstrap
+
+## MODIFIED Requirements
+
+### Requirement: Fluent setup methods
+
+`UseConfig(cfg config.Config)`, `UseServer()`, and `UseServerSecurity(v security.Validator)` MUST support fluent chaining on the same `Application` instance. `UseServer()` MUST apply `cfg.Server.ReadTimeout`, `cfg.Server.WriteTimeout`, and `cfg.Server.MaxHeaderBytes` to the underlying `http.Server` created for application runtime.
+
+(Previously: Fluent chaining was required, but `UseServer()` did not explicitly require applying server timeout/header-size config.)
+
+#### Scenario: Fluent chain remains supported
+
+- GIVEN an application instance
+- WHEN caller chains `UseConfig(...).UseServer().UseServerSecurity(...)`
+- THEN each method returns the same instance for continued chaining
+
+#### Scenario: Server runtime limits are applied from config
+
+- GIVEN `UseConfig` receives server runtime-limit values
+- WHEN `UseServer()` initializes runtime server wiring
+- THEN `http.Server.ReadTimeout` equals `cfg.Server.ReadTimeout`
+- AND `http.Server.WriteTimeout` equals `cfg.Server.WriteTimeout`
+- AND `http.Server.MaxHeaderBytes` equals `cfg.Server.MaxHeaderBytes`
+
+#### Scenario: Default runtime limits are applied when config uses defaults
+
+- GIVEN `UseConfig` receives a config built with core default server runtime limits
+- WHEN `UseServer()` initializes runtime server wiring
+- THEN `http.Server` runtime-limit fields equal the documented defaults

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/specs/config-core/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/specs/config-core/spec.md
@@ -1,0 +1,48 @@
+# Delta for config-core
+
+## ADDED Requirements
+
+### Requirement: Server runtime limits model and defaults
+
+The config core MUST extend `ServerConfig` with `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`. Core constructors SHALL default these fields to `10s`, `10s`, and `1048576` when callers do not provide explicit values.
+
+#### Scenario: Defaults are applied deterministically
+
+- GIVEN a server config created without explicit runtime-limit values
+- WHEN the core constructor assembles `ServerConfig`
+- THEN `ReadTimeout` equals `10s`
+- AND `WriteTimeout` equals `10s`
+- AND `MaxHeaderBytes` equals `1048576`
+
+#### Scenario: Explicit values are preserved
+
+- GIVEN explicit runtime-limit values in constructor inputs
+- WHEN the core constructor assembles `ServerConfig`
+- THEN the resulting fields equal the explicit inputs without mutation
+
+### Requirement: Server runtime limits validation
+
+Core validation MUST reject non-positive timeout values and non-positive `MaxHeaderBytes` with assertable validation errors.
+
+#### Scenario: Validation succeeds for positive values
+
+- GIVEN a config with positive `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`
+- WHEN `ValidateConfig` runs
+- THEN validation succeeds
+
+#### Scenario: Validation fails for invalid runtime limits
+
+- GIVEN a config where any runtime-limit field is zero or negative
+- WHEN `ValidateConfig` runs
+- THEN validation fails with contextual, assertable validation errors
+
+### Requirement: Public docs stay synchronized with server runtime limits
+
+When server runtime-limit fields are part of the public configuration contract, repository documentation MUST include field names, defaults, and at least one usage example in `README.md` and `/docs/*`.
+
+#### Scenario: Docs reflect runtime-limit contract
+
+- GIVEN this capability is released
+- WHEN maintainers review `README.md` and configuration docs under `/docs`
+- THEN both sources include `read-timeout`, `write-timeout`, and `max-header-bytes`
+- AND both sources show defaults and an example configuration

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/specs/config-viper-adapter/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/specs/config-viper-adapter/spec.md
@@ -1,0 +1,36 @@
+# Delta for config-viper-adapter
+
+## ADDED Requirements
+
+### Requirement: Server runtime limits mapping and env overrides
+
+The Viper adapter MUST load `server.read-timeout`, `server.write-timeout`, and `server.max-header-bytes` from configuration files and MUST support deterministic environment overrides for the same keys.
+
+#### Scenario: File values are mapped into core config
+
+- GIVEN a valid config file containing the three server runtime-limit keys
+- WHEN the adapter loader runs
+- THEN returned `config.Config.Server` contains mapped values for all three keys
+
+#### Scenario: Env overrides take precedence when enabled
+
+- GIVEN file values and environment values for the same runtime-limit keys
+- WHEN env override is enabled
+- THEN returned server runtime-limit values come from environment inputs
+- AND behavior is deterministic for identical input snapshots
+
+### Requirement: Typed failures for runtime-limit decoding and mapping
+
+The adapter MUST return adapter-typed errors when runtime-limit values cannot be decoded or mapped into core types.
+
+#### Scenario: Invalid duration format returns decode-typed error
+
+- GIVEN `server.read-timeout` or `server.write-timeout` has an invalid duration string
+- WHEN loading/decoding runs
+- THEN the adapter returns a decode-typed error
+
+#### Scenario: Invalid max-header-bytes type returns mapping/decode typed error
+
+- GIVEN `server.max-header-bytes` is not representable as the required numeric type
+- WHEN decoding/mapping runs
+- THEN the adapter returns an adapter-typed error identifying load failure

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/tasks.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: issue-28-http-server-timeout-header-size
+
+## Phase 1: Config Core Foundation
+
+- [x] 1.1 Modify `config/types.go` to extend `ServerConfig` with `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`.
+- [x] 1.2 Modify `config/constructors.go` so `NewServerConfig` sets defaults (`10s`, `10s`, `1048576`) when runtime-limit inputs are omitted.
+- [x] 1.3 Update `config/constructors.go` call sites impacted by constructor signature changes to keep compilation green.
+- [x] 1.4 Extend `config/validate.go` (`validateServer`) to reject zero/negative timeout and header-size values with contextual validation errors.
+
+## Phase 2: Adapter and Runtime Wiring
+
+- [x] 2.1 Modify `config/viper/mapping.go` to map `server.read-timeout`, `server.write-timeout`, and `server.max-header-bytes` into core config.
+- [x] 2.2 Modify `config/viper/loader.go` to support env overrides `COMMON_FWK_SERVER_READ_TIMEOUT`, `COMMON_FWK_SERVER_WRITE_TIMEOUT`, and `COMMON_FWK_SERVER_MAX_HEADER_BYTES`.
+- [x] 2.3 In `config/viper/loader.go`, parse env runtime limits explicitly (`time.ParseDuration`, `strconv.Atoi`) and return adapter-typed decode/load errors on invalid values.
+- [x] 2.4 Modify `app/application.go` so `UseServer()` applies `a.cfg.Server.ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes` to the underlying `http.Server` while preserving fluent chaining.
+
+## Phase 3: Automated Tests (Table-Driven, Deterministic)
+
+- [x] 3.1 Extend `config/constructors_test.go` with table-driven `t.Run` cases for default application and explicit runtime-limit preservation.
+- [x] 3.2 Extend `config/validate_test.go` with table-driven positive/zero/negative runtime-limit cases and assertable validation error checks.
+- [x] 3.3 Extend `config/viper/mapping_test.go` to verify deterministic file-key mapping for all three runtime-limit fields.
+- [x] 3.4 Extend `config/viper/loader_test.go` to verify env precedence, deterministic override behavior, and typed failures for invalid duration/int inputs.
+- [x] 3.5 Extend `app/application_test.go` to verify fluent chain behavior and `UseServer()` runtime-limit wiring (explicit values and defaults).
+
+## Phase 4: Documentation Synchronization
+
+- [x] 4.1 Update `README.md` with server runtime-limit keys, defaults, env variable names, and at least one configuration example.
+- [x] 4.2 Update `docs/home.md` and related config docs under `docs/` to include the same keys/defaults/example and keep wording aligned with README.
+
+## Phase 5: Verification and Readiness
+
+- [x] 5.1 Run `go test ./...` and confirm all updated tests pass.
+- [x] 5.2 Run `go build ./...` to verify no integration/build regressions.
+- [x] 5.3 Verify completion against spec scenarios (defaults, explicit preservation, validation failures, adapter mapping/overrides, typed decode failures, app wiring, docs sync).

--- a/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/verify-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-28-http-server-timeout-header-size/verify-report.md
@@ -1,0 +1,139 @@
+# Verification Report
+
+**Change**: 2026-05-01-issue-28-http-server-timeout-header-size  
+**Version**: N/A  
+**Mode**: Standard
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 18 |
+| Tasks complete | 18 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/active/2026-05-01-issue-28-http-server-timeout-header-size/tasks.md` are marked complete (`[x]`).
+
+---
+
+### Prior Findings Re-Check
+
+1. Previous **CRITICAL**: docs scenario was `❌ UNTESTED`.  
+   **Current**: resolved by `bootstrap_guard_test.go > TestDocsRuntimeLimitsContract` (passes; includes README + docs/home checks).
+2. Previous **WARNING**: env override determinism only partially evidenced.  
+   **Current**: resolved by explicit determinism assertion in `config/viper/loader_test.go > TestLoadEnvOverrideSemantics` using repeated `EnvOverride=true` loads and `reflect.DeepEqual` (passes).
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed
+```text
+Command: go build ./...
+Result: success (exit code 0, no output)
+```
+
+**Tests**: ✅ Passed (package-level: 9 ok, 1 package with no test files, 0 failed)
+```text
+Command: go test ./...
+ok   github.com/matiasmartin-labs/common-fwk
+ok   github.com/matiasmartin-labs/common-fwk/app
+ok   github.com/matiasmartin-labs/common-fwk/config
+ok   github.com/matiasmartin-labs/common-fwk/config/viper
+ok   github.com/matiasmartin-labs/common-fwk/errors
+ok   github.com/matiasmartin-labs/common-fwk/http/gin
+?    github.com/matiasmartin-labs/common-fwk/security          [no test files]
+ok   github.com/matiasmartin-labs/common-fwk/security/claims
+ok   github.com/matiasmartin-labs/common-fwk/security/jwt
+ok   github.com/matiasmartin-labs/common-fwk/security/keys
+```
+
+Focused scenario evidence:
+```text
+Command: go test -v ./... -run TestDocsRuntimeLimitsContract
+--- PASS: TestDocsRuntimeLimitsContract
+    --- PASS: TestDocsRuntimeLimitsContract/README_includes_runtime-limit_keys_defaults_env_and_example
+    --- PASS: TestDocsRuntimeLimitsContract/docs_home_includes_runtime-limit_keys_defaults_env_and_example
+
+Command: go test -v ./config/viper -run TestLoadEnvOverrideSemantics
+--- PASS: TestLoadEnvOverrideSemantics
+```
+
+**Coverage**: 78.5% aggregate (sum covered statements / sum statements), threshold: 0% → ✅ Above threshold
+```text
+Command: go test ./... -cover
+ok   github.com/matiasmartin-labs/common-fwk             coverage: [no statements]
+ok   github.com/matiasmartin-labs/common-fwk/app         coverage: 90.6% of statements
+ok   github.com/matiasmartin-labs/common-fwk/config      coverage: 85.3% of statements
+ok   github.com/matiasmartin-labs/common-fwk/config/viper coverage: 78.9% of statements
+ok   github.com/matiasmartin-labs/common-fwk/errors      coverage: [no statements]
+ok   github.com/matiasmartin-labs/common-fwk/http/gin    coverage: 85.4% of statements
+?    github.com/matiasmartin-labs/common-fwk/security    [no test files]
+ok   github.com/matiasmartin-labs/common-fwk/security/claims coverage: 58.3% of statements
+ok   github.com/matiasmartin-labs/common-fwk/security/jwt coverage: 73.3% of statements
+ok   github.com/matiasmartin-labs/common-fwk/security/keys coverage: 62.5% of statements
+```
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| config-core: Server runtime limits model and defaults | Defaults are applied deterministically | `config/constructors_test.go > TestNewServerConfig/uses defaults when zero values are provided` | ✅ COMPLIANT |
+| config-core: Server runtime limits model and defaults | Explicit values are preserved | `config/constructors_test.go > TestNewServerConfig/keeps explicit values` | ✅ COMPLIANT |
+| config-core: Server runtime limits validation | Validation succeeds for positive values | `config/validate_test.go > TestValidateConfigValid` | ✅ COMPLIANT |
+| config-core: Server runtime limits validation | Validation fails for invalid runtime limits | `config/validate_test.go > TestValidateConfigInvalid` (runtime-limit invalid subcases) | ✅ COMPLIANT |
+| config-core: Public docs stay synchronized with server runtime limits | Docs reflect runtime-limit contract | `bootstrap_guard_test.go > TestDocsRuntimeLimitsContract/{README...,docs_home...}` | ✅ COMPLIANT |
+| config-viper-adapter: Server runtime limits mapping and env overrides | File values are mapped into core config | `config/viper/loader_test.go > TestLoadSuccessAndDeterminism` | ✅ COMPLIANT |
+| config-viper-adapter: Server runtime limits mapping and env overrides | Env overrides take precedence when enabled (incl. deterministic behavior) | `config/viper/loader_test.go > TestLoadEnvOverrideSemantics` | ✅ COMPLIANT |
+| config-viper-adapter: Typed failures for runtime-limit decoding and mapping | Invalid duration format returns decode-typed error | `config/viper/loader_test.go > TestLoadEnvOverrideTypedFailuresForServerRuntimeLimits/{invalid server read timeout format, invalid server write timeout format}` | ✅ COMPLIANT |
+| config-viper-adapter: Typed failures for runtime-limit decoding and mapping | Invalid max-header-bytes type returns mapping/decode typed error | `config/viper/loader_test.go > TestLoadEnvOverrideTypedFailuresForServerRuntimeLimits/invalid max header bytes format` | ✅ COMPLIANT |
+| app-bootstrap: Fluent setup methods | Fluent chain remains supported | `app/application_test.go > TestBootstrapChain_PreservesPointerAndReadiness` | ✅ COMPLIANT |
+| app-bootstrap: Fluent setup methods | Server runtime limits are applied from config | `app/application_test.go > TestUseServer_WiresRuntimeLimitsFromConfig/explicit values` | ✅ COMPLIANT |
+| app-bootstrap: Fluent setup methods | Default runtime limits are applied when config uses defaults | `app/application_test.go > TestUseServer_WiresRuntimeLimitsFromConfig/defaults from constructor` | ✅ COMPLIANT |
+
+**Compliance summary**: 12/12 scenarios compliant.
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| config-core: runtime limits model/defaults | ✅ Implemented | `ServerConfig` includes runtime-limit fields; `NewServerConfig` applies defaults (`config/types.go`, `config/constructors.go`). |
+| config-core: runtime limits validation | ✅ Implemented | `validateServer` enforces `>0` for read/write timeout and max header bytes (`config/validate.go`). |
+| config-core: docs synchronized | ✅ Implemented | `README.md` and `docs/home.md` include keys, defaults, env vars, and configuration example; guard test enforces contract. |
+| config-viper-adapter: mapping + env overrides | ✅ Implemented | `rawServerConfig` includes three keys and env overrides parse/set values deterministically (`config/viper/mapping.go`, `config/viper/loader.go`). |
+| config-viper-adapter: typed failures | ✅ Implemented | Invalid env duration/int parse paths return adapter-typed load/decode failures (`config/viper/loader.go`, `config/viper/loader_test.go`). |
+| app-bootstrap: fluent + server wiring | ✅ Implemented | `UseServer()` wires `ReadTimeout`, `WriteTimeout`, `MaxHeaderBytes`; fluent chain remains same-pointer (`app/application.go`, `app/application_test.go`). |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Extend `ServerConfig` directly | ✅ Yes | Runtime-limit fields are flat on `ServerConfig`; no nested runtime model introduced. |
+| Keep validation in `config.ValidateConfig` | ✅ Yes | Invariants enforced in `validateServer` at core layer. |
+| Explicit env parsing in loader override path | ✅ Yes | `time.ParseDuration` and `strconv.Atoi` are used explicitly for runtime-limit env keys. |
+| File changes alignment | ✅ Yes | Implemented files align with design table, including tests and docs. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+None.
+
+**WARNING** (should fix):
+None.
+
+**SUGGESTION** (nice to have):
+None.
+
+---
+
+### Verdict
+**PASS**
+
+Re-verification confirms previous blockers are remediated and all 12/12 spec scenarios now have passing runtime evidence.

--- a/openspec/specs/app-bootstrap/spec.md
+++ b/openspec/specs/app-bootstrap/spec.md
@@ -19,7 +19,27 @@ The framework MUST provide an instance-scoped `Application` bootstrap API in `ap
 
 ### Requirement: Fluent setup methods
 
-`UseConfig(cfg config.Config)`, `UseServer()`, and `UseServerSecurity(v security.Validator)` MUST support fluent chaining on the same `Application` instance.
+`UseConfig(cfg config.Config)`, `UseServer()`, and `UseServerSecurity(v security.Validator)` MUST support fluent chaining on the same `Application` instance. `UseServer()` MUST apply `cfg.Server.ReadTimeout`, `cfg.Server.WriteTimeout`, and `cfg.Server.MaxHeaderBytes` to the underlying `http.Server` created for application runtime.
+
+#### Scenario: Fluent chain remains supported
+
+- GIVEN an application instance
+- WHEN caller chains `UseConfig(...).UseServer().UseServerSecurity(...)`
+- THEN each method returns the same instance for continued chaining
+
+#### Scenario: Server runtime limits are applied from config
+
+- GIVEN `UseConfig` receives server runtime-limit values
+- WHEN `UseServer()` initializes runtime server wiring
+- THEN `http.Server.ReadTimeout` equals `cfg.Server.ReadTimeout`
+- AND `http.Server.WriteTimeout` equals `cfg.Server.WriteTimeout`
+- AND `http.Server.MaxHeaderBytes` equals `cfg.Server.MaxHeaderBytes`
+
+#### Scenario: Default runtime limits are applied when config uses defaults
+
+- GIVEN `UseConfig` receives a config built with core default server runtime limits
+- WHEN `UseServer()` initializes runtime server wiring
+- THEN `http.Server` runtime-limit fields equal the documented defaults
 
 ### Requirement: Route registration API
 

--- a/openspec/specs/config-core/spec.md
+++ b/openspec/specs/config-core/spec.md
@@ -64,6 +64,51 @@ The config core MUST provide validation entrypoints for domains (server, JWT, co
 - WHEN validation fails for a core rule
 - THEN callers can still assert the underlying core failure class
 
+### Requirement: Server runtime limits model and defaults
+
+The config core MUST extend `ServerConfig` with `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`. Core constructors SHALL default these fields to `10s`, `10s`, and `1048576` when callers do not provide explicit values.
+
+#### Scenario: Defaults are applied deterministically
+
+- GIVEN a server config created without explicit runtime-limit values
+- WHEN the core constructor assembles `ServerConfig`
+- THEN `ReadTimeout` equals `10s`
+- AND `WriteTimeout` equals `10s`
+- AND `MaxHeaderBytes` equals `1048576`
+
+#### Scenario: Explicit values are preserved
+
+- GIVEN explicit runtime-limit values in constructor inputs
+- WHEN the core constructor assembles `ServerConfig`
+- THEN the resulting fields equal the explicit inputs without mutation
+
+### Requirement: Server runtime limits validation
+
+Core validation MUST reject non-positive timeout values and non-positive `MaxHeaderBytes` with assertable validation errors.
+
+#### Scenario: Validation succeeds for positive values
+
+- GIVEN a config with positive `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes`
+- WHEN `ValidateConfig` runs
+- THEN validation succeeds
+
+#### Scenario: Validation fails for invalid runtime limits
+
+- GIVEN a config where any runtime-limit field is zero or negative
+- WHEN `ValidateConfig` runs
+- THEN validation fails with contextual, assertable validation errors
+
+### Requirement: Public docs stay synchronized with server runtime limits
+
+When server runtime-limit fields are part of the public configuration contract, repository documentation MUST include field names, defaults, and at least one usage example in `README.md` and `/docs/*`.
+
+#### Scenario: Docs reflect runtime-limit contract
+
+- GIVEN this capability is released
+- WHEN maintainers review `README.md` and configuration docs under `/docs`
+- THEN both sources include `read-timeout`, `write-timeout`, and `max-header-bytes`
+- AND both sources show defaults and an example configuration
+
 ### Requirement: Independence from global state and environment adapters
 
 Config core behavior MUST be independent from Viper, filesystem reads, environment-loading side effects, and package-level mutable globals.

--- a/openspec/specs/config-viper-adapter/spec.md
+++ b/openspec/specs/config-viper-adapter/spec.md
@@ -85,3 +85,36 @@ When env expansion is enabled, it MUST be deterministic for a fixed env snapshot
 - GIVEN placeholders in file values and expansion disabled
 - WHEN the loader runs
 - THEN placeholders remain unexpanded before validation
+
+### Requirement: Server runtime limits mapping and env overrides
+
+The Viper adapter MUST load `server.read-timeout`, `server.write-timeout`, and `server.max-header-bytes` from configuration files and MUST support deterministic environment overrides for the same keys.
+
+#### Scenario: File values are mapped into core config
+
+- GIVEN a valid config file containing the three server runtime-limit keys
+- WHEN the adapter loader runs
+- THEN returned `config.Config.Server` contains mapped values for all three keys
+
+#### Scenario: Env overrides take precedence when enabled
+
+- GIVEN file values and environment values for the same runtime-limit keys
+- WHEN env override is enabled
+- THEN returned server runtime-limit values come from environment inputs
+- AND behavior is deterministic for identical input snapshots
+
+### Requirement: Typed failures for runtime-limit decoding and mapping
+
+The adapter MUST return adapter-typed errors when runtime-limit values cannot be decoded or mapped into core types.
+
+#### Scenario: Invalid duration format returns decode-typed error
+
+- GIVEN `server.read-timeout` or `server.write-timeout` has an invalid duration string
+- WHEN loading/decoding runs
+- THEN the adapter returns a decode-typed error
+
+#### Scenario: Invalid max-header-bytes type returns mapping/decode typed error
+
+- GIVEN `server.max-header-bytes` is not representable as the required numeric type
+- WHEN decoding/mapping runs
+- THEN the adapter returns an adapter-typed error identifying load failure


### PR DESCRIPTION
## Summary
- Adds server runtime-limit configuration fields (`read-timeout`, `write-timeout`, `max-header-bytes`) with defaults and core validation.
- Wires runtime limits through Viper file/env loading and applies them to `http.Server` in app bootstrap.
- Adds/updates tests, syncs docs (`README.md`, `docs/home.md`), and archives the full SDD artifact trail for issue #28.

## Linked Issue
Closes #28

## Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan
- [x] `go test ./...`
- [x] `go build ./...`

## Changes
| File | Change |
|------|--------|
| `config/types.go` | Added runtime-limit fields to `ServerConfig` and introduced `ServerRuntimeLimits`. |
| `config/constructors.go` | Added defaults and variadic runtime-limits input in `NewServerConfig`. |
| `config/validate.go` | Added positive-value validation for new server runtime-limit fields. |
| `config/viper/mapping.go` | Mapped runtime-limit keys from file config into core config. |
| `config/viper/loader.go` | Added env override parsing for server runtime-limit keys. |
| `app/application.go` | Wired runtime-limit values into the constructed `http.Server`. |
| `README.md`, `docs/home.md` | Documented new keys, defaults, env overrides, and YAML examples. |
| `openspec/specs/*` | Synced source-of-truth specs for config-core, viper adapter, and app bootstrap. |
| `openspec/changes/archive/...issue-28.../*` | Archived complete SDD artifacts (explore→archive report). |