### PR TITLE
feat(security): support RS256 keypair mode and config-driven wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,10 @@ import (
 
 func main() {
 	jwtCfg := config.NewJWTConfig("secret", "common-fwk", 15)
-	compat := securityjwt.FromConfigJWT(jwtCfg)
+	compat, err := securityjwt.FromConfigJWT(jwtCfg)
+	if err != nil {
+		panic(err)
+	}
 
 	validator, err := securityjwt.NewValidator(compat.Options)
 	if err != nil {
@@ -198,6 +201,30 @@ func main() {
 	fmt.Println(validatedClaims.Subject)
 }
 ```
+
+HS256 remains the default when `jwt.algorithm` is omitted.
+
+RS256 config example (kebab-case adapter keys):
+
+```yaml
+security:
+  auth:
+    jwt:
+      algorithm: RS256
+      issuer: common-fwk
+      ttl-minutes: 15
+      rs256-key-source: private-pem
+      rs256-key-id: auth-main
+      rs256-private-key-pem: |
+        -----BEGIN RSA PRIVATE KEY-----
+        ...
+        -----END RSA PRIVATE KEY-----
+```
+
+Supported RS256 key sources:
+- `generated`: in-memory RSA keypair generated at bootstrap
+- `public-pem`: resolver built from `rs256-public-key-pem`
+- `private-pem`: resolver built from `rs256-private-key-pem`
 
 ### 4) Gin integration example (fluent option-style API)
 
@@ -315,6 +342,7 @@ Behavior notes:
 - Register methods return typed sentinel errors when used out of order (for example, server/security not ready).
 - `RegisterProtectedGET` uses `http/gin.NewAuthMiddleware` internally.
 - `RunListener(net.Listener)` is available for test-friendly startup flows.
+- `UseServerSecurityFromConfig()` is available as a thin convenience wrapper around config-driven JWT validator wiring (HS256/RS256).
 
 ---
 

--- a/app/application.go
+++ b/app/application.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"github.com/matiasmartin-labs/common-fwk/config"
 	httpgin "github.com/matiasmartin-labs/common-fwk/http/gin"
 	"github.com/matiasmartin-labs/common-fwk/security"
+	securityjwt "github.com/matiasmartin-labs/common-fwk/security/jwt"
 )
 
 var (
@@ -67,6 +69,27 @@ func (a *Application) UseServerSecurity(v security.Validator) *Application {
 	a.securityReady = v != nil
 
 	return a
+}
+
+// UseServerSecurityFromConfig wires validator from currently loaded config.
+func (a *Application) UseServerSecurityFromConfig() (*Application, error) {
+	validatedCfg, err := config.ValidateConfig(a.cfg)
+	if err != nil {
+		return a, fmt.Errorf("validate config before security wiring: %w", err)
+	}
+
+	compat, err := securityjwt.FromConfigJWT(validatedCfg.Security.Auth.JWT)
+	if err != nil {
+		return a, fmt.Errorf("build validator options from config: %w", err)
+	}
+
+	validator, err := securityjwt.NewValidator(compat.Options)
+	if err != nil {
+		return a, fmt.Errorf("build jwt validator: %w", err)
+	}
+
+	a.UseServerSecurity(validator)
+	return a, nil
 }
 
 func (a *Application) ensureServerReady() error {

--- a/app/application_test.go
+++ b/app/application_test.go
@@ -2,6 +2,10 @@ package app
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -354,6 +358,82 @@ func TestRun_DelegatesToListenAndServeAndPropagatesErrors(t *testing.T) {
 	}
 }
 
+func TestUseServerSecurityFromConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hs256 success", func(t *testing.T) {
+		a := NewApplication().UseConfig(config.Config{
+			Server: config.NewServerConfig("127.0.0.1", 8080),
+			Security: config.NewSecurityConfig(config.NewAuthConfig(
+				config.NewJWTConfig("secret", "common-fwk", 15),
+				config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+				config.NewLoginConfig("owner@example.com"),
+				config.NewOAuth2Config(nil),
+			)),
+		})
+
+		_, err := a.UseServerSecurityFromConfig()
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if !a.securityReady {
+			t.Fatalf("expected security to be marked ready")
+		}
+		if a.validator == nil {
+			t.Fatalf("expected validator to be set")
+		}
+	})
+
+	t.Run("rs256 success", func(t *testing.T) {
+		privatePEM := mustRSAPrivatePEM(t)
+
+		jwtCfg := config.NewJWTConfig("", "common-fwk", 15)
+		jwtCfg.Algorithm = config.JWTAlgorithmRS256
+		jwtCfg.RS256 = config.NewRS256PrivatePEMConfig("rsa-key", privatePEM)
+
+		a := NewApplication().UseConfig(config.Config{
+			Server: config.NewServerConfig("127.0.0.1", 8080),
+			Security: config.NewSecurityConfig(config.NewAuthConfig(
+				jwtCfg,
+				config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+				config.NewLoginConfig("owner@example.com"),
+				config.NewOAuth2Config(nil),
+			)),
+		})
+
+		_, err := a.UseServerSecurityFromConfig()
+		if err != nil {
+			t.Fatalf("expected RS256 success, got %v", err)
+		}
+		if !a.securityReady || a.validator == nil {
+			t.Fatalf("expected security wiring to be complete")
+		}
+	})
+
+	t.Run("invalid config does not partially wire", func(t *testing.T) {
+		a := NewApplication().UseConfig(config.Config{
+			Server: config.NewServerConfig("127.0.0.1", 8080),
+			Security: config.NewSecurityConfig(config.NewAuthConfig(
+				config.JWTConfig{Algorithm: config.JWTAlgorithmRS256, Issuer: "common-fwk", TTLMinutes: 15},
+				config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+				config.NewLoginConfig("owner@example.com"),
+				config.NewOAuth2Config(nil),
+			)),
+		})
+
+		_, err := a.UseServerSecurityFromConfig()
+		if err == nil {
+			t.Fatalf("expected config-driven security wiring error")
+		}
+		if a.securityReady {
+			t.Fatalf("expected securityReady to remain false on failure")
+		}
+		if a.validator != nil {
+			t.Fatalf("expected validator to remain nil on failure")
+		}
+	})
+}
+
 func waitHTTPGet(url string, timeout time.Duration) (*http.Response, error) {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
@@ -368,4 +448,18 @@ func waitHTTPGet(url string, timeout time.Duration) (*http.Response, error) {
 	}
 
 	return nil, fmt.Errorf("timeout waiting for %s: %w", url, lastErr)
+}
+
+func mustRSAPrivatePEM(t *testing.T) string {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+
+	der := x509.MarshalPKCS1PrivateKey(priv)
+	blk := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}
+
+	return string(pem.EncodeToMemory(blk))
 }

--- a/bootstrap_guard_test.go
+++ b/bootstrap_guard_test.go
@@ -314,3 +314,56 @@ func TestDocsRuntimeLimitsContract(t *testing.T) {
 		})
 	}
 }
+
+func TestDocsJWTModeReleaseAndMigrationContracts(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name      string
+		path      string
+		fragments []string
+	}{
+		{
+			name: "release checklist includes HS256 and RS256 verification checkpoints",
+			path: filepath.Join("docs", "releases", "v0.2.0-checklist.md"),
+			fragments: []string{
+				"Validate JWT mode-aware docs include HS256 default behavior and RS256 bootstrap keys",
+				"Verify RS256 key-source coverage in tests (`generated`, `public-pem`, `private-pem`).",
+				"Verify HS256 backward compatibility tests remain green.",
+				"Validate migration guide at `docs/migration/auth-provider-ms-v0.1.0.md` is complete.",
+			},
+		},
+		{
+			name: "migration guide includes executable HS256 to RS256 sequence and parity checks",
+			path: filepath.Join("docs", "migration", "auth-provider-ms-v0.1.0.md"),
+			fragments: []string{
+				"HS256 -> RS256 executable transition sequence",
+				"security.auth.jwt.algorithm=RS256",
+				"security.auth.jwt.rs256-key-source",
+				"security.auth.jwt.rs256-key-id",
+				"Protected routes still reject missing token with `401`.",
+				"Valid RS256 token for configured issuer passes.",
+				"HS256 path remains valid for services that have not migrated yet (default algorithm behavior).",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Helper()
+
+			content, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatalf("read docs file %q: %v", tc.path, err)
+			}
+
+			doc := string(content)
+			for _, fragment := range tc.fragments {
+				if !strings.Contains(doc, fragment) {
+					t.Fatalf("docs file %q missing required JWT mode contract fragment %q", tc.path, fragment)
+				}
+			}
+		})
+	}
+}

--- a/config/constructors.go
+++ b/config/constructors.go
@@ -82,9 +82,33 @@ func NewJWTConfig(secret, issuer string, ttlMinutes int) JWTConfig {
 	}
 
 	return JWTConfig{
+		Algorithm:  JWTAlgorithmHS256,
 		Secret:     secret,
 		Issuer:     issuer,
 		TTLMinutes: ttlMinutes,
+	}
+}
+
+// NewRS256GeneratedConfig returns RS256 settings for generated key source.
+func NewRS256GeneratedConfig(keyID string) RS256Config {
+	return RS256Config{KeySource: RS256KeySourceGenerated, KeyID: keyID}
+}
+
+// NewRS256PublicPEMConfig returns RS256 settings for public PEM key source.
+func NewRS256PublicPEMConfig(keyID, publicKeyPEM string) RS256Config {
+	return RS256Config{
+		KeySource:    RS256KeySourcePublicPEM,
+		KeyID:        keyID,
+		PublicKeyPEM: publicKeyPEM,
+	}
+}
+
+// NewRS256PrivatePEMConfig returns RS256 settings for private PEM key source.
+func NewRS256PrivatePEMConfig(keyID, privateKeyPEM string) RS256Config {
+	return RS256Config{
+		KeySource:     RS256KeySourcePrivatePEM,
+		KeyID:         keyID,
+		PrivateKeyPEM: privateKeyPEM,
 	}
 }
 

--- a/config/constructors_test.go
+++ b/config/constructors_test.go
@@ -65,6 +65,48 @@ func TestNewJWTConfig(t *testing.T) {
 	if actual.TTLMinutes != defaultJWTTTLMinutes {
 		t.Fatalf("expected default ttl %d, got %d", defaultJWTTTLMinutes, actual.TTLMinutes)
 	}
+
+	if actual.Algorithm != JWTAlgorithmHS256 {
+		t.Fatalf("expected default algorithm %q, got %q", JWTAlgorithmHS256, actual.Algorithm)
+	}
+
+	if actual.RS256 != (RS256Config{}) {
+		t.Fatalf("expected RS256 config to default empty, got %+v", actual.RS256)
+	}
+}
+
+func TestNewRS256ConfigHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generated key source", func(t *testing.T) {
+		cfg := NewRS256GeneratedConfig("kid-1")
+		if cfg.KeySource != RS256KeySourceGenerated {
+			t.Fatalf("expected key source %q, got %q", RS256KeySourceGenerated, cfg.KeySource)
+		}
+		if cfg.KeyID != "kid-1" {
+			t.Fatalf("expected key id kid-1, got %q", cfg.KeyID)
+		}
+	})
+
+	t.Run("public pem key source", func(t *testing.T) {
+		cfg := NewRS256PublicPEMConfig("kid-2", "PUBLIC")
+		if cfg.KeySource != RS256KeySourcePublicPEM {
+			t.Fatalf("expected key source %q, got %q", RS256KeySourcePublicPEM, cfg.KeySource)
+		}
+		if cfg.PublicKeyPEM != "PUBLIC" {
+			t.Fatalf("expected public pem to be preserved")
+		}
+	})
+
+	t.Run("private pem key source", func(t *testing.T) {
+		cfg := NewRS256PrivatePEMConfig("kid-3", "PRIVATE")
+		if cfg.KeySource != RS256KeySourcePrivatePEM {
+			t.Fatalf("expected key source %q, got %q", RS256KeySourcePrivatePEM, cfg.KeySource)
+		}
+		if cfg.PrivateKeyPEM != "PRIVATE" {
+			t.Fatalf("expected private pem to be preserved")
+		}
+	})
 }
 
 func TestNewCookieConfig(t *testing.T) {

--- a/config/types.go
+++ b/config/types.go
@@ -2,6 +2,20 @@ package config
 
 import "time"
 
+const (
+	// JWTAlgorithmHS256 keeps backward-compatible HMAC mode as default.
+	JWTAlgorithmHS256 = "HS256"
+	// JWTAlgorithmRS256 enables RSA verification mode.
+	JWTAlgorithmRS256 = "RS256"
+
+	// RS256KeySourceGenerated derives keys from in-memory generation.
+	RS256KeySourceGenerated = "generated"
+	// RS256KeySourcePublicPEM uses an explicit PEM-encoded public key.
+	RS256KeySourcePublicPEM = "public-pem"
+	// RS256KeySourcePrivatePEM uses an explicit PEM-encoded private key.
+	RS256KeySourcePrivatePEM = "private-pem"
+)
+
 // Config is the root configuration model for common-fwk.
 type Config struct {
 	Server   ServerConfig
@@ -39,9 +53,19 @@ type AuthConfig struct {
 
 // JWTConfig contains token signing and lifetime settings.
 type JWTConfig struct {
+	Algorithm  string
 	Secret     string
 	Issuer     string
 	TTLMinutes int
+	RS256      RS256Config
+}
+
+// RS256Config contains RSA key resolution settings for RS256 mode.
+type RS256Config struct {
+	KeySource     string
+	KeyID         string
+	PublicKeyPEM  string
+	PrivateKeyPEM string
 }
 
 // CookieConfig contains cookie settings used by authentication flows.

--- a/config/validate.go
+++ b/config/validate.go
@@ -15,6 +15,7 @@ var allowedSameSiteValues = map[string]struct{}{
 // ValidateConfig validates a configuration value and returns a normalized copy.
 func ValidateConfig(cfg Config) (Config, error) {
 	normalized := cfg
+	normalized.Security.Auth.JWT = normalizeJWTConfig(normalized.Security.Auth.JWT)
 	normalized.Security.Auth.Login.Email = normalizeLoginEmail(normalized.Security.Auth.Login.Email)
 
 	if err := validateServer(normalized.Server); err != nil {
@@ -65,8 +66,22 @@ func validateServer(cfg ServerConfig) error {
 }
 
 func validateJWT(cfg JWTConfig) error {
-	if strings.TrimSpace(cfg.Secret) == "" {
-		return invalidAt("security.auth.jwt.secret", ErrRequired)
+	algorithm := strings.TrimSpace(cfg.Algorithm)
+	if algorithm == "" {
+		algorithm = JWTAlgorithmHS256
+	}
+
+	switch algorithm {
+	case JWTAlgorithmHS256:
+		if strings.TrimSpace(cfg.Secret) == "" {
+			return invalidAt("security.auth.jwt.secret", ErrRequired)
+		}
+	case JWTAlgorithmRS256:
+		if err := validateRS256(cfg.RS256); err != nil {
+			return err
+		}
+	default:
+		return invalidAt("security.auth.jwt.algorithm", fmt.Errorf("%w: unsupported algorithm %q", ErrOutOfRange, algorithm))
 	}
 
 	if strings.TrimSpace(cfg.Issuer) == "" {
@@ -78,6 +93,34 @@ func validateJWT(cfg JWTConfig) error {
 	}
 
 	return nil
+}
+
+func validateRS256(cfg RS256Config) error {
+	if strings.TrimSpace(cfg.KeyID) == "" {
+		return invalidAt("security.auth.jwt.rs256.keyID", ErrRequired)
+	}
+
+	keySource := strings.TrimSpace(cfg.KeySource)
+	if keySource == "" {
+		return invalidAt("security.auth.jwt.rs256.keySource", ErrRequired)
+	}
+
+	switch keySource {
+	case RS256KeySourceGenerated:
+		return nil
+	case RS256KeySourcePublicPEM:
+		if strings.TrimSpace(cfg.PublicKeyPEM) == "" {
+			return invalidAt("security.auth.jwt.rs256.publicKeyPEM", ErrRequired)
+		}
+		return nil
+	case RS256KeySourcePrivatePEM:
+		if strings.TrimSpace(cfg.PrivateKeyPEM) == "" {
+			return invalidAt("security.auth.jwt.rs256.privateKeyPEM", ErrRequired)
+		}
+		return nil
+	default:
+		return invalidAt("security.auth.jwt.rs256.keySource", fmt.Errorf("%w: unsupported key source %q", ErrOutOfRange, keySource))
+	}
 }
 
 func validateCookie(cfg CookieConfig) error {
@@ -141,4 +184,13 @@ func validateOAuth2(cfg OAuth2Config) error {
 
 func normalizeLoginEmail(email string) string {
 	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func normalizeJWTConfig(jwt JWTConfig) JWTConfig {
+	normalized := jwt
+	if strings.TrimSpace(normalized.Algorithm) == "" {
+		normalized.Algorithm = JWTAlgorithmHS256
+	}
+
+	return normalized
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -17,6 +17,10 @@ func TestValidateConfigValid(t *testing.T) {
 	if validated.Security.Auth.Login.Email != "owner@example.com" {
 		t.Fatalf("expected normalized email to be preserved in lowercase, got %q", validated.Security.Auth.Login.Email)
 	}
+
+	if validated.Security.Auth.JWT.Algorithm != JWTAlgorithmHS256 {
+		t.Fatalf("expected default JWT algorithm %q, got %q", JWTAlgorithmHS256, validated.Security.Auth.JWT.Algorithm)
+	}
 }
 
 func TestValidateConfigInvalid(t *testing.T) {
@@ -110,6 +114,48 @@ func TestValidateConfigInvalid(t *testing.T) {
 			wantPath:     "security.auth.jwt.secret",
 		},
 		{
+			name: "unsupported jwt algorithm",
+			mutate: func(cfg Config) Config {
+				cfg.Security.Auth.JWT.Algorithm = "HS512"
+				return cfg
+			},
+			wantSentinel: ErrOutOfRange,
+			wantPath:     "security.auth.jwt.algorithm",
+		},
+		{
+			name: "rs256 missing key id",
+			mutate: func(cfg Config) Config {
+				cfg.Security.Auth.JWT.Algorithm = JWTAlgorithmRS256
+				cfg.Security.Auth.JWT.Secret = ""
+				cfg.Security.Auth.JWT.RS256 = NewRS256GeneratedConfig("")
+				return cfg
+			},
+			wantSentinel: ErrRequired,
+			wantPath:     "security.auth.jwt.rs256.keyID",
+		},
+		{
+			name: "rs256 missing public pem",
+			mutate: func(cfg Config) Config {
+				cfg.Security.Auth.JWT.Algorithm = JWTAlgorithmRS256
+				cfg.Security.Auth.JWT.Secret = ""
+				cfg.Security.Auth.JWT.RS256 = NewRS256PublicPEMConfig("rsa-1", "")
+				return cfg
+			},
+			wantSentinel: ErrRequired,
+			wantPath:     "security.auth.jwt.rs256.publicKeyPEM",
+		},
+		{
+			name: "rs256 missing private pem",
+			mutate: func(cfg Config) Config {
+				cfg.Security.Auth.JWT.Algorithm = JWTAlgorithmRS256
+				cfg.Security.Auth.JWT.Secret = ""
+				cfg.Security.Auth.JWT.RS256 = NewRS256PrivatePEMConfig("rsa-1", "")
+				return cfg
+			},
+			wantSentinel: ErrRequired,
+			wantPath:     "security.auth.jwt.rs256.privateKeyPEM",
+		},
+		{
 			name: "invalid login email",
 			mutate: func(cfg Config) Config {
 				cfg.Security.Auth.Login.Email = "not-an-email"
@@ -159,6 +205,22 @@ func TestValidateConfigInvalid(t *testing.T) {
 				t.Fatalf("expected path %q, got %q", tc.wantPath, vErr.Path)
 			}
 		})
+	}
+}
+
+func TestValidateConfigDefaultsJWTAlgorithmToHS256(t *testing.T) {
+	t.Parallel()
+
+	input := validConfigFixture()
+	input.Security.Auth.JWT.Algorithm = ""
+
+	validated, err := ValidateConfig(input)
+	if err != nil {
+		t.Fatalf("expected successful validation, got: %v", err)
+	}
+
+	if validated.Security.Auth.JWT.Algorithm != JWTAlgorithmHS256 {
+		t.Fatalf("expected normalized algorithm %q, got %q", JWTAlgorithmHS256, validated.Security.Auth.JWT.Algorithm)
 	}
 }
 

--- a/config/viper/loader.go
+++ b/config/viper/loader.go
@@ -98,6 +98,11 @@ func applyEnvironmentOverrides(v *viper.Viper, opts Options, snapshot map[string
 	setString("server.host", binding("SERVER_HOST"))
 	setString("security.auth.jwt.secret", binding("SECURITY_AUTH_JWT_SECRET"))
 	setString("security.auth.jwt.issuer", binding("SECURITY_AUTH_JWT_ISSUER"))
+	setString("security.auth.jwt.algorithm", binding("SECURITY_AUTH_JWT_ALGORITHM"))
+	setString("security.auth.jwt.rs256-key-source", binding("SECURITY_AUTH_JWT_RS256_KEY_SOURCE"))
+	setString("security.auth.jwt.rs256-key-id", binding("SECURITY_AUTH_JWT_RS256_KEY_ID"))
+	setString("security.auth.jwt.rs256-public-key-pem", binding("SECURITY_AUTH_JWT_RS256_PUBLIC_KEY_PEM"))
+	setString("security.auth.jwt.rs256-private-key-pem", binding("SECURITY_AUTH_JWT_RS256_PRIVATE_KEY_PEM"))
 	setString("security.auth.cookie.name", binding("SECURITY_AUTH_COOKIE_NAME"))
 	setString("security.auth.cookie.domain", binding("SECURITY_AUTH_COOKIE_DOMAIN"))
 	setString("security.auth.cookie.same-site", binding("SECURITY_AUTH_COOKIE_SAMESITE"))
@@ -165,6 +170,10 @@ func applyEnvironmentOverrides(v *viper.Viper, opts Options, snapshot map[string
 func applyLegacyKeyCompatibility(v *viper.Viper) {
 	aliases := [][2]string{
 		{"security.auth.jwt.ttl-minutes", "security.auth.jwt.ttlMinutes"},
+		{"security.auth.jwt.rs256-key-source", "security.auth.jwt.rs256KeySource"},
+		{"security.auth.jwt.rs256-key-id", "security.auth.jwt.rs256KeyID"},
+		{"security.auth.jwt.rs256-public-key-pem", "security.auth.jwt.rs256PublicKeyPEM"},
+		{"security.auth.jwt.rs256-private-key-pem", "security.auth.jwt.rs256PrivateKeyPEM"},
 		{"security.auth.cookie.http-only", "security.auth.cookie.httpOnly"},
 		{"security.auth.cookie.same-site", "security.auth.cookie.sameSite"},
 	}
@@ -272,6 +281,11 @@ func expandRawConfig(raw rawConfig, snapshot map[string]string) rawConfig {
 	raw.Server.Host = expandWithSnapshot(raw.Server.Host, snapshot)
 	raw.Security.Auth.JWT.Secret = expandWithSnapshot(raw.Security.Auth.JWT.Secret, snapshot)
 	raw.Security.Auth.JWT.Issuer = expandWithSnapshot(raw.Security.Auth.JWT.Issuer, snapshot)
+	raw.Security.Auth.JWT.Algorithm = expandWithSnapshot(raw.Security.Auth.JWT.Algorithm, snapshot)
+	raw.Security.Auth.JWT.RS256KeySource = expandWithSnapshot(raw.Security.Auth.JWT.RS256KeySource, snapshot)
+	raw.Security.Auth.JWT.RS256KeyID = expandWithSnapshot(raw.Security.Auth.JWT.RS256KeyID, snapshot)
+	raw.Security.Auth.JWT.RS256PublicKeyPEM = expandWithSnapshot(raw.Security.Auth.JWT.RS256PublicKeyPEM, snapshot)
+	raw.Security.Auth.JWT.RS256PrivateKeyPEM = expandWithSnapshot(raw.Security.Auth.JWT.RS256PrivateKeyPEM, snapshot)
 	raw.Security.Auth.Cookie.Name = expandWithSnapshot(raw.Security.Auth.Cookie.Name, snapshot)
 	raw.Security.Auth.Cookie.Domain = expandWithSnapshot(raw.Security.Auth.Cookie.Domain, snapshot)
 	raw.Security.Auth.Cookie.SameSite = expandWithSnapshot(raw.Security.Auth.Cookie.SameSite, snapshot)

--- a/config/viper/loader_test.go
+++ b/config/viper/loader_test.go
@@ -76,6 +76,121 @@ security:
 	if first.Server.MaxHeaderBytes != 8192 {
 		t.Fatalf("expected max-header-bytes mapping, got %d", first.Server.MaxHeaderBytes)
 	}
+
+	if first.Security.Auth.JWT.Algorithm != config.JWTAlgorithmHS256 {
+		t.Fatalf("expected default algorithm HS256, got %q", first.Security.Auth.JWT.Algorithm)
+	}
+}
+
+func TestLoadRS256CanonicalAndLegacyMapping(t *testing.T) {
+	t.Parallel()
+
+	path := writeTestConfig(t, "rs256-mixed.yaml", `
+server:
+  host: "127.0.0.1"
+  port: 8080
+security:
+  auth:
+    jwt:
+      algorithm: "RS256"
+      secret: "ignored-for-rs256"
+      issuer: "common-fwk"
+      ttl-minutes: 20
+      rs256-key-source: "public-pem"
+      rs256-key-id: "canonical-key"
+      rs256-public-key-pem: "CANONICAL_PUBLIC"
+      rs256KeyID: "legacy-key"
+      rs256PublicKeyPEM: "LEGACY_PUBLIC"
+    cookie:
+      name: "session"
+      domain: "example.com"
+      secure: true
+      http-only: true
+      same-site: "Lax"
+    login:
+      email: "owner@example.com"
+    oauth2:
+      providers: {}
+`)
+
+	first, err := Load(Options{ConfigPath: path})
+	if err != nil {
+		t.Fatalf("expected RS256 load success, got error: %v", err)
+	}
+
+	second, err := Load(Options{ConfigPath: path})
+	if err != nil {
+		t.Fatalf("expected repeated RS256 load success, got error: %v", err)
+	}
+
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("expected deterministic RS256 mapping output")
+	}
+
+	jwtCfg := first.Security.Auth.JWT
+	if jwtCfg.Algorithm != config.JWTAlgorithmRS256 {
+		t.Fatalf("expected RS256 algorithm, got %q", jwtCfg.Algorithm)
+	}
+	if jwtCfg.RS256.KeySource != config.RS256KeySourcePublicPEM {
+		t.Fatalf("expected key source public-pem, got %q", jwtCfg.RS256.KeySource)
+	}
+	if jwtCfg.RS256.KeyID != "canonical-key" {
+		t.Fatalf("expected canonical key id to win, got %q", jwtCfg.RS256.KeyID)
+	}
+	if jwtCfg.RS256.PublicKeyPEM != "CANONICAL_PUBLIC" {
+		t.Fatalf("expected canonical public PEM to win, got %q", jwtCfg.RS256.PublicKeyPEM)
+	}
+}
+
+func TestLoadRS256EnvOverrides(t *testing.T) {
+	path := writeTestConfig(t, "rs256-env.yaml", `
+server:
+  host: "127.0.0.1"
+  port: 8080
+security:
+  auth:
+    jwt:
+      algorithm: "HS256"
+      secret: "file-secret"
+      issuer: "common-fwk"
+      ttl-minutes: 15
+      rs256-key-source: "generated"
+      rs256-key-id: "file-key-id"
+    cookie:
+      name: "session"
+      domain: "example.com"
+      secure: true
+      http-only: true
+      same-site: "Lax"
+    login:
+      email: "owner@example.com"
+    oauth2:
+      providers: {}
+`)
+
+	t.Setenv(defaultEnvPrefix+"_SECURITY_AUTH_JWT_ALGORITHM", "RS256")
+	t.Setenv(defaultEnvPrefix+"_SECURITY_AUTH_JWT_RS256_KEY_SOURCE", "private-pem")
+	t.Setenv(defaultEnvPrefix+"_SECURITY_AUTH_JWT_RS256_KEY_ID", "env-key-id")
+	t.Setenv(defaultEnvPrefix+"_SECURITY_AUTH_JWT_RS256_PRIVATE_KEY_PEM", "ENV_PRIVATE")
+
+	cfg, err := Load(Options{ConfigPath: path, EnvOverride: true})
+	if err != nil {
+		t.Fatalf("expected RS256 env override load success, got error: %v", err)
+	}
+
+	jwtCfg := cfg.Security.Auth.JWT
+	if jwtCfg.Algorithm != config.JWTAlgorithmRS256 {
+		t.Fatalf("expected env algorithm RS256, got %q", jwtCfg.Algorithm)
+	}
+	if jwtCfg.RS256.KeySource != config.RS256KeySourcePrivatePEM {
+		t.Fatalf("expected env key source private-pem, got %q", jwtCfg.RS256.KeySource)
+	}
+	if jwtCfg.RS256.KeyID != "env-key-id" {
+		t.Fatalf("expected env key id, got %q", jwtCfg.RS256.KeyID)
+	}
+	if jwtCfg.RS256.PrivateKeyPEM != "ENV_PRIVATE" {
+		t.Fatalf("expected env private key pem, got %q", jwtCfg.RS256.PrivateKeyPEM)
+	}
 }
 
 func TestLoadFailureTypes(t *testing.T) {

--- a/config/viper/mapping.go
+++ b/config/viper/mapping.go
@@ -39,9 +39,14 @@ type rawAuthConfig struct {
 type rawLegacy struct{}
 
 type rawJWTConfig struct {
-	Secret     string `mapstructure:"secret"`
-	Issuer     string `mapstructure:"issuer"`
-	TTLMinutes int    `mapstructure:"ttl-minutes"`
+	Algorithm          string `mapstructure:"algorithm"`
+	Secret             string `mapstructure:"secret"`
+	Issuer             string `mapstructure:"issuer"`
+	TTLMinutes         int    `mapstructure:"ttl-minutes"`
+	RS256KeySource     string `mapstructure:"rs256-key-source"`
+	RS256KeyID         string `mapstructure:"rs256-key-id"`
+	RS256PublicKeyPEM  string `mapstructure:"rs256-public-key-pem"`
+	RS256PrivateKeyPEM string `mapstructure:"rs256-private-key-pem"`
 }
 
 type rawCookieConfig struct {
@@ -80,6 +85,15 @@ func mapRawToCore(raw rawConfig) (config.Config, error) {
 		},
 	)
 	jwt := config.NewJWTConfig(raw.Security.Auth.JWT.Secret, raw.Security.Auth.JWT.Issuer, raw.Security.Auth.JWT.TTLMinutes)
+	if raw.Security.Auth.JWT.Algorithm != "" {
+		jwt.Algorithm = raw.Security.Auth.JWT.Algorithm
+	}
+	jwt.RS256 = config.RS256Config{
+		KeySource:     raw.Security.Auth.JWT.RS256KeySource,
+		KeyID:         raw.Security.Auth.JWT.RS256KeyID,
+		PublicKeyPEM:  raw.Security.Auth.JWT.RS256PublicKeyPEM,
+		PrivateKeyPEM: raw.Security.Auth.JWT.RS256PrivateKeyPEM,
+	}
 	cookie := config.NewCookieConfig(
 		raw.Security.Auth.Cookie.Name,
 		raw.Security.Auth.Cookie.Domain,

--- a/config/viper/mapping_test.go
+++ b/config/viper/mapping_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/matiasmartin-labs/common-fwk/config"
 )
 
 func TestMappingReturnsTypedErrorForInvalidProviderKey(t *testing.T) {
@@ -13,7 +15,7 @@ func TestMappingReturnsTypedErrorForInvalidProviderKey(t *testing.T) {
 	_, err := mapRawToCore(rawConfig{
 		Server: rawServerConfig{Host: "127.0.0.1", Port: 8080, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, MaxHeaderBytes: 1024},
 		Security: rawSecurityConfig{Auth: rawAuthConfig{
-			JWT:    rawJWTConfig{Secret: "secret", Issuer: "issuer", TTLMinutes: 15},
+			JWT:    rawJWTConfig{Algorithm: "HS256", Secret: "secret", Issuer: "issuer", TTLMinutes: 15},
 			Cookie: rawCookieConfig{Name: "session", SameSite: "Lax"},
 			Login:  rawLoginConfig{Email: "owner@example.com"},
 			OAuth2: rawOAuth2Config{Providers: map[string]rawOAuth2ProviderConfig{
@@ -51,7 +53,14 @@ func TestMappingDeterministicAndDefensiveCopies(t *testing.T) {
 	raw := rawConfig{
 		Server: rawServerConfig{Host: "127.0.0.1", Port: 8080, ReadTimeout: 9 * time.Second, WriteTimeout: 11 * time.Second, MaxHeaderBytes: 2048},
 		Security: rawSecurityConfig{Auth: rawAuthConfig{
-			JWT:    rawJWTConfig{Secret: "secret", Issuer: "issuer", TTLMinutes: 15},
+			JWT: rawJWTConfig{
+				Algorithm:         "RS256",
+				Issuer:            "issuer",
+				TTLMinutes:        15,
+				RS256KeySource:    "public-pem",
+				RS256KeyID:        "rsa-key",
+				RS256PublicKeyPEM: "PUBLIC",
+			},
 			Cookie: rawCookieConfig{Name: "session", Domain: "example.com", Secure: true, HTTPOnly: true, SameSite: "Lax"},
 			Login:  rawLoginConfig{Email: "owner@example.com"},
 			OAuth2: rawOAuth2Config{Providers: map[string]rawOAuth2ProviderConfig{
@@ -89,6 +98,16 @@ func TestMappingDeterministicAndDefensiveCopies(t *testing.T) {
 	}
 	if first.Server.MaxHeaderBytes != 2048 {
 		t.Fatalf("expected max header bytes to be mapped, got %d", first.Server.MaxHeaderBytes)
+	}
+
+	if first.Security.Auth.JWT.Algorithm != config.JWTAlgorithmRS256 {
+		t.Fatalf("expected algorithm RS256, got %q", first.Security.Auth.JWT.Algorithm)
+	}
+	if first.Security.Auth.JWT.RS256.KeySource != config.RS256KeySourcePublicPEM {
+		t.Fatalf("expected key source public-pem, got %q", first.Security.Auth.JWT.RS256.KeySource)
+	}
+	if first.Security.Auth.JWT.RS256.KeyID != "rsa-key" {
+		t.Fatalf("expected key id rsa-key, got %q", first.Security.Auth.JWT.RS256.KeyID)
 	}
 
 	raw.Security.Auth.OAuth2.Providers["github"] = rawOAuth2ProviderConfig{}

--- a/docs/home.md
+++ b/docs/home.md
@@ -14,6 +14,16 @@ This index groups the main project documentation pages.
 ## Notes
 
 - File-based config examples use canonical kebab-case keys (`ttl-minutes`, `http-only`, `same-site`, `client-id`, `client-secret`, `auth-url`, `token-url`, `redirect-url`).
+- JWT mode-aware config defaults to HS256 when `security.auth.jwt.algorithm` is omitted.
+- RS256 adapter keys (kebab-case):
+  - `security.auth.jwt.rs256-key-source`
+  - `security.auth.jwt.rs256-key-id`
+  - `security.auth.jwt.rs256-public-key-pem`
+  - `security.auth.jwt.rs256-private-key-pem`
+- RS256 key sources:
+  - `generated` (in-memory keypair bootstrap)
+  - `public-pem`
+  - `private-pem`
 - Server runtime-limit contract:
   - `server.read-timeout` (default `10s`)
   - `server.write-timeout` (default `10s`)

--- a/docs/migration/auth-provider-ms-v0.1.0.md
+++ b/docs/migration/auth-provider-ms-v0.1.0.md
@@ -49,6 +49,23 @@ Legacy camelCase keys remain compatibility-only during migration and should be p
 2. Provide resolver through `security/keys` (for example `NewStaticResolver`, RSA resolver variants).
 3. Keep token issuing concerns in service code; validator options cover runtime token validation.
 
+#### HS256 -> RS256 executable transition sequence
+
+1. In file-based config, set `security.auth.jwt.algorithm=RS256`.
+2. Keep shared JWT fields (`issuer`, `ttl-minutes`) unchanged.
+3. Add RS256 key settings:
+   - `security.auth.jwt.rs256-key-source` (`generated` | `public-pem` | `private-pem`)
+   - `security.auth.jwt.rs256-key-id`
+   - matching PEM field when required by source (`rs256-public-key-pem` or `rs256-private-key-pem`)
+4. Remove HS256 dependency on `security.auth.jwt.secret` for RS256 mode.
+5. Wire validator from config via compatibility path (`security/jwt.FromConfigJWT`) or app helper (`app.UseServerSecurityFromConfig()`).
+
+Verification checklist for migration parity:
+- Protected routes still reject missing token with `401`.
+- Invalid token/signature still returns `401`.
+- Valid RS256 token for configured issuer passes.
+- HS256 path remains valid for services that have not migrated yet (default algorithm behavior).
+
 ### 3) Middleware migration
 
 1. Replace service-local auth middleware wiring with `http/gin.NewAuthMiddleware(validator, opts...)`.

--- a/docs/releases/v0.2.0-checklist.md
+++ b/docs/releases/v0.2.0-checklist.md
@@ -15,6 +15,9 @@ Use this checklist to publish `common-fwk` `v0.2.0`.
 - [ ] Run build validation: `go build ./...`
 - [ ] Validate README quickstart snippets remain aligned with public API.
 - [ ] Validate config snippets use canonical kebab-case file keys (`ttl-minutes`, `http-only`, `same-site`, `client-id`, `client-secret`, `auth-url`, `token-url`, `redirect-url`).
+- [ ] Validate JWT mode-aware docs include HS256 default behavior and RS256 bootstrap keys (`algorithm`, `rs256-key-source`, `rs256-key-id`, PEM fields).
+- [ ] Verify RS256 key-source coverage in tests (`generated`, `public-pem`, `private-pem`).
+- [ ] Verify HS256 backward compatibility tests remain green.
 - [ ] Validate migration guide at `docs/migration/auth-provider-ms-v0.1.0.md` is complete.
 
 ## Publication

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/apply-progress.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/apply-progress.md
@@ -1,0 +1,106 @@
+# Apply Progress: issue-30-rs256-keypair-security
+
+Mode: Standard (`openspec/config.yaml` sets `strict_tdd: false`; governed checks run via `go test ./...` + `go build ./...`)
+
+## Task Checklist
+
+### Phase 1: Config Foundation
+- ✅ 1.1 Extend `config/types.go` with JWT mode-aware fields (`Algorithm`, `RS256Config`) and RS256 source constants while preserving legacy fields.
+- ✅ 1.2 Keep `NewJWTConfig(secret, issuer, ttlMinutes)` backward-compatible and add focused RS256 helpers (`NewRS256GeneratedConfig`, `NewRS256PublicPEMConfig`, `NewRS256PrivatePEMConfig`).
+- ✅ 1.3 Implement conditional JWT validation for HS256 vs RS256, including unsupported algorithm/source error paths and default algorithm normalization.
+
+### Phase 2: Adapter + Security Core Wiring
+- ✅ 2.1 Add RS256 canonical mapping in `config/viper/mapping.go` and compatibility aliases/env override handling in `config/viper/loader.go`.
+- ✅ 2.2 Create `security/keys/keypair.go` with in-memory RSA generation and resolver bootstrap for `generated`, `public-pem`, and `private-pem`.
+- ✅ 2.3 Update `security/jwt/compat.go` so `FromConfigJWT` branches by algorithm and returns algorithm-constrained options + TTL with contextual errors.
+- ✅ 2.4 Add `UseServerSecurityFromConfig()` to `app/application.go` as a thin wrapper: validate config, derive compat options, build validator, and delegate to `UseServerSecurity`.
+
+### Phase 3: Deterministic Tests and Invalid-Mode Coverage
+- ✅ 3.1 Expand `config/validate_test.go` with HS256/RS256 valid-invalid matrix coverage.
+- ✅ 3.2 Update `config/viper/*_test.go` for RS256 canonical precedence, legacy alias compatibility, env override behavior, and deterministic repeated output.
+- ✅ 3.3 Create `security/keys/keypair_test.go` for generation/retrieval success and invalid-classification failures.
+- ✅ 3.4 Add `security/jwt/compat_test.go` for HS256/RS256 resolver wiring, method allowlists, and invalid-mode failures.
+- ✅ 3.5 Update `app/application_test.go` for `UseServerSecurityFromConfig()` success cases and no-partial-wiring failure behavior.
+
+### Phase 4: Documentation and Verification
+- ✅ 4.1 Update `README.md` and `docs/home.md` with HS256 default + RS256 bootstrap semantics and examples.
+- ✅ 4.2 Update `docs/migration/auth-provider-ms-v0.1.0.md` with executable HS256→RS256 migration steps and parity checklist.
+- ✅ 4.3 Update `docs/releases/v0.2.0-checklist.md` with HS256/RS256 release verification checkpoints.
+- ✅ 4.4 Run full verification commands: `go test ./...` and `go build ./...` (green), including doc-contract assertions for release checklist and migration guide scenarios.
+
+## Evidence
+
+### Governance Normalization
+
+- Previous apply-progress batches were labeled “Strict TDD”.
+- Project governance source of truth is `openspec/config.yaml` (`strict_tdd: false`).
+- This artifact is normalized to **Standard** mode while preserving prior implementation evidence.
+
+### TDD Cycle Evidence (Historical)
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 1.1 | `config/constructors_test.go` | Unit | ✅ `go test ./config/...` baseline green | ✅ Added failing assertions for new fields/helpers | ✅ `go test ./config -run TestNewJWTConfig\|TestNewRS256ConfigHelpers` | ✅ multiple helper scenarios | ✅ gofmt cleanup |
+| 1.2 | `config/constructors_test.go` | Unit | ✅ baseline above | ✅ Helper constructor tests written first | ✅ targeted config tests green | ✅ generated/public/private constructor cases | ✅ gofmt cleanup |
+| 1.3 | `config/validate_test.go` | Unit | ✅ baseline above | ✅ Added failing RS256/algorithm matrix tests first | ✅ `go test ./config -run ...Validate...` | ✅ happy + multiple invalid branches | ✅ normalized helper extraction |
+| 2.1 | `config/viper/mapping_test.go`, `config/viper/loader_test.go` | Integration | ✅ `go test ./config/...` baseline green | ✅ RS256 mapping/env tests added first | ✅ `go test ./config/viper -run TestMapping\|TestLoadRS256...` | ✅ canonical+legacy+env override paths | ✅ gofmt + focused alias additions |
+| 2.2 | `security/keys/keypair_test.go` | Unit | ✅ `go test ./security/...` baseline green | ✅ keypair/resolver tests created before implementation | ✅ `go test ./security/keys -run TestGenerateRSAKeyPair\|TestResolverFromRS256Config` | ✅ generated/public/private + invalid bits/pem/source | ✅ parser helpers extracted |
+| 2.3 | `security/jwt/compat_test.go` | Unit | ✅ `go test ./security/...` baseline green | ✅ compat tests wrote new function signature/behaviors first | ✅ `go test ./security/jwt -run TestFromConfigJWT` | ✅ HS256 + RS256 + invalid algorithm/mode | ✅ sentinel cleanup (`errors.New`) |
+| 2.4 | `app/application_test.go` | Integration | ✅ `go test ./app/...` baseline green | ✅ helper behavior tests written first | ✅ `go test ./app -run TestUseServerSecurityFromConfig` | ✅ HS256 success, RS256 success, failure no-partial-wiring | ✅ validate-before-wire refactor |
+| 3.1 | `config/validate_test.go` | Unit | ✅ baseline preserved | ✅ added matrix before validation code branch changes | ✅ config tests pass | ✅ multi-scenario invalid matrix | ✅ gofmt |
+| 3.2 | `config/viper/loader_test.go`, `config/viper/mapping_test.go` | Integration | ✅ baseline preserved | ✅ new RS256 mapping precedence/env tests first | ✅ viper tests pass | ✅ deterministic repeat + precedence checks | ✅ gofmt |
+| 3.3 | `security/keys/keypair_test.go` | Unit | ✅ baseline preserved | ✅ tests first for keypair API and errors | ✅ keys tests pass | ✅ success + edge/failure coverage | ✅ helper functions localized |
+| 3.4 | `security/jwt/compat_test.go` | Unit | ✅ baseline preserved | ✅ tests first for compat branching | ✅ jwt tests pass | ✅ HS256/RS256 + invalid scenarios | ✅ gofmt |
+| 3.5 | `app/application_test.go` | Integration | ✅ baseline preserved | ✅ tests first for wrapper success/failure | ✅ app tests pass | ✅ behavior + no-partial-wiring path | ✅ gofmt |
+| 4.1 | `README.md`, `docs/home.md` (docs validation via tests/build) | Docs | ✅ baseline preserved | ✅ N/A (docs) | ✅ full suite/build remained green | ➖ structural docs update | ✅ wording + consistency cleanup |
+| 4.2 | `docs/migration/auth-provider-ms-v0.1.0.md` | Docs | ✅ baseline preserved | ✅ N/A (docs) | ✅ full suite/build remained green | ➖ structural docs update | ✅ step ordering cleanup |
+| 4.3 | `docs/releases/v0.2.0-checklist.md` | Docs | ✅ baseline preserved | ✅ N/A (docs) | ✅ full suite/build remained green | ➖ structural docs update | ✅ checklist clarity cleanup |
+| 4.4 | Full repo (`go test ./...`, `go build ./...`) | Verification | ✅ package-level safety nets completed earlier | ✅ verification commands are acceptance gate | ✅ both commands passed | ➖ single command behavior | ➖ none needed |
+
+## Test Summary
+
+- **Total tests written/updated**: 6 files (new: `security/keys/keypair_test.go`, `security/jwt/compat_test.go`; updated: `config/constructors_test.go`, `config/validate_test.go`, `config/viper/*_test.go`, `app/application_test.go`, `bootstrap_guard_test.go`)
+- **Total tests passing**: full suite green via `go test ./...`
+- **Layers used**: Unit + Integration
+- **Approval tests**: None — this change was additive feature work
+- **Pure functions created**: parsing/normalization helpers in config and keypair modules
+
+## Files Changed
+
+- `config/types.go`
+- `config/constructors.go`
+- `config/constructors_test.go`
+- `config/validate.go`
+- `config/validate_test.go`
+- `config/viper/mapping.go`
+- `config/viper/mapping_test.go`
+- `config/viper/loader.go`
+- `config/viper/loader_test.go`
+- `security/keys/keypair.go`
+- `security/keys/keypair_test.go`
+- `security/jwt/compat.go`
+- `security/jwt/compat_test.go`
+- `app/application.go`
+- `app/application_test.go`
+- `README.md`
+- `docs/home.md`
+- `docs/migration/auth-provider-ms-v0.1.0.md`
+- `docs/releases/v0.2.0-checklist.md`
+- `bootstrap_guard_test.go`
+- `openspec/changes/issue-30-rs256-keypair-security/tasks.md`
+
+## Deviations from Design
+
+None — implementation follows design intent (mode-aware JWT config, provider-agnostic `security/*`, thin app convenience wrapper).
+
+## Issues Found
+
+None.
+
+## Remaining Tasks
+
+None — 16/16 tasks complete.
+
+## Status
+
+Ready for `sdd-verify`.

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/archive-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/archive-report.md
@@ -1,0 +1,53 @@
+# Archive Report — issue-30-rs256-keypair-security
+
+**Change**: `issue-30-rs256-keypair-security`  
+**Archive Date**: `2026-05-01`  
+**Artifact Store Mode**: `hybrid`
+
+## Traceability (Engram Observations)
+
+- Proposal: `sdd/issue-30-rs256-keypair-security/proposal` → observation **#422**
+- Spec: `sdd/issue-30-rs256-keypair-security/spec` → observation **#424**
+- Design: `sdd/issue-30-rs256-keypair-security/design` → observation **#423**
+- Tasks: `sdd/issue-30-rs256-keypair-security/tasks` → observation **#426**
+- Verify report: `sdd/issue-30-rs256-keypair-security/verify-report` → observation **#431**
+
+## Pre-Archive Gate
+
+- Verification verdict from authoritative report: **PASS**
+- Critical issues: **none**
+- Tasks completion: **16/16 complete**
+
+## Spec Sync to Main Source of Truth
+
+Delta specs were merged from archived change specs into `openspec/specs/*/spec.md` by appending ADDED requirements and preserving existing requirements.
+
+| Domain | Action | Delta Result |
+|---|---|---|
+| `config-core` | Updated | +1 added, 0 modified, 0 removed |
+| `config-viper-adapter` | Updated | +1 added, 0 modified, 0 removed |
+| `security-core-jwt-validation` | Updated | +1 added, 0 modified, 0 removed |
+| `app-bootstrap` | Updated | +1 added, 0 modified, 0 removed |
+| `release-readiness-docs` | Updated | +1 added, 0 modified, 0 removed |
+| `adoption-migration-guide` | Updated | +1 added, 0 modified, 0 removed |
+
+Notes:
+- Existing `security-rs256-keypair-management` main spec remains present at `openspec/specs/security-rs256-keypair-management/spec.md`.
+- Core/adapter boundaries remain explicit (`config` core vs `config/viper` adapter and `security/*` provider-agnostic contracts).
+
+## Archive Move
+
+- Moved:
+  - `openspec/changes/issue-30-rs256-keypair-security/`
+  - → `openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/`
+
+## Post-Archive Verification Checklist
+
+- [x] Main specs updated with delta requirements
+- [x] Change folder moved into dated archive path
+- [x] Archived folder contains proposal/specs/design/tasks/verify-report artifacts
+- [x] Active change path `openspec/changes/issue-30-rs256-keypair-security/` no longer exists
+
+## Outcome
+
+The change is fully archived. Main OpenSpec specs now include RS256 keypair security requirements, and the complete implementation audit trail is preserved in both OpenSpec archive filesystem and Engram.

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/design.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/design.md
@@ -1,0 +1,122 @@
+# Design: RS256 Keypair Security Bootstrap
+
+## Technical Approach
+
+Implement RS256 as an additive path over existing HS256 behavior. Keep `config.JWTConfig` backward-compatible (`HS256` default), add RS256-specific settings, and make validation conditional by algorithm. Reuse existing `security/jwt` method allowlist + resolver model by extending `security/jwt.FromConfigJWT` to produce either HS256 or RS256 `Options`. Add a small in-memory keypair utility in `security/keys` for deterministic bootstrap, then add an app convenience method that wires validator-from-config without replacing explicit `UseServerSecurity`.
+
+## Architecture Decisions
+
+### Decision: Single expanded JWT config model
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Split HS/RS config structs | Strong typing, but high migration churn across constructors/adapter/tests/docs | ❌ |
+| Expand existing `JWTConfig` with algorithm + RS256 fields | Slightly richer struct, but additive and migration-safe | ✅ |
+
+Rationale: Minimizes API churn and preserves existing call sites using `NewJWTConfig(secret, issuer, ttlMinutes)`.
+
+### Decision: Deterministic in-memory RSA keypair API in `security/keys`
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Add provider/JWKS integration | More featureful, violates current non-goals and boundaries | ❌ |
+| Keep deterministic local keypair generation/retrieval | Limited scope, aligns with core contracts and testability | ✅ |
+
+Rationale: Keeps `security/*` provider-agnostic and enables robust unit tests for valid/invalid RS256 bootstrap.
+
+### Decision: App bootstrap convenience as thin wrapper
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Replace `UseServerSecurity` with implicit global wiring | Simpler API, but boundary erosion and hidden state risk | ❌ |
+| Add explicit convenience method delegating to `UseServerSecurity` | Slight extra method surface, but preserves explicit injection path | ✅ |
+
+Rationale: Satisfies usability goal while keeping adapters dependent on core contracts and avoiding singleton key stores.
+
+## Data Flow
+
+1. Config is built (explicit constructors or `config/viper.Load`) and validated.
+2. `security/jwt.FromConfigJWT(cfg.Security.Auth.JWT)` branches:
+   - `HS256`: build static HMAC resolver from `secret`.
+   - `RS256`: obtain resolver from configured RS256 key source (`generated` or provided PEM/public key).
+3. App convenience method creates validator and calls `UseServerSecurity`.
+4. HTTP middleware validates incoming tokens with algorithm-constrained options.
+
+```text
+config/viper.Load or constructors
+           │
+           ▼
+      ValidateConfig
+           │
+           ▼
+ security/jwt.FromConfigJWT
+   ├─ HS256 ──> NewStaticResolver(HMAC)
+   └─ RS256 ──> keys keypair/public resolver
+           │
+           ▼
+  jwt.NewValidator(options) ──> app.UseServerSecurity
+```
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `config/types.go` | Modify | Extend `JWTConfig` with algorithm + RS256 sub-config types. |
+| `config/constructors.go` | Modify | Keep `NewJWTConfig` compatibility and add focused RS256 helpers/defaults. |
+| `config/validate.go` | Modify | Conditional validation: secret required only for HS256; RS256 key-source constraints. |
+| `config/validate_test.go` | Modify | Add HS256/RS256 valid/invalid matrix tests. |
+| `config/viper/mapping.go` | Modify | Map canonical RS256 keys into expanded core JWT config. |
+| `config/viper/loader.go` | Modify | Add env overrides + legacy alias handling for new JWT keys. |
+| `config/viper/*_test.go` | Modify | Deterministic adapter tests for canonical/legacy/env/error cases. |
+| `security/keys/keypair.go` | Create | RSA keypair generation/retrieval helpers and resolver bridge. |
+| `security/keys/keypair_test.go` | Create | Deterministic behavior + error classification tests. |
+| `security/jwt/compat.go` | Modify | Add HS256/RS256 branching for config-driven validator options. |
+| `security/jwt/compat_test.go` | Create | Verify options/resolver wiring for both algorithms + invalid configs. |
+| `app/application.go` | Modify | Add `UseServerSecurityFromConfig()` convenience wiring with wrapped errors. |
+| `app/application_test.go` | Modify | Ordering/behavior tests for convenience method and failure modes. |
+| `README.md`, `docs/home.md`, `docs/migration/auth-provider-ms-v0.1.0.md`, `docs/releases/v0.2.0-checklist.md` | Modify | Document mode semantics, bootstrap examples, migration/release impact. |
+
+## Interfaces / Contracts
+
+```go
+// config/types.go
+type JWTConfig struct {
+    Algorithm  string // default: "HS256"
+    Secret     string // required when Algorithm=HS256
+    Issuer     string
+    TTLMinutes int
+    RS256      RS256Config
+}
+
+type RS256Config struct {
+    KeySource    string // "generated" | "public-pem" | "private-pem"
+    KeyID        string
+    PublicKeyPEM string
+    PrivateKeyPEM string
+}
+
+// security/keys/keypair.go
+func GenerateRSAKeyPair(bits int) (*rsa.PrivateKey, error)
+func ResolverFromRS256Config(cfg config.RS256Config) (keys.Resolver, error)
+
+// app/application.go
+func (a *Application) UseServerSecurityFromConfig() (*Application, error)
+```
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Unit | JWT config validation matrix | Table-driven tests for HS256/RS256 + invalid combinations. |
+| Unit | Keypair helper behavior | Deterministic resolver output, nil/invalid PEM errors, 2048-bit default. |
+| Unit | JWT compat mapping | Assert `Methods`, issuer, resolver type for HS256 and RS256. |
+| Integration | Viper load + env aliasing | Load fixtures (kebab + camel legacy), assert canonical precedence and typed failures. |
+| Integration | App convenience bootstrap | Verify success path and wrapped errors without replacing explicit API. |
+
+## Migration / Rollout
+
+No data migration required. Rollout is additive: existing HS256 configs continue unchanged; RS256 is opt-in via `security.auth.jwt.algorithm`. Documentation and release checklist updates ship in the same change.
+
+## Open Questions
+
+- [ ] Should `RS256.KeySource=generated` cache the generated keypair per app instance only, or per config bootstrap call? (Design assumes per bootstrap call, no global cache.)

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/exploration.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/exploration.md
@@ -1,0 +1,43 @@
+## Exploration: issue-30-rs256-keypair-security
+
+### Current State
+`config.JWTConfig` currently supports only `{secret, issuer, ttlMinutes}` and validation treats `security.auth.jwt.secret` as always required (`config/validate.go`).
+`security/jwt.FromConfigJWT` always builds HS256 validator options with a static HMAC secret resolver (`security/jwt/compat.go`).
+RS256 verification support exists in core via deterministic RSA resolvers (`security/keys.NewRSAResolver`, `NewRSAPublicKeyResolver`) and validator method allowlists (`security/jwt/options.go`, `validator.go`), but there is no keypair generation/retrieval API and no config-driven RS256 setup path.
+`app.Application` requires explicit validator injection (`UseServerSecurity(v security.Validator)`), with no convenience builder from config (`app/application.go`).
+
+### Affected Areas
+- `config/types.go` — JWT schema must represent mode-dependent auth material (HS256 secret vs RS256 keypair settings).
+- `config/constructors.go` — constructors/defaults need to support new JWT mode shape without breaking explicit API usage.
+- `config/validate.go` (+ tests) — secret requirement must become conditional (required in HS256, not required in RS256), plus invalid-combination checks.
+- `config/viper/mapping.go` + `config/viper/loader.go` (+ tests) — adapter mapping/env compatibility for new JWT fields and deterministic decode behavior.
+- `security/keys/*` — add safe keypair generation/retrieval API for RS256 (2048-bit generation, deterministic resolver integration, no provider coupling).
+- `security/jwt/compat.go` (+ tests) — config-to-validator wiring must support HS256 and RS256 modes.
+- `app/application.go` (+ tests) — add optional convenience wiring from config while preserving explicit `UseServerSecurity` path.
+- `README.md`, `docs/home.md`, and migration/release docs — document mode-dependent config, generation/retrieval flow, and bootstrap usage.
+
+### Approaches
+1. **Single expanded JWTConfig + helper constructors (recommended)** — extend existing `JWTConfig` with `Algorithm`/`Mode` and optional RS256 key settings; add small keypair helper API in `security/keys`; add app convenience method that builds validator from config.
+   - Pros: Minimal API churn, keeps current layering, easiest migration from current `secret` model, explicit injection path remains unchanged.
+   - Cons: `JWTConfig` becomes richer and requires careful validation/mapping compatibility.
+   - Effort: Medium.
+
+2. **Split config model by algorithm (HSJWTConfig + RSJWTConfig union-like design)** — redesign auth config shape to separate HS and RS branches and force mode-specific fields by structure.
+   - Pros: Strong type-level clarity for algorithm-specific fields.
+   - Cons: Higher breaking-change risk across constructors, loader mapping, docs, and existing users; larger migration surface.
+   - Effort: High.
+
+### Recommendation
+Choose **Approach 1**.
+It satisfies issue #30 with additive, backward-aware evolution: keep current constructor flow, make `jwt.secret` conditional, add RS256 keypair generation/retrieval primitives in `security/keys`, then expose app convenience wiring (e.g., a config-based security bootstrap helper) while retaining `UseServerSecurity` for explicit dependency injection.
+This best aligns with project non-goals and dependency boundaries (no provider coupling in `security/*`, adapters depending on core contracts).
+
+### Risks
+- **Config compatibility drift**: introducing mode fields can break existing viper mappings and env keys if aliases/precedence are not explicitly preserved.
+- **Key lifecycle ambiguity**: generated in-memory keys may confuse callers if persistence/export boundaries are not documented and tested.
+- **Boundary erosion in app layer**: convenience wiring could accidentally hard-couple `app` to provider-specific/security-side effects if scope is not constrained.
+- **Doc staleness risk**: README/docs currently teach HS256-first setup and will become incorrect unless updated together with behavior.
+
+### Ready for Proposal
+Yes — enough repository context exists to move to `sdd-propose`.
+Proposal should explicitly lock: (1) JWT mode field names/default semantics, (2) RS256 keypair generation/retrieval API contract and storage scope, (3) app convenience method signature and ordering/error behavior.

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/proposal.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: RS256 Keypair Security Bootstrap
+
+## Intent
+
+Enable first-class RS256 JWT verification from framework config while keeping HS256 backward compatibility and preserving provider-agnostic boundaries in `security/*`.
+
+## Scope
+
+### In Scope
+- Extend JWT config model to support algorithm/mode-specific fields for HS256 and RS256.
+- Add deterministic keypair generation/retrieval helpers in `security/keys` for RS256 bootstrap.
+- Wire config-driven validator construction (HS256 or RS256) plus optional app convenience bootstrap.
+- Update docs/migration guidance for mode semantics, defaults, and setup examples.
+
+### Out of Scope
+- JWKS/network key discovery or provider-specific key management.
+- Replacing explicit `UseServerSecurity` injection as the primary low-level API.
+
+## Capabilities
+
+### New Capabilities
+- `security-rs256-keypair-management`: In-memory RSA keypair generation/retrieval contract for deterministic validator bootstrap without provider coupling.
+
+### Modified Capabilities
+- `config-core`: JWT contract becomes mode-aware with conditional validation semantics.
+- `config-viper-adapter`: Mapping/env override support for new JWT RS256 fields and compatibility aliases.
+- `security-core-jwt-validation`: Config-to-validator compatibility path for HS256/RS256 method selection and resolver wiring.
+- `app-bootstrap`: Optional config-based security bootstrap helper with deterministic ordering/errors.
+- `release-readiness-docs`: Release checklist/notes reflect RS256 configuration behavior.
+- `adoption-migration-guide`: Migration steps include HS256→RS256 transition guidance.
+
+## Approach
+
+Adopt the additive “single expanded JWTConfig” approach: keep current shape compatible, add algorithm defaults (`HS256` default), enforce conditional validation (`secret` required only for HS256), introduce `security/keys` keypair helpers, and expose app-level convenience wiring that delegates to existing validator injection.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `config/types.go`, `config/constructors.go`, `config/validate.go` | Modified | Mode-aware JWT fields, defaults, conditional validation |
+| `config/viper/mapping.go`, `config/viper/loader.go` | Modified | RS256 field mapping, env compatibility, typed failures |
+| `security/keys/*` | New/Modified | RSA keypair generation + resolver-friendly retrieval API |
+| `security/jwt/compat.go` | Modified | HS256/RS256 config bootstrap into validator options |
+| `app/application.go` | Modified | Optional config-driven security convenience method |
+| `README.md`, `docs/home.md`, `docs/migration/*`, `docs/releases/*` | Modified | Updated setup, migration, and release notes |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Env/config compatibility regressions | Med | Preserve legacy aliases; add deterministic adapter tests |
+| Key lifecycle confusion | Med | Document in-memory scope and non-persistence explicitly |
+| App boundary erosion | Low | Keep convenience API thin; retain explicit validator injection |
+
+## Rollback Plan
+
+Revert to HS256-only bootstrap by removing RS256 config branches and convenience wiring while preserving existing `jwt.secret` path; keep explicit `UseServerSecurity`-based setup as stable fallback.
+
+## Dependencies
+
+- Existing RSA resolver contracts in `security/keys` and method allowlist behavior in `security/jwt`.
+
+## Success Criteria
+
+- [ ] HS256 configs continue to work unchanged.
+- [ ] RS256 can be enabled via config with deterministic keypair bootstrap and passing tests.
+- [ ] Docs/migration/release artifacts match implemented mode behavior.

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/adoption-migration-guide/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/adoption-migration-guide/spec.md
@@ -1,0 +1,14 @@
+# Delta for adoption-migration-guide
+
+## ADDED Requirements
+
+### Requirement: Migration guidance for HS256 to RS256 transition
+
+Migration documentation MUST include an explicit HS256-to-RS256 transition path covering required config key changes, keypair bootstrap expectations, and validation steps proving behavior parity for existing protected routes.
+
+#### Scenario: Migration guide provides executable transition sequence
+
+- GIVEN maintainers currently using HS256 configuration
+- WHEN they follow the documented transition steps to RS256
+- THEN required config and key material changes are explicit
+- AND verification steps confirm expected authentication behavior after migration

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/app-bootstrap/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/app-bootstrap/spec.md
@@ -1,0 +1,20 @@
+# Delta for app-bootstrap
+
+## ADDED Requirements
+
+### Requirement: Optional config-based security bootstrap convenience
+
+The application bootstrap API MAY provide an optional helper that derives validator wiring from already loaded config. This helper MUST preserve existing explicit `UseServerSecurity` behavior and MUST fail deterministically with contextual errors when config prerequisites are invalid or incomplete.
+
+#### Scenario: Config-based helper succeeds with valid JWT mode configuration
+
+- GIVEN an application instance with valid security config for HS256 or RS256
+- WHEN the optional config-based security bootstrap helper is invoked
+- THEN validator wiring is configured successfully for protected routes
+
+#### Scenario: Config-based helper fails deterministically on invalid security config
+
+- GIVEN an application instance with incomplete or invalid JWT mode configuration
+- WHEN the optional config-based security bootstrap helper is invoked
+- THEN it returns a contextual error
+- AND no partial security wiring is applied

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/config-core/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/config-core/spec.md
@@ -1,0 +1,19 @@
+# Delta for config-core
+
+## ADDED Requirements
+
+### Requirement: JWT mode-aware configuration semantics
+
+The config core MUST support mode-aware JWT configuration. `algorithm` SHALL default to `HS256` for backward compatibility. When algorithm is `HS256`, `secret` MUST be present. When algorithm is `RS256`, `key_id` and RSA signing material MUST be present. Shared JWT fields (issuer/expiry) MUST remain supported in both modes.
+
+#### Scenario: HS256 legacy configuration remains valid
+
+- GIVEN JWT config without explicit algorithm and with `secret`
+- WHEN core defaults and validation execute
+- THEN algorithm resolves to `HS256` and validation succeeds
+
+#### Scenario: RS256 missing key fields is rejected
+
+- GIVEN JWT config with algorithm `RS256` and missing `key_id` or RSA key material
+- WHEN validation executes
+- THEN validation fails with an assertable, contextual configuration error

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/config-viper-adapter/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/config-viper-adapter/spec.md
@@ -1,0 +1,20 @@
+# Delta for config-viper-adapter
+
+## ADDED Requirements
+
+### Requirement: JWT RS256 field mapping and compatibility aliases
+
+The adapter MUST map JWT RS256 fields (`algorithm`, `key_id`, RSA keypair inputs) from file/environment sources into core config and SHALL preserve deterministic compatibility aliases for legacy JWT keys. For identical inputs and options, mapped output MUST be deterministic.
+
+#### Scenario: RS256 fields map deterministically
+
+- GIVEN file/env inputs defining JWT `algorithm=RS256`, `key_id`, and RSA key fields
+- WHEN the adapter loads and maps configuration repeatedly
+- THEN mapped core JWT config is identical across runs
+
+#### Scenario: Legacy aliases remain compatible
+
+- GIVEN legacy JWT key names and new mode-aware keys are both configured
+- WHEN adapter precedence rules execute
+- THEN documented precedence is applied deterministically
+- AND resulting config remains valid for backward-compatible HS256 usage

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/release-readiness-docs/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/release-readiness-docs/spec.md
@@ -1,0 +1,13 @@
+# Delta for release-readiness-docs
+
+## ADDED Requirements
+
+### Requirement: Release checklist covers JWT mode behavior
+
+Release-readiness documentation MUST describe RS256 keypair bootstrap behavior, HS256 backward compatibility expectations, and verification checkpoints for both JWT modes before release publication.
+
+#### Scenario: Release checklist includes mode-specific checks
+
+- GIVEN release checklist documentation for the targeted version
+- WHEN maintainers execute pre-release verification
+- THEN checklist items explicitly validate HS256 compatibility and RS256 bootstrap behavior

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/security-core-jwt-validation/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/specs/security-core-jwt-validation/spec.md
@@ -1,0 +1,19 @@
+# Delta for security-core-jwt-validation
+
+## ADDED Requirements
+
+### Requirement: Config-driven HS256 and RS256 validator compatibility
+
+The security core SHALL provide a compatibility path that translates mode-aware JWT config into validator options for both HS256 and RS256. The path MUST enforce method allowlist alignment with configured algorithm and MUST wire the corresponding key resolver deterministically without provider coupling.
+
+#### Scenario: HS256 config builds HS256-compatible validator options
+
+- GIVEN mode-aware JWT config resolved to `HS256` with valid shared fields and secret
+- WHEN compatibility wiring builds validator options
+- THEN methods include `HS256` and resolver wiring matches HS256 expectations
+
+#### Scenario: RS256 config builds RS256-compatible validator options
+
+- GIVEN mode-aware JWT config resolved to `RS256` with valid key material and `key_id`
+- WHEN compatibility wiring builds validator options
+- THEN methods include `RS256` and resolver wiring uses deterministic RSA verification keys

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/tasks.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: RS256 Keypair Security Bootstrap
+
+## Phase 1: Config Foundation
+
+- [x] 1.1 Extend `config/types.go` with `JWTConfig.Algorithm` (default `HS256`) and `RS256Config` (`KeySource`, `KeyID`, `PublicKeyPEM`, `PrivateKeyPEM`) while preserving existing fields.
+- [x] 1.2 Update `config/constructors.go` so `NewJWTConfig(secret, issuer, ttlMinutes)` remains backward-compatible and add focused RS256 helper/default constructors used by tests.
+- [x] 1.3 Implement conditional JWT validation in `config/validate.go` for HS256 vs RS256 requirements, including deterministic errors for unsupported algorithm/mode combinations.
+
+## Phase 2: Adapter + Security Core Wiring
+
+- [x] 2.1 Add RS256 canonical key mapping in `config/viper/mapping.go` and deterministic compatibility alias behavior in `config/viper/loader.go` for file+env inputs.
+- [x] 2.2 Create `security/keys/keypair.go` with in-memory RSA keypair generation and resolver bootstrap (`generated`, `public-pem`, `private-pem`) without provider coupling.
+- [x] 2.3 Update `security/jwt/compat.go` so `FromConfigJWT` branches by algorithm and returns algorithm-constrained `Options` (`Methods`, resolver, issuer, TTL) for HS256 and RS256.
+- [x] 2.4 Add `UseServerSecurityFromConfig()` to `app/application.go` as a thin wrapper that builds validator from config and delegates to existing `UseServerSecurity` with wrapped errors.
+
+## Phase 3: Deterministic Tests and Invalid-Mode Coverage
+
+- [x] 3.1 Expand `config/validate_test.go` with table-driven HS256/RS256 matrices, including invalid algorithm, missing `secret`, missing `key_id`, and missing PEM scenarios.
+- [x] 3.2 Update `config/viper/*_test.go` to verify deterministic RS256 mapping precedence, legacy alias compatibility, env overrides, and typed failure paths.
+- [x] 3.3 Create `security/keys/keypair_test.go` for valid generation/retrieval plus invalid input cases (bad bits, malformed PEM, missing key) with assertable error classification.
+- [x] 3.4 Add `security/jwt/compat_test.go` validating `FromConfigJWT` HS256/RS256 resolver wiring, method allowlist correctness, and deterministic invalid-mode failures.
+- [x] 3.5 Update `app/application_test.go` to cover `UseServerSecurityFromConfig()` success ordering and no-partial-wiring behavior on invalid configuration.
+
+## Phase 4: Documentation and Verification
+
+- [x] 4.1 Update `README.md` and `docs/home.md` with configuration examples for HS256 default and RS256 bootstrap semantics.
+- [x] 4.2 Update `docs/migration/auth-provider-ms-v0.1.0.md` with an executable HS256→RS256 migration sequence and verification checklist.
+- [x] 4.3 Update `docs/releases/v0.2.0-checklist.md` with release checks for HS256 compatibility and RS256 bootstrap readiness.
+- [x] 4.4 Run `go test ./...` and `go build ./...` and record any follow-up fixes required to keep the change releasable, including doc-contract assertions for release checklist and migration guide scenarios.

--- a/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/verify-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-30-rs256-keypair-security/verify-report.md
@@ -1,0 +1,106 @@
+## Verification Report
+
+**Change**: issue-30-rs256-keypair-security  
+**Version**: N/A  
+**Mode**: Standard
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 16 |
+| Tasks complete | 16 |
+| Tasks incomplete | 0 |
+
+No incomplete tasks found.
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed (`go build ./...`, exit code 0)
+
+**Tests**: ✅ Passed (`go test ./...`, exit code 0)
+- Failed tests: none
+- Skipped tests: none reported
+
+**Coverage**: ✅ Available (`go test ./... -cover`)
+- `app`: 89.3%
+- `config`: 84.0%
+- `config/viper`: 80.0%
+- `http/gin`: 85.4%
+- `security/jwt`: 74.7%
+- `security/keys`: 77.5%
+- threshold from `openspec/config.yaml`: 0% (met)
+
+**Type/quality check**: ✅ Passed (`go vet ./...`, no diagnostics)
+
+**Doc-contract execution**: ✅ Passed (`go test ./... -run TestDocsJWTModeReleaseAndMigrationContracts -count=1`)
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| security-rs256-keypair-management | Keypair generation succeeds for valid parameters | `security/keys/keypair_test.go > TestGenerateRSAKeyPair/generates key pair with explicit bits` | ✅ COMPLIANT |
+| security-rs256-keypair-management | Keypair generation fails safely for invalid parameters | `security/keys/keypair_test.go > TestGenerateRSAKeyPair/rejects invalid bits` | ✅ COMPLIANT |
+| security-rs256-keypair-management | Retrieval by key ID returns matching key material | `security/keys/resolver_test.go > TestStaticResolverResolve/kid hit` | ✅ COMPLIANT |
+| security-rs256-keypair-management | Missing key retrieval returns assertable failure | `security/keys/resolver_test.go > TestStaticResolverResolve/kid miss` | ✅ COMPLIANT |
+| security-rs256-keypair-management | Keypair helpers compile without provider adapters | `go test ./security/keys` package execution (passed) | ✅ COMPLIANT |
+| config-core | HS256 legacy configuration remains valid | `config/validate_test.go > TestValidateConfigDefaultsJWTAlgorithmToHS256` | ✅ COMPLIANT |
+| config-core | RS256 missing key fields is rejected | `config/validate_test.go > TestValidateConfigInvalid/rs256 missing key id` (+ missing pem cases) | ✅ COMPLIANT |
+| config-viper-adapter | RS256 fields map deterministically | `config/viper/loader_test.go > TestLoadRS256CanonicalAndLegacyMapping` | ✅ COMPLIANT |
+| config-viper-adapter | Legacy aliases remain compatible | `config/viper/loader_test.go > TestLoadLegacyCamelCaseCompatibility` | ✅ COMPLIANT |
+| security-core-jwt-validation | HS256 config builds HS256-compatible validator options | `security/jwt/compat_test.go > TestFromConfigJWTHS256Compatibility` | ✅ COMPLIANT |
+| security-core-jwt-validation | RS256 config builds RS256-compatible validator options | `security/jwt/compat_test.go > TestFromConfigJWTRS256Compatibility` | ✅ COMPLIANT |
+| app-bootstrap | Config-based helper succeeds with valid JWT mode configuration | `app/application_test.go > TestUseServerSecurityFromConfig/hs256 success` and `.../rs256 success` | ✅ COMPLIANT |
+| app-bootstrap | Config-based helper fails deterministically on invalid security config | `app/application_test.go > TestUseServerSecurityFromConfig/invalid config does not partially wire` | ✅ COMPLIANT |
+| release-readiness-docs | Release checklist includes mode-specific checks | `bootstrap_guard_test.go > TestDocsJWTModeReleaseAndMigrationContracts/release checklist includes HS256 and RS256 verification checkpoints` | ✅ COMPLIANT |
+| adoption-migration-guide | Migration guide provides executable transition sequence | `bootstrap_guard_test.go > TestDocsJWTModeReleaseAndMigrationContracts/migration guide includes executable HS256 to RS256 sequence and parity checks` | ✅ COMPLIANT |
+
+**Compliance summary**: 15/15 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Deterministic in-memory keypair generation/retrieval contracts | ✅ Implemented | `security/keys/keypair.go` provides generated/public/private PEM flows with typed, assertable errors. |
+| JWT mode-aware config semantics | ✅ Implemented | `config/types.go`, `config/constructors.go`, `config/validate.go` implement HS256 default and RS256 conditional rules. |
+| Viper RS256 mapping + compatibility aliases | ✅ Implemented | `config/viper/mapping.go` and `config/viper/loader.go` support canonical keys and legacy alias precedence. |
+| Config-driven validator compatibility (HS256/RS256) | ✅ Implemented | `security/jwt/compat.go` branches by algorithm and wires deterministic resolver/method allowlist. |
+| Optional app bootstrap helper | ✅ Implemented | `app/application.go` adds `UseServerSecurityFromConfig()` and preserves explicit `UseServerSecurity` path. |
+| Release/migration docs updated | ✅ Implemented | `docs/releases/v0.2.0-checklist.md` and `docs/migration/auth-provider-ms-v0.1.0.md` include required RS256/HS256 guidance. |
+| common-fwk usage boundaries preserved | ✅ Implemented | `bootstrap_guard_test.go` keeps bootstrap/package boundary contracts and passes. |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Expand existing `JWTConfig` with algorithm + RS256 fields | ✅ Yes | Additive fields in `config/types.go`; legacy constructor retained. |
+| Keep provider-agnostic in-memory RSA keypair API in `security/keys` | ✅ Yes | `security/keys/keypair.go` imports stdlib + core config only; no provider adapter coupling. |
+| Add thin app convenience wrapper over explicit security wiring | ✅ Yes | `UseServerSecurityFromConfig()` validates/builds then delegates to `UseServerSecurity`. |
+| File changes align with design table | ✅ Yes | Planned code/test/doc files are present and aligned. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+None.
+
+**WARNING** (should fix):
+None.
+
+**SUGGESTION** (nice to have):
+1. Consider adding the full `security-rs256-keypair-management` spec domain file under `openspec/changes/.../specs/` for filesystem parity with Engram aggregate spec artifact.
+
+---
+
+### Verdict
+PASS
+
+All tasks are complete, required runtime checks pass, and all 15/15 spec scenarios have executable passing evidence.

--- a/openspec/specs/adoption-migration-guide/spec.md
+++ b/openspec/specs/adoption-migration-guide/spec.md
@@ -36,3 +36,14 @@ The migration guide MUST include a compatibility section that lists known breaki
 - GIVEN migration changes were applied in `auth-provider-ms`
 - WHEN maintainers run the documented verification commands
 - THEN compatibility expectations and breaking-change impacts are explicit in the guide
+
+### Requirement: Migration guidance for HS256 to RS256 transition
+
+Migration documentation MUST include an explicit HS256-to-RS256 transition path covering required config key changes, keypair bootstrap expectations, and validation steps proving behavior parity for existing protected routes.
+
+#### Scenario: Migration guide provides executable transition sequence
+
+- GIVEN maintainers currently using HS256 configuration
+- WHEN they follow the documented transition steps to RS256
+- THEN required config and key material changes are explicit
+- AND verification steps confirm expected authentication behavior after migration

--- a/openspec/specs/app-bootstrap/spec.md
+++ b/openspec/specs/app-bootstrap/spec.md
@@ -94,6 +94,23 @@ Misordered usage (for example registering routes before server setup, or protect
 
 The bootstrap API SHOULD remain test-friendly: behavior MUST be verifiable through automated tests without requiring process-level exits. Startup wiring MUST preserve explicit dependency injection boundaries (config and validator are provided by caller). Route registration behavior MUST be deterministic and reproducible across test runs.
 
+### Requirement: Optional config-based security bootstrap convenience
+
+The application bootstrap API MAY provide an optional helper that derives validator wiring from already loaded config. This helper MUST preserve existing explicit `UseServerSecurity` behavior and MUST fail deterministically with contextual errors when config prerequisites are invalid or incomplete.
+
+#### Scenario: Config-based helper succeeds with valid JWT mode configuration
+
+- GIVEN an application instance with valid security config for HS256 or RS256
+- WHEN the optional config-based security bootstrap helper is invoked
+- THEN validator wiring is configured successfully for protected routes
+
+#### Scenario: Config-based helper fails deterministically on invalid security config
+
+- GIVEN an application instance with incomplete or invalid JWT mode configuration
+- WHEN the optional config-based security bootstrap helper is invoked
+- THEN it returns a contextual error
+- AND no partial security wiring is applied
+
 ## Out of Scope
 
 - Adding config provider abstractions (for example viper loader interfaces) beyond accepting `config.Config`.

--- a/openspec/specs/config-core/spec.md
+++ b/openspec/specs/config-core/spec.md
@@ -124,3 +124,19 @@ Config core behavior MUST be independent from Viper, filesystem reads, environme
 - GIVEN repeated constructor/validation calls with identical inputs
 - WHEN calls are executed in any order
 - THEN outputs are deterministic and unaffected by shared mutable globals
+
+### Requirement: JWT mode-aware configuration semantics
+
+The config core MUST support mode-aware JWT configuration. `algorithm` SHALL default to `HS256` for backward compatibility. When algorithm is `HS256`, `secret` MUST be present. When algorithm is `RS256`, `key_id` and RSA signing material MUST be present. Shared JWT fields (issuer/expiry) MUST remain supported in both modes.
+
+#### Scenario: HS256 legacy configuration remains valid
+
+- GIVEN JWT config without explicit algorithm and with `secret`
+- WHEN core defaults and validation execute
+- THEN algorithm resolves to `HS256` and validation succeeds
+
+#### Scenario: RS256 missing key fields is rejected
+
+- GIVEN JWT config with algorithm `RS256` and missing `key_id` or RSA key material
+- WHEN validation executes
+- THEN validation fails with an assertable, contextual configuration error

--- a/openspec/specs/config-viper-adapter/spec.md
+++ b/openspec/specs/config-viper-adapter/spec.md
@@ -118,3 +118,20 @@ The adapter MUST return adapter-typed errors when runtime-limit values cannot be
 - GIVEN `server.max-header-bytes` is not representable as the required numeric type
 - WHEN decoding/mapping runs
 - THEN the adapter returns an adapter-typed error identifying load failure
+
+### Requirement: JWT RS256 field mapping and compatibility aliases
+
+The adapter MUST map JWT RS256 fields (`algorithm`, `key_id`, RSA keypair inputs) from file/environment sources into core config and SHALL preserve deterministic compatibility aliases for legacy JWT keys. For identical inputs and options, mapped output MUST be deterministic.
+
+#### Scenario: RS256 fields map deterministically
+
+- GIVEN file/env inputs defining JWT `algorithm=RS256`, `key_id`, and RSA key fields
+- WHEN the adapter loads and maps configuration repeatedly
+- THEN mapped core JWT config is identical across runs
+
+#### Scenario: Legacy aliases remain compatible
+
+- GIVEN legacy JWT key names and new mode-aware keys are both configured
+- WHEN adapter precedence rules execute
+- THEN documented precedence is applied deterministically
+- AND resulting config remains valid for backward-compatible HS256 usage

--- a/openspec/specs/release-readiness-docs/spec.md
+++ b/openspec/specs/release-readiness-docs/spec.md
@@ -37,3 +37,13 @@ The release documentation MUST include a release notes baseline that identifies 
 - GIVEN the release checklist document is read before tagging
 - WHEN release notes are prepared
 - THEN the maintainer can derive capability summary, migration impact, and limitations from the documented baseline
+
+### Requirement: Release checklist covers JWT mode behavior
+
+Release-readiness documentation MUST describe RS256 keypair bootstrap behavior, HS256 backward compatibility expectations, and verification checkpoints for both JWT modes before release publication.
+
+#### Scenario: Release checklist includes mode-specific checks
+
+- GIVEN release checklist documentation for the targeted version
+- WHEN maintainers execute pre-release verification
+- THEN checklist items explicitly validate HS256 compatibility and RS256 bootstrap behavior

--- a/openspec/specs/security-core-jwt-validation/spec.md
+++ b/openspec/specs/security-core-jwt-validation/spec.md
@@ -138,3 +138,19 @@ This capability MUST NOT depend on Gin middleware, app globals, or OAuth/JWKS pr
 - GIVEN `security/claims`, `security/keys`, and `security/jwt`
 - WHEN building and testing these packages in isolation
 - THEN no Gin, app-global singleton, or provider adapter dependency is required
+
+### Requirement: Config-driven HS256 and RS256 validator compatibility
+
+The security core SHALL provide a compatibility path that translates mode-aware JWT config into validator options for both HS256 and RS256. The path MUST enforce method allowlist alignment with configured algorithm and MUST wire the corresponding key resolver deterministically without provider coupling.
+
+#### Scenario: HS256 config builds HS256-compatible validator options
+
+- GIVEN mode-aware JWT config resolved to `HS256` with valid shared fields and secret
+- WHEN compatibility wiring builds validator options
+- THEN methods include `HS256` and resolver wiring matches HS256 expectations
+
+#### Scenario: RS256 config builds RS256-compatible validator options
+
+- GIVEN mode-aware JWT config resolved to `RS256` with valid key material and `key_id`
+- WHEN compatibility wiring builds validator options
+- THEN methods include `RS256` and resolver wiring uses deterministic RSA verification keys

--- a/openspec/specs/security-rs256-keypair-management/spec.md
+++ b/openspec/specs/security-rs256-keypair-management/spec.md
@@ -1,0 +1,51 @@
+# security-rs256-keypair-management Specification
+
+## Purpose
+
+Define provider-agnostic, deterministic in-memory RSA keypair management contracts for RS256 validator bootstrap.
+
+## Requirements
+
+### Requirement: Deterministic in-memory keypair generation
+
+The `security/keys` capability MUST provide an in-memory keypair generation contract for RSA material that is deterministic in behavior (success/error outcomes and returned structure shape) for valid inputs, and MUST be panic-free for expected invalid inputs.
+
+#### Scenario: Keypair generation succeeds for valid parameters
+
+- GIVEN valid RSA generation parameters accepted by the API
+- WHEN keypair generation is invoked
+- THEN RSA private/public key material is returned in-memory
+- AND no filesystem or network dependency is required
+
+#### Scenario: Keypair generation fails safely for invalid parameters
+
+- GIVEN invalid RSA generation parameters
+- WHEN keypair generation is invoked
+- THEN a contextual error is returned
+- AND no panic occurs
+
+### Requirement: Deterministic key retrieval for resolver bootstrap
+
+The capability MUST expose retrieval helpers that return key material for resolver wiring by `key_id` or deterministic default selection. Missing key lookups MUST fail with assertable key-resolution errors.
+
+#### Scenario: Retrieval by key ID returns matching key material
+
+- GIVEN an in-memory keypair store containing key ID `K1`
+- WHEN retrieval is requested for `K1`
+- THEN the matching key material is returned for validator resolver wiring
+
+#### Scenario: Missing key retrieval returns assertable failure
+
+- GIVEN an in-memory keypair store without requested key ID `KX`
+- WHEN retrieval is requested for `KX`
+- THEN retrieval fails with a contextual, assertable key-resolution error
+
+### Requirement: Provider-agnostic boundary preservation
+
+Keypair management APIs MUST remain inside `security/*` without provider-specific coupling and SHALL be consumable by JWT validation compatibility paths without importing provider adapters.
+
+#### Scenario: Keypair helpers compile without provider adapters
+
+- GIVEN package `security/keys` is built and tested in isolation
+- WHEN dependency graph is evaluated
+- THEN no provider-specific adapter dependency is required

--- a/security/jwt/compat.go
+++ b/security/jwt/compat.go
@@ -1,11 +1,17 @@
 package jwt
 
 import (
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/matiasmartin-labs/common-fwk/config"
 	"github.com/matiasmartin-labs/common-fwk/security/keys"
 )
+
+// ErrUnsupportedJWTAlgorithm indicates unsupported JWT algorithm mapping.
+var ErrUnsupportedJWTAlgorithm = errors.New("unsupported jwt algorithm")
 
 // CompatOptions bundles validator options with token-issuing compatibility data.
 type CompatOptions struct {
@@ -17,16 +23,41 @@ type CompatOptions struct {
 //
 // TTLMinutes remains a token-issuing concern and is exposed as TokenTTL for
 // callers that issue tokens; validator runtime checks do not enforce it.
-func FromConfigJWT(cfg config.JWTConfig) CompatOptions {
-	return CompatOptions{
-		Options: Options{
-			Methods: []string{"HS256"},
-			Issuer:  cfg.Issuer,
-			Resolver: keys.NewStaticResolver(
-				&keys.Key{Method: "HS256", Verify: []byte(cfg.Secret)},
-				nil,
-			),
-		},
-		TokenTTL: time.Duration(cfg.TTLMinutes) * time.Minute,
+func FromConfigJWT(cfg config.JWTConfig) (CompatOptions, error) {
+	ttl := time.Duration(cfg.TTLMinutes) * time.Minute
+	algorithm := strings.TrimSpace(cfg.Algorithm)
+	if algorithm == "" {
+		algorithm = config.JWTAlgorithmHS256
+	}
+
+	switch algorithm {
+	case config.JWTAlgorithmHS256:
+		return CompatOptions{
+			Options: Options{
+				Methods: []string{"HS256"},
+				Issuer:  cfg.Issuer,
+				Resolver: keys.NewStaticResolver(
+					&keys.Key{Method: "HS256", Verify: []byte(cfg.Secret)},
+					nil,
+				),
+			},
+			TokenTTL: ttl,
+		}, nil
+	case config.JWTAlgorithmRS256:
+		resolver, err := keys.ResolverFromRS256Config(cfg.RS256)
+		if err != nil {
+			return CompatOptions{}, fmt.Errorf("build RS256 resolver: %w", err)
+		}
+
+		return CompatOptions{
+			Options: Options{
+				Methods:  []string{"RS256"},
+				Issuer:   cfg.Issuer,
+				Resolver: resolver,
+			},
+			TokenTTL: ttl,
+		}, nil
+	default:
+		return CompatOptions{}, fmt.Errorf("algorithm %q: %w", algorithm, ErrUnsupportedJWTAlgorithm)
 	}
 }

--- a/security/jwt/compat_test.go
+++ b/security/jwt/compat_test.go
@@ -1,0 +1,140 @@
+package jwt
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/matiasmartin-labs/common-fwk/config"
+	"github.com/matiasmartin-labs/common-fwk/security/keys"
+)
+
+func TestFromConfigJWTHS256Compatibility(t *testing.T) {
+	t.Parallel()
+
+	compat, err := FromConfigJWT(config.JWTConfig{
+		Algorithm:  config.JWTAlgorithmHS256,
+		Secret:     "hs-secret",
+		Issuer:     "common-fwk",
+		TTLMinutes: 30,
+	})
+	if err != nil {
+		t.Fatalf("expected HS256 compatibility success, got %v", err)
+	}
+
+	if len(compat.Options.Methods) != 1 || compat.Options.Methods[0] != "HS256" {
+		t.Fatalf("expected methods [HS256], got %v", compat.Options.Methods)
+	}
+	if compat.Options.Issuer != "common-fwk" {
+		t.Fatalf("expected issuer common-fwk, got %q", compat.Options.Issuer)
+	}
+	if compat.TokenTTL != 30*time.Minute {
+		t.Fatalf("expected token ttl 30m, got %s", compat.TokenTTL)
+	}
+
+	resolved, err := compat.Options.Resolver.Resolve(context.Background(), "")
+	if err != nil {
+		t.Fatalf("resolve HS256 key: %v", err)
+	}
+	if resolved.Method != "HS256" {
+		t.Fatalf("expected HS256 key method, got %q", resolved.Method)
+	}
+}
+
+func TestFromConfigJWTRS256Compatibility(t *testing.T) {
+	t.Parallel()
+
+	privatePEM := mustPrivatePEM(t)
+
+	compat, err := FromConfigJWT(config.JWTConfig{
+		Algorithm:  config.JWTAlgorithmRS256,
+		Issuer:     "common-fwk",
+		TTLMinutes: 15,
+		RS256: config.RS256Config{
+			KeySource:     config.RS256KeySourcePrivatePEM,
+			KeyID:         "rsa-1",
+			PrivateKeyPEM: privatePEM,
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected RS256 compatibility success, got %v", err)
+	}
+
+	if len(compat.Options.Methods) != 1 || compat.Options.Methods[0] != "RS256" {
+		t.Fatalf("expected methods [RS256], got %v", compat.Options.Methods)
+	}
+	if compat.TokenTTL != 15*time.Minute {
+		t.Fatalf("expected token ttl 15m, got %s", compat.TokenTTL)
+	}
+
+	resolved, err := compat.Options.Resolver.Resolve(context.Background(), "")
+	if err != nil {
+		t.Fatalf("resolve RS256 key: %v", err)
+	}
+	if resolved.Method != "RS256" {
+		t.Fatalf("expected RS256 key method, got %q", resolved.Method)
+	}
+}
+
+func TestFromConfigJWTInvalidModes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     config.JWTConfig
+		wantErr error
+	}{
+		{
+			name:    "unsupported algorithm",
+			cfg:     config.JWTConfig{Algorithm: "ES256", Issuer: "common-fwk", TTLMinutes: 15},
+			wantErr: ErrUnsupportedJWTAlgorithm,
+		},
+		{
+			name: "rs256 resolver failure",
+			cfg: config.JWTConfig{
+				Algorithm:  config.JWTAlgorithmRS256,
+				Issuer:     "common-fwk",
+				TTLMinutes: 15,
+				RS256: config.RS256Config{
+					KeySource: config.RS256KeySourceGenerated,
+					KeyID:     "",
+				},
+			},
+			wantErr: keys.ErrRS256KeyIDRequired,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := FromConfigJWT(tc.cfg)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func mustPrivatePEM(t *testing.T) string {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+
+	der := x509.MarshalPKCS1PrivateKey(priv)
+	blk := pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}
+
+	return string(pem.EncodeToMemory(&blk))
+}

--- a/security/keys/keypair.go
+++ b/security/keys/keypair.go
@@ -1,0 +1,113 @@
+package keys
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/matiasmartin-labs/common-fwk/config"
+)
+
+const defaultRSABits = 2048
+
+var (
+	ErrInvalidRSAKeySize         = errors.New("invalid RSA key size")
+	ErrUnsupportedRS256KeySource = errors.New("unsupported RS256 key source")
+	ErrRS256KeyIDRequired        = errors.New("rs256 key id is required")
+	ErrInvalidRS256PEM           = errors.New("invalid rs256 pem")
+)
+
+// GenerateRSAKeyPair creates an in-memory RSA keypair.
+func GenerateRSAKeyPair(bits int) (*rsa.PrivateKey, error) {
+	if bits == 0 {
+		bits = defaultRSABits
+	}
+
+	if bits < 1024 {
+		return nil, fmt.Errorf("bits=%d: %w", bits, ErrInvalidRSAKeySize)
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, fmt.Errorf("generate rsa keypair: %w", err)
+	}
+
+	return priv, nil
+}
+
+// ResolverFromRS256Config builds a deterministic resolver from RS256 config.
+func ResolverFromRS256Config(cfg config.RS256Config) (Resolver, error) {
+	if strings.TrimSpace(cfg.KeyID) == "" {
+		return nil, ErrRS256KeyIDRequired
+	}
+
+	switch strings.TrimSpace(cfg.KeySource) {
+	case config.RS256KeySourceGenerated:
+		priv, err := GenerateRSAKeyPair(0)
+		if err != nil {
+			return nil, fmt.Errorf("generate keypair for key source %q: %w", config.RS256KeySourceGenerated, err)
+		}
+		return NewRSAResolver(priv, cfg.KeyID), nil
+	case config.RS256KeySourcePublicPEM:
+		pub, err := parsePublicKeyPEM(cfg.PublicKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("parse public pem: %w: %w", ErrInvalidRS256PEM, err)
+		}
+		return NewRSAPublicKeyResolver(pub, cfg.KeyID), nil
+	case config.RS256KeySourcePrivatePEM:
+		priv, err := parsePrivateKeyPEM(cfg.PrivateKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("parse private pem: %w: %w", ErrInvalidRS256PEM, err)
+		}
+		return NewRSAResolver(priv, cfg.KeyID), nil
+	default:
+		return nil, fmt.Errorf("key source %q: %w", cfg.KeySource, ErrUnsupportedRS256KeySource)
+	}
+}
+
+func parsePublicKeyPEM(raw string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(raw))
+	if block == nil {
+		return nil, errors.New("pem decode failed")
+	}
+
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	pub, ok := parsed.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("public key is not RSA")
+	}
+
+	return pub, nil
+}
+
+func parsePrivateKeyPEM(raw string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(raw))
+	if block == nil {
+		return nil, errors.New("pem decode failed")
+	}
+
+	priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err == nil {
+		return priv, nil
+	}
+
+	parsedPKCS8, errPKCS8 := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if errPKCS8 != nil {
+		return nil, err
+	}
+
+	parsed, ok := parsedPKCS8.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("private key is not RSA")
+	}
+
+	return parsed, nil
+}

--- a/security/keys/keypair_test.go
+++ b/security/keys/keypair_test.go
@@ -1,0 +1,182 @@
+package keys
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"testing"
+
+	"github.com/matiasmartin-labs/common-fwk/config"
+)
+
+func TestGenerateRSAKeyPair(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generates key pair with explicit bits", func(t *testing.T) {
+		priv, err := GenerateRSAKeyPair(2048)
+		if err != nil {
+			t.Fatalf("expected keypair generation success, got: %v", err)
+		}
+		if priv == nil || priv.PublicKey.N == nil {
+			t.Fatalf("expected non-nil RSA key pair")
+		}
+		if priv.N.BitLen() != 2048 {
+			t.Fatalf("expected 2048-bit key, got %d", priv.N.BitLen())
+		}
+	})
+
+	t.Run("defaults to 2048 bits", func(t *testing.T) {
+		priv, err := GenerateRSAKeyPair(0)
+		if err != nil {
+			t.Fatalf("expected default keypair generation success, got: %v", err)
+		}
+		if priv.N.BitLen() != 2048 {
+			t.Fatalf("expected default 2048-bit key, got %d", priv.N.BitLen())
+		}
+	})
+
+	t.Run("rejects invalid bits", func(t *testing.T) {
+		_, err := GenerateRSAKeyPair(256)
+		if err == nil {
+			t.Fatalf("expected invalid bits error")
+		}
+		if !errors.Is(err, ErrInvalidRSAKeySize) {
+			t.Fatalf("expected ErrInvalidRSAKeySize, got %v", err)
+		}
+	})
+}
+
+func TestResolverFromRS256Config(t *testing.T) {
+	t.Parallel()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate deterministic key: %v", err)
+	}
+
+	publicPEM, err := encodePublicKeyPEM(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("encode public pem: %v", err)
+	}
+
+	privatePEM, err := encodePrivateKeyPEM(priv)
+	if err != nil {
+		t.Fatalf("encode private pem: %v", err)
+	}
+
+	t.Run("generated source", func(t *testing.T) {
+		resolver, err := ResolverFromRS256Config(config.RS256Config{KeySource: config.RS256KeySourceGenerated, KeyID: "kid-generated"})
+		if err != nil {
+			t.Fatalf("expected resolver success, got %v", err)
+		}
+
+		resolved, err := resolver.Resolve(context.Background(), "")
+		if err != nil {
+			t.Fatalf("resolve generated key: %v", err)
+		}
+		if resolved.Method != "RS256" {
+			t.Fatalf("expected RS256 method, got %q", resolved.Method)
+		}
+	})
+
+	t.Run("public pem source", func(t *testing.T) {
+		resolver, err := ResolverFromRS256Config(config.RS256Config{
+			KeySource:    config.RS256KeySourcePublicPEM,
+			KeyID:        "kid-public",
+			PublicKeyPEM: publicPEM,
+		})
+		if err != nil {
+			t.Fatalf("expected resolver success, got %v", err)
+		}
+
+		resolved, err := resolver.Resolve(context.Background(), "")
+		if err != nil {
+			t.Fatalf("resolve public key: %v", err)
+		}
+		if resolved.ID != "kid-public" {
+			t.Fatalf("expected kid-public, got %q", resolved.ID)
+		}
+	})
+
+	t.Run("private pem source", func(t *testing.T) {
+		resolver, err := ResolverFromRS256Config(config.RS256Config{
+			KeySource:     config.RS256KeySourcePrivatePEM,
+			KeyID:         "kid-private",
+			PrivateKeyPEM: privatePEM,
+		})
+		if err != nil {
+			t.Fatalf("expected resolver success, got %v", err)
+		}
+
+		resolved, err := resolver.Resolve(context.Background(), "")
+		if err != nil {
+			t.Fatalf("resolve private key-derived verifier: %v", err)
+		}
+		if resolved.ID != "kid-private" {
+			t.Fatalf("expected kid-private, got %q", resolved.ID)
+		}
+	})
+
+	t.Run("unsupported key source", func(t *testing.T) {
+		_, err := ResolverFromRS256Config(config.RS256Config{KeySource: "vault", KeyID: "kid"})
+		if err == nil {
+			t.Fatalf("expected unsupported key source error")
+		}
+		if !errors.Is(err, ErrUnsupportedRS256KeySource) {
+			t.Fatalf("expected ErrUnsupportedRS256KeySource, got %v", err)
+		}
+	})
+
+	t.Run("missing key id", func(t *testing.T) {
+		_, err := ResolverFromRS256Config(config.RS256Config{KeySource: config.RS256KeySourceGenerated})
+		if err == nil {
+			t.Fatalf("expected missing key id error")
+		}
+		if !errors.Is(err, ErrRS256KeyIDRequired) {
+			t.Fatalf("expected ErrRS256KeyIDRequired, got %v", err)
+		}
+	})
+
+	t.Run("malformed pem", func(t *testing.T) {
+		_, err := ResolverFromRS256Config(config.RS256Config{
+			KeySource:    config.RS256KeySourcePublicPEM,
+			KeyID:        "kid",
+			PublicKeyPEM: "-----BEGIN PUBLIC KEY-----\nINVALID\n-----END PUBLIC KEY-----",
+		})
+		if err == nil {
+			t.Fatalf("expected malformed pem error")
+		}
+		if !errors.Is(err, ErrInvalidRS256PEM) {
+			t.Fatalf("expected ErrInvalidRS256PEM, got %v", err)
+		}
+	})
+}
+
+func encodePublicKeyPEM(pub *rsa.PublicKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+
+	var out bytes.Buffer
+	if err := pem.Encode(&out, &pem.Block{Type: "PUBLIC KEY", Bytes: der}); err != nil {
+		return "", err
+	}
+
+	return out.String(), nil
+}
+
+func encodePrivateKeyPEM(priv *rsa.PrivateKey) (string, error) {
+	der := x509.MarshalPKCS1PrivateKey(priv)
+
+	var out bytes.Buffer
+	if err := pem.Encode(&out, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}); err != nil {
+		return "", err
+	}
+
+	return out.String(), nil
+}


### PR DESCRIPTION
Closes #30

## Summary
- Add mode-aware JWT configuration supporting HS256 (secret) and RS256 (RSA keypair) with validation and viper adapter mapping updates.
- Add RS256 keypair generation/retrieval utilities and wire JWT compat validator selection by configured algorithm.
- Add app-level config-driven security wiring convenience while preserving explicit validator injection path.
- Update docs and OpenSpec artifacts, including archived change artifacts and synced specs.

## Validation
- go test ./...
- go build ./...
- go test ./... -cover
- go vet ./...