### PR TITLE
feat(app): expose read-only runtime accessors for issue #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,38 @@ Behavior notes:
 - `RunListener(net.Listener)` is available for test-friendly startup flows.
 - `UseServerSecurityFromConfig()` is available as a thin convenience wrapper around config-driven JWT validator wiring (HS256/RS256).
 
+Read-only runtime accessors:
+
+```go
+fresh := app.NewApplication()
+
+// Explicit non-init behavior.
+_ = fresh.GetConfig()               // zero-value config snapshot
+_ = fresh.GetSecurityValidator()    // nil
+_ = fresh.IsSecurityReady()         // false
+
+a := app.NewApplication().
+	UseConfig(cfg).
+	UseServer()
+
+runtimeCfg := a.GetConfig()         // read-only snapshot
+_ = runtimeCfg.Security.Auth.OAuth2.Providers // safe to inspect
+
+// Mutating runtimeCfg does not mutate app internals.
+
+a = a.UseServerSecurity(validator)
+_ = a.GetSecurityValidator() != nil // true after security wiring
+_ = a.IsSecurityReady()             // true
+```
+
+Accessor lifecycle + immutability contract:
+- `GetConfig() config.Config`
+- `GetSecurityValidator() security.Validator`
+- `IsSecurityReady() bool`
+- `GetConfig()` is safe in all lifecycle stages and never triggers implicit bootstrap.
+- Before security wiring, `GetSecurityValidator()` returns `nil` and `IsSecurityReady()` returns `false`.
+- `GetConfig()` deep-copies mutable descendants (OAuth2 providers map and nested scopes slices) on each read.
+
 ---
 
 ## Layered architecture overview

--- a/app/application.go
+++ b/app/application.go
@@ -33,6 +33,21 @@ type Application struct {
 	securityReady bool
 }
 
+// GetConfig returns a read-only snapshot of the current runtime config.
+func (a *Application) GetConfig() config.Config {
+	return cloneConfig(a.cfg)
+}
+
+// GetSecurityValidator returns the current security validator when wired.
+func (a *Application) GetSecurityValidator() security.Validator {
+	return a.validator
+}
+
+// IsSecurityReady reports whether security runtime was fully wired.
+func (a *Application) IsSecurityReady() bool {
+	return a.securityReady
+}
+
 // NewApplication creates a bootstrap instance with safe defaults.
 func NewApplication() *Application {
 	h := gin.New()
@@ -46,6 +61,37 @@ func NewApplication() *Application {
 func (a *Application) UseConfig(cfg config.Config) *Application {
 	a.cfg = cfg
 	return a
+}
+
+func cloneConfig(cfg config.Config) config.Config {
+	cfg.Security.Auth.OAuth2.Providers = cloneOAuth2Providers(cfg.Security.Auth.OAuth2.Providers)
+
+	return cfg
+}
+
+func cloneOAuth2Providers(providers map[string]config.OAuth2ProviderConfig) map[string]config.OAuth2ProviderConfig {
+	if providers == nil {
+		return nil
+	}
+
+	cloned := make(map[string]config.OAuth2ProviderConfig, len(providers))
+	for key, provider := range providers {
+		provider.Scopes = cloneStringSlice(provider.Scopes)
+		cloned[key] = provider
+	}
+
+	return cloned
+}
+
+func cloneStringSlice(values []string) []string {
+	if values == nil {
+		return nil
+	}
+
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+
+	return cloned
 }
 
 // UseServer wires the HTTP server and marks server readiness.

--- a/app/application_test.go
+++ b/app/application_test.go
@@ -12,6 +12,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -42,6 +44,27 @@ func testConfig() config.Config {
 	return config.Config{
 		Server: config.ServerConfig{Host: "127.0.0.1", Port: 0, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, MaxHeaderBytes: 1 << 20},
 	}
+}
+
+func testConfigWithOAuth2Provider() config.Config {
+	return config.NewConfig(
+		config.NewServerConfig("127.0.0.1", 8080),
+		config.NewSecurityConfig(config.NewAuthConfig(
+			config.NewJWTConfig("secret", "common-fwk", 15),
+			config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+			config.NewLoginConfig("owner@example.com"),
+			config.NewOAuth2Config(map[string]config.OAuth2ProviderConfig{
+				"github": config.NewOAuth2ProviderConfig(
+					"client-id",
+					"client-secret",
+					"https://github.com/login/oauth/authorize",
+					"https://github.com/login/oauth/access_token",
+					"https://app.example.com/auth/github/callback",
+					[]string{"read:user", "user:email"},
+				),
+			}),
+		)),
+	)
 }
 
 func TestBootstrapChain_PreservesPointerAndReadiness(t *testing.T) {
@@ -432,6 +455,238 @@ func TestUseServerSecurityFromConfig(t *testing.T) {
 			t.Fatalf("expected validator to remain nil on failure")
 		}
 	})
+}
+
+func TestAccessors_LifecycleMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		bootstrap      func(*Application)
+		wantConfig     config.Config
+		wantValidator  bool
+		wantSecReady   bool
+	}{
+		{
+			name:          "pre-init returns explicit non-ready values",
+			bootstrap:     func(_ *Application) {},
+			wantConfig:    config.Config{},
+			wantValidator: false,
+			wantSecReady:  false,
+		},
+		{
+			name: "partial-init after UseConfig exposes only config",
+			bootstrap: func(a *Application) {
+				a.UseConfig(testConfigWithOAuth2Provider())
+			},
+			wantConfig:     testConfigWithOAuth2Provider(),
+			wantValidator:  false,
+			wantSecReady:   false,
+		},
+		{
+			name: "post-init with direct validator exposes both config and security",
+			bootstrap: func(a *Application) {
+				a.UseConfig(testConfigWithOAuth2Provider()).UseServerSecurity(&fakeValidator{})
+			},
+			wantConfig:     testConfigWithOAuth2Provider(),
+			wantValidator:  true,
+			wantSecReady:   true,
+		},
+		{
+			name: "post-init with config-driven security exposes both config and security",
+			bootstrap: func(a *Application) {
+				a.UseConfig(testConfigWithOAuth2Provider())
+				_, err := a.UseServerSecurityFromConfig()
+				if err != nil {
+					t.Fatalf("expected config-driven security wiring success, got %v", err)
+				}
+			},
+			wantConfig:     testConfigWithOAuth2Provider(),
+			wantValidator:  true,
+			wantSecReady:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewApplication()
+			tc.bootstrap(a)
+
+			var gotCfg config.Config
+			var gotValidator any
+			var gotReady bool
+
+			mustNotPanic(t, "GetConfig", func() {
+				gotCfg = a.GetConfig()
+			})
+			mustNotPanic(t, "GetSecurityValidator", func() {
+				gotValidator = a.GetSecurityValidator()
+			})
+			mustNotPanic(t, "IsSecurityReady", func() {
+				gotReady = a.IsSecurityReady()
+			})
+
+			if !reflect.DeepEqual(gotCfg, tc.wantConfig) {
+				t.Fatalf("unexpected config snapshot\nwant=%#v\ngot =%#v", tc.wantConfig, gotCfg)
+			}
+			if (gotValidator != nil) != tc.wantValidator {
+				t.Fatalf("unexpected validator presence: want=%t got=%t", tc.wantValidator, gotValidator != nil)
+			}
+			if gotReady != tc.wantSecReady {
+				t.Fatalf("unexpected security readiness: want=%t got=%t", tc.wantSecReady, gotReady)
+			}
+		})
+	}
+}
+
+func TestGetConfig_DefensiveSnapshotImmutability(t *testing.T) {
+	t.Parallel()
+
+	a := NewApplication().UseConfig(testConfigWithOAuth2Provider())
+
+	firstSnapshot := a.GetConfig()
+	if firstSnapshot.Security.Auth.OAuth2.Providers == nil {
+		t.Fatalf("expected providers map in snapshot")
+	}
+
+	provider, ok := firstSnapshot.Security.Auth.OAuth2.Providers["github"]
+	if !ok {
+		t.Fatalf("expected github provider in snapshot")
+	}
+
+	provider.Scopes[0] = "mutated-scope"
+	firstSnapshot.Security.Auth.OAuth2.Providers["github"] = provider
+	firstSnapshot.Security.Auth.OAuth2.Providers["evil"] = config.NewOAuth2ProviderConfig(
+		"x",
+		"y",
+		"https://example.com/auth",
+		"https://example.com/token",
+		"https://example.com/callback",
+		[]string{"scope"},
+	)
+
+	secondSnapshot := a.GetConfig()
+	provider2, ok := secondSnapshot.Security.Auth.OAuth2.Providers["github"]
+	if !ok {
+		t.Fatalf("expected github provider in second snapshot")
+	}
+
+	if provider2.Scopes[0] != "read:user" {
+		t.Fatalf("expected internal scopes to remain unchanged, got %q", provider2.Scopes[0])
+	}
+	if _, exists := secondSnapshot.Security.Auth.OAuth2.Providers["evil"]; exists {
+		t.Fatalf("expected injected provider key to not leak into internal runtime state")
+	}
+
+	thirdSnapshot := a.GetConfig()
+	secondProvider := secondSnapshot.Security.Auth.OAuth2.Providers["github"]
+	thirdProvider := thirdSnapshot.Security.Auth.OAuth2.Providers["github"]
+	if &secondProvider.Scopes[0] == &thirdProvider.Scopes[0] {
+		t.Fatalf("expected scope slices to be independently copied per read")
+	}
+}
+
+func TestAccessors_FailedConfigDrivenSecurityRemainsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	a := NewApplication().UseConfig(config.Config{
+		Server: config.NewServerConfig("127.0.0.1", 8080),
+		Security: config.NewSecurityConfig(config.NewAuthConfig(
+			config.JWTConfig{Algorithm: config.JWTAlgorithmRS256, Issuer: "common-fwk", TTLMinutes: 15},
+			config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+			config.NewLoginConfig("owner@example.com"),
+			config.NewOAuth2Config(nil),
+		)),
+	})
+
+	_, err := a.UseServerSecurityFromConfig()
+	if err == nil {
+		t.Fatalf("expected config-driven security wiring error")
+	}
+
+	if a.GetSecurityValidator() != nil {
+		t.Fatalf("expected accessor validator to remain nil after failed wiring")
+	}
+	if a.IsSecurityReady() {
+		t.Fatalf("expected accessor security readiness to remain false after failed wiring")
+	}
+}
+
+func TestDocumentation_AccessorContractSynchronization(t *testing.T) {
+	t.Parallel()
+
+	type docSpec struct {
+		name string
+		path string
+	}
+
+	docs := []docSpec{
+		{name: "package docs", path: "doc.go"},
+		{name: "readme", path: "../README.md"},
+		{name: "docs home", path: "../docs/home.md"},
+	}
+
+	sharedSignatures := []string{
+		"GetConfig() config.Config",
+		"GetSecurityValidator() security.Validator",
+		"IsSecurityReady() bool",
+	}
+
+	for _, doc := range docs {
+		doc := doc
+		t.Run(doc.name, func(t *testing.T) {
+			raw, err := os.ReadFile(doc.path)
+			if err != nil {
+				t.Fatalf("read %s (%s): %v", doc.name, doc.path, err)
+			}
+
+			text := string(raw)
+			lower := strings.ToLower(text)
+
+			for _, signature := range sharedSignatures {
+				if !strings.Contains(text, signature) {
+					t.Fatalf("%s must include accessor signature %q", doc.name, signature)
+				}
+			}
+
+			if !(strings.Contains(lower, "pre-init") || strings.Contains(lower, "non-init")) {
+				t.Fatalf("%s must describe pre-init/non-init accessor behavior", doc.name)
+			}
+			if !strings.Contains(lower, "zero-value") || !strings.Contains(lower, "nil") || !strings.Contains(lower, "false") {
+				t.Fatalf("%s must document pre-init expectations (zero-value config, nil validator, false readiness)", doc.name)
+			}
+
+			if !(strings.Contains(lower, "post-init") || strings.Contains(lower, "after security wiring")) {
+				t.Fatalf("%s must describe post-init accessor behavior", doc.name)
+			}
+			if !strings.Contains(lower, "true") {
+				t.Fatalf("%s must document ready/true post-init expectations", doc.name)
+			}
+
+			hasImmutabilityWording := strings.Contains(lower, "defensive snapshot") || strings.Contains(lower, "deep-cop")
+			if !hasImmutabilityWording {
+				t.Fatalf("%s must document defensive snapshot/deep-copy immutability", doc.name)
+			}
+
+			hasMutationSafetyWording := strings.Contains(lower, "internal runtime state") || strings.Contains(lower, "app internals")
+			if !hasMutationSafetyWording {
+				t.Fatalf("%s must document that external mutation does not affect internals", doc.name)
+			}
+		})
+	}
+}
+
+func mustNotPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked: %v", name, r)
+		}
+	}()
+
+	fn()
 }
 
 func waitHTTPGet(url string, timeout time.Duration) (*http.Response, error) {

--- a/app/doc.go
+++ b/app/doc.go
@@ -1,2 +1,21 @@
 // Package app defines the application bootstrap boundary for common-fwk.
+//
+// The Application type now also exposes read-only runtime inspection helpers:
+//
+//	GetConfig() config.Config
+//	GetSecurityValidator() security.Validator
+//	IsSecurityReady() bool
+//
+// Lifecycle contract:
+//   - Pre-init (fresh NewApplication): GetConfig returns zero-value config snapshot,
+//     GetSecurityValidator returns nil, IsSecurityReady returns false.
+//   - Partial-init (after UseConfig only): GetConfig reflects configured values,
+//     security accessors still report unavailable state (nil/false).
+//   - Post-init (after security wiring succeeds): GetSecurityValidator is non-nil and
+//     IsSecurityReady is true.
+//
+// Immutability contract:
+// GetConfig returns a defensive snapshot. Mutable descendants like
+// OAuth2.Providers maps and provider Scopes slices are deep-copied on each call,
+// so external mutation attempts do not alter internal runtime state.
 package app

--- a/docs/home.md
+++ b/docs/home.md
@@ -40,3 +40,20 @@ server:
   write-timeout: 10s
   max-header-bytes: 1048576
 ```
+
+## App runtime accessor contract
+
+`app.Application` exposes read-only runtime accessors for config and security state:
+
+- `GetConfig() config.Config`
+- `GetSecurityValidator() security.Validator`
+- `IsSecurityReady() bool`
+
+Lifecycle semantics are explicit and deterministic:
+- Pre-init (`NewApplication()`): config accessor returns zero-value snapshot; security accessors return `nil` / `false`.
+- Partial-init (`UseConfig(...)` only): config accessor reflects configured runtime state; security accessors remain `nil` / `false`.
+- Post-init (security wiring success): security validator accessor is non-`nil` and `IsSecurityReady()` is `true`.
+
+Immutability guarantee:
+- `GetConfig()` returns a defensive snapshot with deep copies of mutable descendants (`OAuth2.Providers` and provider `Scopes`).
+- External mutations to returned values do not alter internal runtime state.

--- a/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/apply-progress.md
+++ b/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/apply-progress.md
@@ -1,0 +1,40 @@
+# Apply Progress: issue-33-app-readonly-accessors
+
+## Completed
+
+- Added `Application` read-only runtime accessors in `app/application.go`:
+  - `GetConfig() config.Config`
+  - `GetSecurityValidator() security.Validator`
+  - `IsSecurityReady() bool`
+- Implemented defensive config snapshot helpers in `app/application.go`:
+  - `cloneConfig`
+  - `cloneOAuth2Providers`
+  - `cloneStringSlice`
+- Kept lifecycle semantics explicit and deterministic:
+  - Pre-init: zero-value config snapshot, `nil` validator, `false` security readiness
+  - Partial-init: config available, security still unavailable
+  - Post-init: validator available, security readiness true
+- Preserved existing registration and runtime behavior (`Register*`, `Run`, `RunListener`) without bootstrap side effects.
+- Added table-driven lifecycle accessor tests in `app/application_test.go` covering pre-init, partial-init, and post-init flows (direct and config-driven security wiring), with explicit no-panic assertions.
+- Added immutability tests in `app/application_test.go` to verify map/slice mutation attempts on `GetConfig()` snapshots do not alter internal runtime state.
+- Added failed config-driven security wiring accessor test to verify `GetSecurityValidator()==nil` and `IsSecurityReady()==false` after error.
+- Updated docs to keep contract language synchronized:
+  - `app/doc.go`
+  - `README.md`
+  - `docs/home.md`
+- Added executable docs synchronization acceptance coverage in `app/application_test.go`:
+  - `TestDocumentation_AccessorContractSynchronization`
+  - Asserts accessor signatures, lifecycle expectations (pre-init/post-init), and immutability wording are consistently present in `app/doc.go`, `README.md`, and `docs/home.md`.
+- Strengthened README synchronization by adding explicit accessor signatures under the accessor contract bullets so docs contract checks are deterministic and aligned.
+
+## Verification
+
+- `go test ./...` passed.
+
+## Spec/Design Self-Review
+
+- Read-only accessor API shape matches design (`GetConfig`, `GetSecurityValidator`, `IsSecurityReady`).
+- Config immutability guarantee is enforced via deep-copy of OAuth2 providers map and nested scopes slices.
+- Lifecycle semantics across pre-init, partial-init, post-init, and failed security wiring are covered by automated tests and docs.
+- Documentation synchronization acceptance is now executable via test assertions instead of static/manual comparison only.
+- Core/adapters boundaries remain intact: accessors expose only config/security contracts, no framework lock-in added to core.

--- a/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/archive-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/archive-report.md
@@ -1,0 +1,103 @@
+# Archive Report
+
+**Change**: `issue-33-app-readonly-accessors`  
+**Archived On**: `2026-05-01`  
+**Artifact Store Mode**: `hybrid`  
+**Final Status**: ✅ Archived (verification PASS, ready for archive)
+
+---
+
+## Executive Summary
+
+This change is fully completed and archived. It adds deterministic, read-only runtime accessors on `app.Application` for config and security inspection, with defensive immutability behavior, lifecycle guarantees, synchronized documentation, and passing verification evidence.
+
+---
+
+## Outcomes
+
+### Delivered
+- Read-only accessor API for runtime inspection:
+  - `GetConfig() config.Config`
+  - `GetSecurityValidator() security.Validator`
+  - `IsSecurityReady() bool`
+- Deterministic lifecycle semantics across pre-init, partial-init, and post-init.
+- Defensive config snapshot behavior to prevent external mutation of internal map/slice state.
+- Automated lifecycle, immutability, failed-wiring, and docs-sync verification tests.
+- Documentation contract synchronized across `app/doc.go`, `README.md`, and `docs/home.md`.
+
+### Compliance and Verification
+- Tasks complete: **15/15**
+- Build: `go build ./...` ✅
+- Tests: `go test -count=1 ./...` ✅
+- Coverage: **80.0% total**, changed package `app`: **90.2%** (threshold 0%)
+- Spec scenario compliance: **8/8 COMPLIANT**
+- Verification verdict: **PASS**
+- Archive readiness: **Ready for archive**
+
+---
+
+## Spec Sync (Delta → Main)
+
+**Main spec updated**: `openspec/specs/app-bootstrap/spec.md`
+
+| Domain | Action | Details |
+|---|---|---|
+| `app-bootstrap` | Updated | Merged ADDED delta requirements into main spec: 4 requirements added, 0 modified, 0 removed |
+
+Merged requirements:
+1. Read-only application runtime accessors
+2. Deterministic accessor lifecycle semantics
+3. Accessor contract test acceptance
+4. Documentation synchronization acceptance
+
+All pre-existing requirements not mentioned in the delta were preserved.
+
+---
+
+## Boundary and Non-Goals Preservation
+
+The archived result preserves original scope boundaries and non-goals:
+- No exposure of mutable internals (e.g., server/engine internals).
+- No new bootstrap lifecycle phase introduced.
+- No broader refactor of config/security core models beyond accessor contract needs.
+- Existing registration/run behavior remained unchanged.
+
+---
+
+## Archive Move Verification
+
+Change directory moved from:
+- `openspec/changes/issue-33-app-readonly-accessors/`
+
+to:
+- `openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/`
+
+Archive contains expected artifacts:
+- `proposal.md` ✅
+- `exploration.md` ✅
+- `specs/` ✅
+- `design.md` ✅
+- `tasks.md` ✅
+- `apply-progress.md` ✅
+- `verify-report.md` ✅
+- `archive-report.md` ✅
+
+Active changes no longer contain this change folder.
+
+---
+
+## Traceability (Engram Observation IDs)
+
+- explore: `#445`
+- proposal: `#443`
+- spec: `#446`
+- design: `#447`
+- tasks: `#449`
+- apply-progress: `#450`
+- verify-report: `#453`
+
+---
+
+## Completion State
+
+The SDD cycle for `issue-33-app-readonly-accessors` is complete: explore → propose → spec → design → tasks → apply → verify → archive.

--- a/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/design.md
+++ b/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/design.md
@@ -1,0 +1,93 @@
+# Design: App Read-Only Accessors for Config and Security Runtime
+
+## Technical Approach
+
+Add explicit read-only accessors to `app.Application` for runtime config and security wiring, while preserving encapsulation and framework boundaries. The design follows the proposal by exposing inspection-only API and preventing external mutation through defensive config snapshots.
+
+## Architecture Decisions
+
+### Decision: Public API shape for runtime inspection
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| `GetConfig()`, `GetSecurityValidator()`, `IsSecurityReady()` | Minimal and explicit, but multiple calls for security state | ✅ Chosen |
+| Single snapshot structs (`ConfigSnapshot()`, `SecurityRuntime()`) | Extensible grouping, but introduces extra exported types now | Rejected (over-design for issue scope) |
+| Raw field exposure without copy/readiness method | Lowest effort, but violates immutability and explicit contract goals | Rejected |
+
+**Rationale**: Minimal cohesive API aligns with existing naming style (`UseX`, `RegisterX`, `RunX`) and keeps behavior explicit.
+
+### Decision: Immutability strategy for config accessor
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Return `config.Config` by value + deep copy nested map/slice fields | Slight copy cost, strong safety and simple caller contract | ✅ Chosen |
+| Return raw `config.Config` by value only (shallow copy) | Fast, but leaks map/slice mutability (`OAuth2.Providers`, `Scopes`) | Rejected |
+| Introduce read-only config interfaces/types | Strong encapsulation, but larger API and conversion overhead | Rejected |
+
+**Rationale**: Deep-copy snapshot is the smallest change that guarantees read-only semantics for mutable internals.
+
+### Decision: Lifecycle contract before initialization
+
+| State | Accessor Output | Decision |
+|---|---|---|
+| Fresh `NewApplication()` | `GetConfig()` returns zero-value snapshot; `GetSecurityValidator()` returns `nil`; `IsSecurityReady()` returns `false` | ✅ Chosen |
+| After `UseConfig()` only | Config snapshot reflects loaded config; validator still `nil`; security ready `false` | ✅ Chosen |
+| After `UseServerSecurity(...)` or `UseServerSecurityFromConfig()` success | Validator non-nil; security ready `true` | ✅ Chosen |
+
+**Rationale**: Deterministic non-error accessors fit current explicit-contract style and avoid hidden state transitions.
+
+## Data Flow
+
+```
+Caller ──> app.Application.GetConfig()
+          └─> cloneConfig(a.cfg)
+               ├─ clone OAuth2 provider map
+               └─ clone provider scopes slices
+          ──> snapshot returned to caller
+
+Caller ──> app.Application.GetSecurityValidator() ──> a.validator (interface)
+Caller ──> app.Application.IsSecurityReady() ──────> a.securityReady
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `app/application.go` | Modify | Add new accessors and private `cloneConfig` helpers for deep-copy snapshot behavior. |
+| `app/application_test.go` | Modify | Add lifecycle tests (pre-init/partial/post-init), deep-copy immutability tests for OAuth2 providers/scopes, and security accessor contract tests. |
+| `app/doc.go` | Modify | Expand package docs to include accessor purpose and lifecycle semantics. |
+| `README.md` | Modify | Add bootstrap usage note/examples for read-only accessors and pre-init behavior. |
+| `docs/home.md` | Modify | Add concise contract notes so docs index stays aligned with README behavior notes. |
+| `openspec/specs/app-bootstrap/spec.md` | Modify (if missing requirement) | Add/align requirement language for runtime inspection accessors and immutability guarantee. |
+
+## Interfaces / Contracts
+
+```go
+// Read-only runtime inspection API.
+func (a *Application) GetConfig() config.Config
+func (a *Application) GetSecurityValidator() security.Validator
+func (a *Application) IsSecurityReady() bool
+```
+
+Contract notes:
+- `GetConfig()` MUST return a defensive snapshot (deep-copied mutable descendants).
+- Accessors MUST NOT mutate runtime state and MUST be safe to call in any bootstrap order.
+- `GetSecurityValidator()` MAY return `nil` when security is not wired.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Config accessor immutability | Mutate returned `OAuth2.Providers` map and `Scopes` slices; assert internal `a.cfg` remains unchanged. |
+| Unit | Lifecycle semantics | Table-driven cases for fresh app, after `UseConfig`, after failed/successful security wiring. |
+| Unit | Compatibility/non-regression | Existing route registration and run tests remain green with added accessors. |
+| Integration | N/A for this change | No new integration path required beyond existing bootstrap tests. |
+| E2E | N/A | Not required for accessor-only API extension. |
+
+## Migration / Rollout
+
+No migration required. This is additive API surface; existing callers remain compatible.
+
+## Open Questions
+
+- [ ] Should naming remain `GetX` for consistency with issue wording, or prefer noun methods (`Config()`, `SecurityValidator()`) in a future style pass?

--- a/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/exploration.md
+++ b/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/exploration.md
@@ -1,0 +1,53 @@
+## Exploration: issue-33-app-readonly-accessors
+
+### Current State
+`app.Application` currently keeps runtime state private (`cfg`, `validator`, readiness booleans, server/handler internals). Consumers can bootstrap and run the app but cannot inspect effective config or security runtime wiring from outside the package.
+
+Important nuance: returning `config.Config` by value is only a shallow copy. `config.Config.Security.Auth.OAuth2.Providers` is a map and provider scopes are slices, so naive return-by-value can still leak mutable internals unless deep-copy logic is applied.
+
+Security integration is currently represented by `security.Validator` (interface). `Application` tracks this in `validator` plus `securityReady`.
+
+### Affected Areas
+- `app/application.go` — add public read-only accessor API and define pre-init semantics.
+- `app/application_test.go` — add tests for initialized/non-initialized accessors and mutation-safety.
+- `app/doc.go` — document accessor lifecycle behavior and read-only guarantees.
+- `README.md` — show core app API usage with accessor examples (core APIs first).
+- `docs/home.md` — add `/docs/*` lifecycle/usage notes to satisfy issue acceptance criteria.
+- `openspec/specs/app-bootstrap/spec.md` — likely needs requirement/scenario updates for accessor contract.
+
+### Approaches
+1. **Minimal getters with targeted defensive copy** — Add `GetConfig() config.Config`, `GetSecurityValidator() security.Validator`, and `IsSecurityReady() bool`.
+   - Pros: Small API surface, easy adoption, explicit intent per accessor, low implementation cost.
+   - Cons: Requires deep-clone helper for config to avoid map/slice mutation leaks; multiple methods to call for security state.
+   - Effort: Low
+
+2. **Snapshot accessor objects** — Add `ConfigSnapshot()` and `SecurityRuntime()` snapshot structs (read-only fields/interfaces).
+   - Pros: Groups related data cleanly; easier future extension without adding many methods.
+   - Cons: Introduces new exported snapshot types and more API design overhead; larger surface than needed by issue.
+   - Effort: Medium
+
+3. **Direct raw field exposure via simple getters** — Return internal `cfg` and `validator` directly with no clone/snapshot semantics.
+   - Pros: Very fast to implement.
+   - Cons: Violates acceptance criteria (unsafe mutation leak risk through map/slice fields), weak lifecycle guarantees.
+   - Effort: Low
+
+### Recommendation
+Use **Approach 1** with strict defensive copy behavior for config.
+
+Concretely:
+- `GetConfig() config.Config` returns a deep-copied config snapshot (including cloned OAuth2 providers map and provider scopes).
+- `GetSecurityValidator() security.Validator` returns the interface currently wired (or `nil` pre-init).
+- `IsSecurityReady() bool` returns deterministic readiness for lifecycle checks.
+
+Pre-init contract should be explicit and tested:
+- New `Application` before wiring returns zero-value config snapshot, `nil` validator, and `false` readiness.
+
+This aligns with project standards (core API first, explicit boundaries, no singleton, no framework lock-in in core contracts) and gives consumers the required integration visibility without leaking mutable internals.
+
+### Risks
+- **False immutability confidence**: forgetting deep copy for nested map/slice fields would still leak mutability.
+- **API naming churn**: choosing `GetX` vs `X` method names inconsistently with repo style can cause follow-up refactors.
+- **Lifecycle ambiguity**: if pre-init behavior is not explicit in docs/tests, consumers may assume non-nil defaults.
+
+### Ready for Proposal
+Yes — proceed to `sdd-spec`/`sdd-design` with Approach 1 and lock in explicit pre-init/post-init scenarios, immutability tests, and `/docs/*` updates.

--- a/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/proposal.md
+++ b/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/proposal.md
@@ -1,0 +1,63 @@
+# Proposal: App Read-Only Accessors for Config and Security Runtime
+
+## Intent
+
+Issue #33 needs safe public access to runtime state from `app.Application` without exposing mutable internals. Callers need to inspect effective config and security wiring across lifecycle stages (before and after initialization) while preserving framework-boundary and immutability guarantees.
+
+## Scope
+
+### In Scope
+- Add public read-only accessors on `Application` for config and security runtime state.
+- Define deterministic lifecycle behavior for accessor outputs pre-init, partial init, and post-init.
+- Add/expand tests for immutability, encapsulation, and lifecycle semantics.
+- Update docs to describe accessor contract and usage expectations.
+
+### Out of Scope
+- Exposing mutable internals (`http.Server`, `gin.Engine`, validator internals) directly.
+- Adding new bootstrap lifecycle phases or startup orchestration.
+- Refactoring config/security core models beyond accessor contract needs.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `app-bootstrap`: add public read-only accessor requirements and lifecycle semantics for pre/post initialization visibility.
+
+## Approach
+
+Implement explicit accessor methods on `app.Application` that return safe snapshots or read-only views, never writable references to internal mutable state. Document return semantics for uninitialized and initialized states, and enforce behavior with table-driven tests covering chaining and ordering paths.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `app/application.go` | Modified | Add public accessor API and lifecycle behavior.
+| `app/application_test.go` | Modified | Add lifecycle/immutability contract tests.
+| `app/doc.go` | Modified | Package-level API contract update.
+| `README.md` | Modified | Public usage docs for new accessors.
+| `docs/home.md` | Modified | Framework docs synchronization for accessor behavior.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Accessors leak mutable references | Med | Return copied values / read-only projections; add mutation-attempt tests. |
+| Ambiguous zero-value semantics pre-init | Med | Specify explicit lifecycle contract in spec/docs and test all states. |
+| API drift from docs | Low | Update README + docs in same change and gate via review checklist. |
+
+## Rollback Plan
+
+Revert accessor additions and related docs/tests in one commit, restoring prior encapsulated API surface (`UseConfig`, `UseServer`, `UseServerSecurity`, registration, run). No data migration or persistent state rollback is required.
+
+## Dependencies
+
+- Alignment with issue #33 acceptance criteria and existing `app-bootstrap` spec wording.
+
+## Success Criteria
+
+- [ ] Public read-only accessors are available for config/security runtime inspection.
+- [ ] Accessor behavior is deterministic before and after initialization.
+- [ ] Tests prove no external mutation of internal runtime state through accessors.
+- [ ] README and docs describe lifecycle and immutability guarantees consistently.

--- a/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/specs/app-bootstrap/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/specs/app-bootstrap/spec.md
@@ -1,0 +1,75 @@
+# Delta for app-bootstrap
+
+## ADDED Requirements
+
+### Requirement: Read-only application runtime accessors
+
+`app.Application` MUST provide public read-only accessors for (a) effective runtime config and (b) security runtime state used for protected routing. These accessors MUST NOT expose writable references to internal mutable runtime components.
+
+#### Scenario: Accessors expose runtime snapshots after bootstrap
+
+- GIVEN an `Application` configured through `UseConfig(...).UseServer().UseServerSecurity(...)`
+- WHEN the caller reads config and security runtime through the public accessors
+- THEN both accessors return initialized state that reflects the effective runtime wiring
+- AND returned data can be inspected without requiring internal package access
+
+#### Scenario: External mutation attempts do not alter internal runtime state
+
+- GIVEN a caller retrieved accessor outputs
+- WHEN the caller mutates the returned values or projections
+- THEN subsequent accessor reads still reflect the original internal runtime state
+- AND bootstrap/run behavior remains unchanged by external mutation attempts
+
+### Requirement: Deterministic accessor lifecycle semantics
+
+Accessor behavior MUST be deterministic across pre-init, partial-init, and post-init stages. For any uninitialized stage, accessors MUST signal "not available" in a documented way and MUST NOT panic.
+
+#### Scenario: Pre-init accessor behavior is explicit
+
+- GIVEN a new `Application` instance with no bootstrap methods invoked
+- WHEN config/security accessors are called
+- THEN each accessor reports uninitialized state according to the contract
+- AND no panic or implicit initialization occurs
+
+#### Scenario: Partial-init exposes only configured runtime state
+
+- GIVEN an `Application` where `UseConfig(...)` has run but security bootstrap has not completed
+- WHEN config/security accessors are called
+- THEN config accessor reports initialized state
+- AND security accessor reports uninitialized state without side effects
+
+#### Scenario: Post-init exposes both runtime domains
+
+- GIVEN an `Application` where bootstrap prerequisites are fully configured
+- WHEN config/security accessors are called
+- THEN both accessors report initialized state
+- AND results remain stable across repeated reads
+
+### Requirement: Accessor contract test acceptance
+
+The change MUST include automated tests that verify lifecycle semantics and immutability guarantees for the new accessors.
+
+#### Scenario: Lifecycle test matrix coverage
+
+- GIVEN automated tests for pre-init, partial-init, and post-init states
+- WHEN tests exercise accessor reads across valid method-order combinations
+- THEN expected availability/unavailability outcomes are asserted for each state
+- AND tests confirm deterministic behavior without panic
+
+#### Scenario: Immutability contract coverage
+
+- GIVEN automated tests that attempt to mutate accessor-returned values
+- WHEN mutation attempts are followed by additional reads and runtime checks
+- THEN internal runtime state remains unchanged
+- AND tests fail if mutable internals are leaked
+
+### Requirement: Documentation synchronization acceptance
+
+Docs MUST describe accessor lifecycle and immutability guarantees consistently across package docs and user-facing guides.
+
+#### Scenario: Documentation reflects accessor contract
+
+- GIVEN the change updates `app/doc.go`, `README.md`, and `docs/home.md`
+- WHEN a reader compares lifecycle and immutability statements across these docs
+- THEN terminology and behavior expectations are consistent
+- AND docs include pre-init and post-init usage expectations

--- a/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/tasks.md
+++ b/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: App Read-Only Accessors for Config and Security Runtime
+
+## Phase 1: Foundation (Accessor contract + safe copy helpers)
+
+- [x] 1.1 In `app/application.go`, add `GetConfig() config.Config`, `GetSecurityValidator() security.Validator`, and `IsSecurityReady() bool` on `Application` with deterministic zero-value/`nil`/`false` behavior for non-init state.
+- [x] 1.2 In `app/application.go`, implement private config snapshot helpers (deep-copy OAuth2 providers map and nested scopes slices) so `GetConfig()` never returns mutable internals.
+- [x] 1.3 In `app/application.go`, ensure accessor methods are read-only (no state mutation, no implicit bootstrap) and preserve core/adapters boundaries by exposing only config/security contracts.
+
+## Phase 2: Core behavior wiring (init and partial-init semantics)
+
+- [x] 2.1 In `app/application.go`, verify `UseConfig`, `UseServerSecurity`, and `UseServerSecurityFromConfig` leave accessor outputs consistent for init/non-init/partial-init flows.
+- [x] 2.2 In `app/application.go`, confirm failed `UseServerSecurityFromConfig` keeps security state unavailable (`validator=nil`, `securityReady=false`) for accessor reads.
+- [x] 2.3 In `app/application.go`, keep existing registration/run behavior untouched while adding accessors (no regressions to `Register*`, `Run`, `RunListener`).
+
+## Phase 3: Tests (lifecycle matrix + immutability)
+
+- [x] 3.1 In `app/application_test.go`, add table-driven tests for init/non-init/partial-init/post-init accessor outcomes (`GetConfig`, `GetSecurityValidator`, `IsSecurityReady`) and assert no panic.
+- [x] 3.2 In `app/application_test.go`, add immutability tests that mutate returned `GetConfig()` values (`OAuth2.Providers` map and provider `Scopes`) and verify subsequent reads/internal runtime state remain unchanged.
+- [x] 3.3 In `app/application_test.go`, add tests for failed config-driven security wiring to confirm accessors still report uninitialized security state.
+- [x] 3.4 In `app/application_test.go`, run/adjust non-regression tests for existing bootstrap, route registration, and run lifecycle behavior.
+
+## Phase 4: Documentation sync (`/docs/*` + package/user docs)
+
+- [x] 4.1 Update `app/doc.go` to document accessor purpose, lifecycle semantics (pre-init/partial/post-init), and immutability guarantees.
+- [x] 4.2 Update `README.md` with a small bootstrap usage example showing read-only accessor reads and expected non-init behavior.
+- [x] 4.3 Update `docs/home.md` with the same accessor contract language used in `app/doc.go`/`README.md` to keep `/docs/*` guidance aligned.
+
+## Phase 5: Verification and closeout
+
+- [x] 5.1 Execute `go test ./...` and verify deterministic pass for new accessor lifecycle and immutability coverage.
+- [x] 5.2 Self-review task completion against `openspec/changes/issue-33-app-readonly-accessors/specs/app-bootstrap/spec.md` scenarios, then mark completed checklist items during implementation.

--- a/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/verify-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/verify-report.md
@@ -1,0 +1,109 @@
+# Verification Report
+
+**Change**: issue-33-app-readonly-accessors
+**Version**: N/A (delta spec)
+**Mode**: Standard
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 15 |
+| Tasks complete | 15 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/issue-33-app-readonly-accessors/tasks.md` are marked complete.
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed
+```text
+Command: go build ./...
+Output: (no output)
+Exit code: 0
+```
+
+**Tests**: ✅ Passed / ❌ 0 failed / ⚠️ 0 skipped
+```text
+Command: go test -count=1 ./...
+Result: PASS (all packages)
+
+Focused evidence for changed area:
+Command: go test -json -count=1 ./app
+Key passing tests:
+- TestAccessors_LifecycleMatrix
+- TestGetConfig_DefensiveSnapshotImmutability
+- TestAccessors_FailedConfigDrivenSecurityRemainsUnavailable
+- TestDocumentation_AccessorContractSynchronization
+```
+
+**Coverage**: 80.0% / threshold: 0% → ✅ Above threshold
+```text
+Command: go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out
+Total: 80.0%
+Changed package (`app`): 90.2%
+```
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Read-only application runtime accessors | Accessors expose runtime snapshots after bootstrap | `app/application_test.go > TestAccessors_LifecycleMatrix/post-init_with_direct_validator_exposes_both_config_and_security` (+ config-driven post-init variant) | ✅ COMPLIANT |
+| Read-only application runtime accessors | External mutation attempts do not alter internal runtime state | `app/application_test.go > TestGetConfig_DefensiveSnapshotImmutability` | ✅ COMPLIANT |
+| Deterministic accessor lifecycle semantics | Pre-init accessor behavior is explicit | `app/application_test.go > TestAccessors_LifecycleMatrix/pre-init_returns_explicit_non-ready_values` | ✅ COMPLIANT |
+| Deterministic accessor lifecycle semantics | Partial-init exposes only configured runtime state | `app/application_test.go > TestAccessors_LifecycleMatrix/partial-init_after_UseConfig_exposes_only_config` | ✅ COMPLIANT |
+| Deterministic accessor lifecycle semantics | Post-init exposes both runtime domains | `app/application_test.go > TestAccessors_LifecycleMatrix/post-init_with_direct_validator_exposes_both_config_and_security` (+ config-driven post-init variant) | ✅ COMPLIANT |
+| Accessor contract test acceptance | Lifecycle test matrix coverage | `app/application_test.go > TestAccessors_LifecycleMatrix` | ✅ COMPLIANT |
+| Accessor contract test acceptance | Immutability contract coverage | `app/application_test.go > TestGetConfig_DefensiveSnapshotImmutability` | ✅ COMPLIANT |
+| Documentation synchronization acceptance | Documentation reflects accessor contract | `app/application_test.go > TestDocumentation_AccessorContractSynchronization` | ✅ COMPLIANT |
+
+**Compliance summary**: 8/8 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Read-only application runtime accessors | ✅ Implemented | `GetConfig`, `GetSecurityValidator`, `IsSecurityReady` implemented in `app/application.go`; only config/security contracts are exposed. |
+| Deterministic accessor lifecycle semantics | ✅ Implemented | Pre-init/partial-init/post-init and failed config-driven wiring semantics are implemented and covered. |
+| Accessor contract test acceptance | ✅ Implemented | Automated lifecycle and immutability tests exist and pass in `app/application_test.go`. |
+| Documentation synchronization acceptance | ✅ Implemented | Executable docs contract test validates synchronized language/signatures across `app/doc.go`, `README.md`, and `docs/home.md`. |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| API shape: `GetConfig`, `GetSecurityValidator`, `IsSecurityReady` | ✅ Yes | Matches design contract exactly. |
+| Config immutability via deep-copy of mutable descendants | ✅ Yes | `cloneConfig`, `cloneOAuth2Providers`, `cloneStringSlice` enforce map/slice isolation. |
+| Deterministic lifecycle semantics (zero/nil/false before init) | ✅ Yes | Implemented and tested across lifecycle matrix cases. |
+| Planned file changes | ✅ Yes | `app/application.go`, `app/application_test.go`, `app/doc.go`, `README.md`, `docs/home.md` updated as designed. |
+| Framework-agnostic, boundary-safe contract | ✅ Yes | No framework runtime internals are exposed by the new public accessors. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+- None.
+
+**WARNING** (should fix):
+- None.
+
+**SUGGESTION** (nice to have):
+- Keep `TestDocumentation_AccessorContractSynchronization` assertions focused on stable contract markers to reduce false positives during future wording-only docs edits.
+
+---
+
+### Verdict
+PASS
+
+All spec scenarios are now backed by passing executable evidence, and tasks/design/spec/apply-progress are coherent.
+
+### Archive Readiness
+Ready for archive.

--- a/openspec/specs/app-bootstrap/spec.md
+++ b/openspec/specs/app-bootstrap/spec.md
@@ -111,6 +111,78 @@ The application bootstrap API MAY provide an optional helper that derives valida
 - THEN it returns a contextual error
 - AND no partial security wiring is applied
 
+### Requirement: Read-only application runtime accessors
+
+`app.Application` MUST provide public read-only accessors for (a) effective runtime config and (b) security runtime state used for protected routing. These accessors MUST NOT expose writable references to internal mutable runtime components.
+
+#### Scenario: Accessors expose runtime snapshots after bootstrap
+
+- GIVEN an `Application` configured through `UseConfig(...).UseServer().UseServerSecurity(...)`
+- WHEN the caller reads config and security runtime through the public accessors
+- THEN both accessors return initialized state that reflects the effective runtime wiring
+- AND returned data can be inspected without requiring internal package access
+
+#### Scenario: External mutation attempts do not alter internal runtime state
+
+- GIVEN a caller retrieved accessor outputs
+- WHEN the caller mutates the returned values or projections
+- THEN subsequent accessor reads still reflect the original internal runtime state
+- AND bootstrap/run behavior remains unchanged by external mutation attempts
+
+### Requirement: Deterministic accessor lifecycle semantics
+
+Accessor behavior MUST be deterministic across pre-init, partial-init, and post-init stages. For any uninitialized stage, accessors MUST signal "not available" in a documented way and MUST NOT panic.
+
+#### Scenario: Pre-init accessor behavior is explicit
+
+- GIVEN a new `Application` instance with no bootstrap methods invoked
+- WHEN config/security accessors are called
+- THEN each accessor reports uninitialized state according to the contract
+- AND no panic or implicit initialization occurs
+
+#### Scenario: Partial-init exposes only configured runtime state
+
+- GIVEN an `Application` where `UseConfig(...)` has run but security bootstrap has not completed
+- WHEN config/security accessors are called
+- THEN config accessor reports initialized state
+- AND security accessor reports uninitialized state without side effects
+
+#### Scenario: Post-init exposes both runtime domains
+
+- GIVEN an `Application` where bootstrap prerequisites are fully configured
+- WHEN config/security accessors are called
+- THEN both accessors report initialized state
+- AND results remain stable across repeated reads
+
+### Requirement: Accessor contract test acceptance
+
+The change MUST include automated tests that verify lifecycle semantics and immutability guarantees for the new accessors.
+
+#### Scenario: Lifecycle test matrix coverage
+
+- GIVEN automated tests for pre-init, partial-init, and post-init states
+- WHEN tests exercise accessor reads across valid method-order combinations
+- THEN expected availability/unavailability outcomes are asserted for each state
+- AND tests confirm deterministic behavior without panic
+
+#### Scenario: Immutability contract coverage
+
+- GIVEN automated tests that attempt to mutate accessor-returned values
+- WHEN mutation attempts are followed by additional reads and runtime checks
+- THEN internal runtime state remains unchanged
+- AND tests fail if mutable internals are leaked
+
+### Requirement: Documentation synchronization acceptance
+
+Docs MUST describe accessor lifecycle and immutability guarantees consistently across package docs and user-facing guides.
+
+#### Scenario: Documentation reflects accessor contract
+
+- GIVEN the change updates `app/doc.go`, `README.md`, and `docs/home.md`
+- WHEN a reader compares lifecycle and immutability statements across these docs
+- THEN terminology and behavior expectations are consistent
+- AND docs include pre-init and post-init usage expectations
+
 ## Out of Scope
 
 - Adding config provider abstractions (for example viper loader interfaces) beyond accepting `config.Config`.


### PR DESCRIPTION
Closes #33

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Exposes `Application` read-only runtime accessors for config and security validator state.
- Defines deterministic lifecycle behavior across pre-init/partial-init/post-init and failed security setup paths.
- Enforces config immutability via defensive cloning, adds comprehensive tests (including docs contract sync), and updates docs.

## Changes
| File | Change |
|------|--------|
| `app/application.go` | Added `GetConfig`, `GetSecurityValidator`, `IsSecurityReady`, and defensive clone helpers for mutable config internals. |
| `app/application_test.go` | Added lifecycle matrix, immutability coverage, failed setup state checks, and docs synchronization contract test. |
| `app/doc.go` | Documented accessor lifecycle semantics and immutability guarantees. |
| `README.md` | Added accessor usage and lifecycle/immutability contract notes. |
| `docs/home.md` | Added synchronized accessor contract section. |
| `openspec/specs/app-bootstrap/spec.md` | Merged archived delta requirements for app-bootstrap capability. |
| `openspec/changes/archive/2026-05-01-issue-33-app-readonly-accessors/*` | Archived full SDD artifact trail: exploration, proposal, spec, design, tasks, apply-progress, verify, archive report. |

## Test Plan
- [x] `go test ./...`
- [x] Accessor lifecycle behavior verified (pre-init, partial-init, post-init, failed setup).
- [x] Immutability behavior verified (map/slice defensive clone semantics).
- [x] Documentation synchronization acceptance verified via executable docs contract test.

## Checklist
- [x] Linked approved issue (`#33` has `status:approved`).
- [x] Exactly one `type:*` label will be set on PR.
- [x] Docs updated for behavior changes.
- [x] Conventional commit used.