### PR TITLE
feat(app): add opt-in health/readiness endpoint presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,112 @@ Behavior notes:
 - `RunListener(net.Listener)` is available for test-friendly startup flows.
 - `UseServerSecurityFromConfig()` is available as a thin convenience wrapper around config-driven JWT validator wiring (HS256/RS256).
 
+Health/readiness preset API (explicit opt-in):
+
+- `EnableHealthReadinessPresets(opts HealthReadinessOptions) error`
+
+```go
+package main
+
+import (
+	"errors"
+	"log"
+
+	"github.com/matiasmartin-labs/common-fwk/app"
+	"github.com/matiasmartin-labs/common-fwk/config"
+)
+
+func main() {
+	a := app.NewApplication().
+		UseConfig(config.NewConfig(
+			config.NewServerConfig("127.0.0.1", 8080),
+			config.NewSecurityConfig(config.NewAuthConfig(
+				config.NewJWTConfig("secret", "common-fwk", 15),
+				config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+				config.NewLoginConfig("admin@example.com"),
+				config.NewOAuth2Config(nil),
+			)),
+		)).
+		UseServer()
+
+	if err := a.EnableHealthReadinessPresets(app.HealthReadinessOptions{}); err != nil {
+		if errors.Is(err, app.ErrServerNotReady) {
+			log.Fatal("server bootstrap incomplete")
+		}
+		log.Fatal(err)
+	}
+
+	if err := a.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+Custom paths + synchronous checks:
+
+```go
+package main
+
+import (
+	"errors"
+	"log"
+
+	"github.com/matiasmartin-labs/common-fwk/app"
+	"github.com/matiasmartin-labs/common-fwk/config"
+)
+
+func main() {
+	a := app.NewApplication().
+		UseConfig(config.NewConfig(
+			config.NewServerConfig("127.0.0.1", 8080),
+			config.NewSecurityConfig(config.NewAuthConfig(
+				config.NewJWTConfig("secret", "common-fwk", 15),
+				config.NewCookieConfig("session", "example.com", true, true, "Lax"),
+				config.NewLoginConfig("admin@example.com"),
+				config.NewOAuth2Config(nil),
+			)),
+		)).
+		UseServer()
+
+	err := a.EnableHealthReadinessPresets(app.HealthReadinessOptions{
+		HealthPath: "/livez",
+		ReadyPath:  "/readyz/internal",
+		Checks: []app.ReadinessCheck{
+			func() error { return nil },
+			func() error {
+				if false {
+					return errors.New("dependency not ready")
+				}
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		if errors.Is(err, app.ErrRouteConflict) {
+			log.Fatal("preset route conflicts with existing GET route")
+		}
+		if errors.Is(err, app.ErrInvalidPresetOptions) {
+			log.Fatal("invalid health/readiness options")
+		}
+		log.Fatal(err)
+	}
+
+	if err := a.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+Readiness semantics:
+- `/healthz` (or custom `HealthPath`) always returns `200` once presets are enabled.
+- `/readyz` (or custom `ReadyPath`) returns `200` only when bootstrap invariants and all checks pass.
+- Readiness returns `503` when invariants are unmet or any check fails.
+- Presets are never auto-registered by `UseServer()`; default paths are not duplicated when custom paths are configured.
+
+Health/readiness non-goals:
+- No implicit preset registration during bootstrap.
+- No provider-specific probing in framework internals; dependency readiness checks are caller-provided.
+
 Read-only runtime accessors:
 
 ```go

--- a/app/application.go
+++ b/app/application.go
@@ -16,12 +16,39 @@ import (
 )
 
 var (
-	ErrServerNotReady   = errors.New("server not ready")
-	ErrSecurityNotReady = errors.New("security not ready")
-	ErrInvalidPath      = errors.New("invalid path")
-	ErrNilHandler       = errors.New("nil handler")
-	ErrNilListener      = errors.New("nil listener")
+	ErrServerNotReady       = errors.New("server not ready")
+	ErrSecurityNotReady     = errors.New("security not ready")
+	ErrInvalidPath          = errors.New("invalid path")
+	ErrNilHandler           = errors.New("nil handler")
+	ErrNilListener          = errors.New("nil listener")
+	ErrRouteConflict        = errors.New("route conflict")
+	ErrInvalidPresetOptions = errors.New("invalid preset options")
 )
+
+const (
+	defaultHealthPath = "/healthz"
+	defaultReadyPath  = "/readyz"
+)
+
+// ReadinessCheck is a synchronous readiness probe.
+//
+// Returning nil means the check passed. Returning an error marks the
+// application as not-ready for the current request.
+type ReadinessCheck func() error
+
+// HealthReadinessOptions configures health/readiness preset registration.
+type HealthReadinessOptions struct {
+	// HealthPath overrides the health endpoint path.
+	//
+	// Defaults to "/healthz" when omitted.
+	HealthPath string
+	// ReadyPath overrides the readiness endpoint path.
+	//
+	// Defaults to "/readyz" when omitted.
+	ReadyPath string
+	// Checks are evaluated synchronously in order for each readiness request.
+	Checks []ReadinessCheck
+}
 
 // Application is an instance-scoped bootstrap container.
 type Application struct {
@@ -166,6 +193,110 @@ func validateHandler(h gin.HandlerFunc) error {
 	if h == nil {
 		return ErrNilHandler
 	}
+
+	return nil
+}
+
+func resolveHealthReadinessOptions(opts HealthReadinessOptions) (HealthReadinessOptions, error) {
+	resolved := HealthReadinessOptions{
+		HealthPath: defaultHealthPath,
+		ReadyPath:  defaultReadyPath,
+		Checks:     opts.Checks,
+	}
+
+	if opts.HealthPath != "" {
+		if strings.TrimSpace(opts.HealthPath) == "" {
+			return HealthReadinessOptions{}, fmt.Errorf("health path is blank: %w", ErrInvalidPresetOptions)
+		}
+		resolved.HealthPath = opts.HealthPath
+	}
+
+	if opts.ReadyPath != "" {
+		if strings.TrimSpace(opts.ReadyPath) == "" {
+			return HealthReadinessOptions{}, fmt.Errorf("ready path is blank: %w", ErrInvalidPresetOptions)
+		}
+		resolved.ReadyPath = opts.ReadyPath
+	}
+
+	if resolved.HealthPath == resolved.ReadyPath {
+		return HealthReadinessOptions{}, fmt.Errorf(
+			"health and readiness paths must differ: %w",
+			ErrInvalidPresetOptions,
+		)
+	}
+
+	return resolved, nil
+}
+
+func hasGETRoute(routes gin.RoutesInfo, path string) bool {
+	for _, route := range routes {
+		if route.Method == http.MethodGet && route.Path == path {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (a *Application) ensureNoPresetRouteConflict(paths ...string) error {
+	routes := a.handler.Routes()
+	for _, path := range paths {
+		if hasGETRoute(routes, path) {
+			return fmt.Errorf("method=%s path=%q: %w", http.MethodGet, path, ErrRouteConflict)
+		}
+	}
+
+	return nil
+}
+
+func (a *Application) readinessInvariantSatisfied() bool {
+	return a.serverReady && a.handler != nil && a.server.Handler != nil
+}
+
+func (a *Application) readinessStatus(checks []ReadinessCheck) int {
+	if !a.readinessInvariantSatisfied() {
+		return http.StatusServiceUnavailable
+	}
+
+	for _, check := range checks {
+		if check == nil {
+			return http.StatusServiceUnavailable
+		}
+
+		if err := check(); err != nil {
+			return http.StatusServiceUnavailable
+		}
+	}
+
+	return http.StatusOK
+}
+
+// EnableHealthReadinessPresets registers health/readiness handlers explicitly.
+//
+// The method is opt-in and never runs implicitly from UseServer. It requires a
+// ready server bootstrap and fails when requested paths are invalid or conflict
+// with already registered GET routes.
+func (a *Application) EnableHealthReadinessPresets(opts HealthReadinessOptions) error {
+	if err := a.ensureServerReady(); err != nil {
+		return err
+	}
+
+	resolvedOpts, err := resolveHealthReadinessOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	if err := a.ensureNoPresetRouteConflict(resolvedOpts.HealthPath, resolvedOpts.ReadyPath); err != nil {
+		return err
+	}
+
+	a.handler.GET(resolvedOpts.HealthPath, func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	a.handler.GET(resolvedOpts.ReadyPath, func(c *gin.Context) {
+		c.Status(a.readinessStatus(resolvedOpts.Checks))
+	})
 
 	return nil
 }

--- a/app/application_test.go
+++ b/app/application_test.go
@@ -287,6 +287,230 @@ func TestOrderingGuards_ReturnExpectedErrors(t *testing.T) {
 	})
 }
 
+func TestEnableHealthReadinessPresets_OptionsAndOrdering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fails before server bootstrap", func(t *testing.T) {
+		a := NewApplication()
+
+		err := a.EnableHealthReadinessPresets(HealthReadinessOptions{})
+		if !errors.Is(err, ErrServerNotReady) {
+			t.Fatalf("expected ErrServerNotReady, got %v", err)
+		}
+	})
+
+	tests := []struct {
+		name    string
+		opts    HealthReadinessOptions
+		wantErr error
+	}{
+		{
+			name:    "blank health path rejected",
+			opts:    HealthReadinessOptions{HealthPath: "   "},
+			wantErr: ErrInvalidPresetOptions,
+		},
+		{
+			name:    "blank ready path rejected",
+			opts:    HealthReadinessOptions{ReadyPath: "\t"},
+			wantErr: ErrInvalidPresetOptions,
+		},
+		{
+			name:    "same path rejected after defaults resolution",
+			opts:    HealthReadinessOptions{HealthPath: "/same", ReadyPath: "/same"},
+			wantErr: ErrInvalidPresetOptions,
+		},
+		{
+			name: "defaults are accepted",
+			opts: HealthReadinessOptions{},
+		},
+		{
+			name: "custom paths are accepted",
+			opts: HealthReadinessOptions{HealthPath: "/live", ReadyPath: "/ready"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewApplication().UseConfig(testConfig()).UseServer()
+
+			err := a.EnableHealthReadinessPresets(tc.opts)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnableHealthReadinessPresets_ConflictPreflightAndNoPartialRegistration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("health conflict fails and does not install readiness", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig()).UseServer()
+
+		if err := a.RegisterGET("/healthz", func(c *gin.Context) { c.Status(http.StatusAccepted) }); err != nil {
+			t.Fatalf("register conflicting route: %v", err)
+		}
+
+		err := a.EnableHealthReadinessPresets(HealthReadinessOptions{ReadyPath: "/readyz-alt"})
+		if !errors.Is(err, ErrRouteConflict) {
+			t.Fatalf("expected ErrRouteConflict, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "method=GET") || !strings.Contains(err.Error(), "path=\"/healthz\"") {
+			t.Fatalf("expected error context with method/path, got %q", err.Error())
+		}
+
+		wExisting := httptest.NewRecorder()
+		a.handler.ServeHTTP(wExisting, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+		if wExisting.Code != http.StatusAccepted {
+			t.Fatalf("existing route should remain unchanged, got %d", wExisting.Code)
+		}
+
+		wReady := httptest.NewRecorder()
+		a.handler.ServeHTTP(wReady, httptest.NewRequest(http.MethodGet, "/readyz-alt", nil))
+		if wReady.Code != http.StatusNotFound {
+			t.Fatalf("ready route must not be partially registered, got %d", wReady.Code)
+		}
+	})
+
+	t.Run("ready conflict fails", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig()).UseServer()
+
+		if err := a.RegisterGET("/readyz", func(c *gin.Context) { c.Status(http.StatusAccepted) }); err != nil {
+			t.Fatalf("register conflicting route: %v", err)
+		}
+
+		err := a.EnableHealthReadinessPresets(HealthReadinessOptions{})
+		if !errors.Is(err, ErrRouteConflict) {
+			t.Fatalf("expected ErrRouteConflict, got %v", err)
+		}
+	})
+}
+
+func TestEnableHealthReadinessPresets_HTTPBehavior_DefaultAndCustomPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default paths with readiness pass and fail", func(t *testing.T) {
+		pass := func() error { return nil }
+		fail := func() error { return errors.New("dependency down") }
+
+		aPass := NewApplication().UseConfig(testConfig()).UseServer()
+		if err := aPass.EnableHealthReadinessPresets(HealthReadinessOptions{Checks: []ReadinessCheck{pass, pass}}); err != nil {
+			t.Fatalf("enable presets (pass): %v", err)
+		}
+
+		wHealth := httptest.NewRecorder()
+		aPass.handler.ServeHTTP(wHealth, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+		if wHealth.Code != http.StatusOK {
+			t.Fatalf("/healthz expected 200 got %d", wHealth.Code)
+		}
+
+		wReadyPass := httptest.NewRecorder()
+		aPass.handler.ServeHTTP(wReadyPass, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+		if wReadyPass.Code != http.StatusOK {
+			t.Fatalf("/readyz expected 200 when checks pass got %d", wReadyPass.Code)
+		}
+
+		aFail := NewApplication().UseConfig(testConfig()).UseServer()
+		if err := aFail.EnableHealthReadinessPresets(HealthReadinessOptions{Checks: []ReadinessCheck{pass, fail}}); err != nil {
+			t.Fatalf("enable presets (fail): %v", err)
+		}
+
+		wReadyFail := httptest.NewRecorder()
+		aFail.handler.ServeHTTP(wReadyFail, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+		if wReadyFail.Code != http.StatusServiceUnavailable {
+			t.Fatalf("/readyz expected 503 when a check fails got %d", wReadyFail.Code)
+		}
+	})
+
+	t.Run("custom paths are honored and defaults not duplicated", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig()).UseServer()
+		err := a.EnableHealthReadinessPresets(HealthReadinessOptions{
+			HealthPath: "/livez",
+			ReadyPath:  "/readyz-custom",
+			Checks: []ReadinessCheck{
+				func() error { return nil },
+			},
+		})
+		if err != nil {
+			t.Fatalf("enable custom presets: %v", err)
+		}
+
+		wCustomHealth := httptest.NewRecorder()
+		a.handler.ServeHTTP(wCustomHealth, httptest.NewRequest(http.MethodGet, "/livez", nil))
+		if wCustomHealth.Code != http.StatusOK {
+			t.Fatalf("custom health expected 200 got %d", wCustomHealth.Code)
+		}
+
+		wCustomReady := httptest.NewRecorder()
+		a.handler.ServeHTTP(wCustomReady, httptest.NewRequest(http.MethodGet, "/readyz-custom", nil))
+		if wCustomReady.Code != http.StatusOK {
+			t.Fatalf("custom ready expected 200 got %d", wCustomReady.Code)
+		}
+
+		wDefaultHealth := httptest.NewRecorder()
+		a.handler.ServeHTTP(wDefaultHealth, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+		if wDefaultHealth.Code != http.StatusNotFound {
+			t.Fatalf("default health path should not be duplicated, got %d", wDefaultHealth.Code)
+		}
+
+		wDefaultReady := httptest.NewRecorder()
+		a.handler.ServeHTTP(wDefaultReady, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+		if wDefaultReady.Code != http.StatusNotFound {
+			t.Fatalf("default ready path should not be duplicated, got %d", wDefaultReady.Code)
+		}
+	})
+
+	t.Run("unmet invariant returns 503", func(t *testing.T) {
+		a := NewApplication().UseConfig(testConfig()).UseServer()
+		if err := a.EnableHealthReadinessPresets(HealthReadinessOptions{}); err != nil {
+			t.Fatalf("enable presets: %v", err)
+		}
+
+		a.server.Handler = nil
+
+		wReady := httptest.NewRecorder()
+		a.handler.ServeHTTP(wReady, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+		if wReady.Code != http.StatusServiceUnavailable {
+			t.Fatalf("/readyz expected 503 when invariant is unmet got %d", wReady.Code)
+		}
+	})
+}
+
+func TestManualRouteRegistration_UnchangedWithoutPresets(t *testing.T) {
+	t.Parallel()
+
+	a := NewApplication().UseConfig(testConfig()).UseServer()
+	if err := a.RegisterGET("/health", func(c *gin.Context) { c.Status(http.StatusNoContent) }); err != nil {
+		t.Fatalf("register manual route: %v", err)
+	}
+
+	wManual := httptest.NewRecorder()
+	a.handler.ServeHTTP(wManual, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if wManual.Code != http.StatusNoContent {
+		t.Fatalf("manual route expected 204 got %d", wManual.Code)
+	}
+
+	wPresetHealth := httptest.NewRecorder()
+	a.handler.ServeHTTP(wPresetHealth, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if wPresetHealth.Code != http.StatusNotFound {
+		t.Fatalf("/healthz should not exist without explicit preset opt-in, got %d", wPresetHealth.Code)
+	}
+
+	wPresetReady := httptest.NewRecorder()
+	a.handler.ServeHTTP(wPresetReady, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if wPresetReady.Code != http.StatusNotFound {
+		t.Fatalf("/readyz should not exist without explicit preset opt-in, got %d", wPresetReady.Code)
+	}
+}
+
 func TestRunListener_ServesRequestAndStopsCleanly(t *testing.T) {
 	a := NewApplication().UseConfig(testConfig()).UseServer()
 	if err := a.RegisterGET("/health", func(c *gin.Context) { c.String(http.StatusOK, "ok") }); err != nil {
@@ -461,11 +685,11 @@ func TestAccessors_LifecycleMatrix(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		bootstrap      func(*Application)
-		wantConfig     config.Config
-		wantValidator  bool
-		wantSecReady   bool
+		name          string
+		bootstrap     func(*Application)
+		wantConfig    config.Config
+		wantValidator bool
+		wantSecReady  bool
 	}{
 		{
 			name:          "pre-init returns explicit non-ready values",
@@ -479,18 +703,18 @@ func TestAccessors_LifecycleMatrix(t *testing.T) {
 			bootstrap: func(a *Application) {
 				a.UseConfig(testConfigWithOAuth2Provider())
 			},
-			wantConfig:     testConfigWithOAuth2Provider(),
-			wantValidator:  false,
-			wantSecReady:   false,
+			wantConfig:    testConfigWithOAuth2Provider(),
+			wantValidator: false,
+			wantSecReady:  false,
 		},
 		{
 			name: "post-init with direct validator exposes both config and security",
 			bootstrap: func(a *Application) {
 				a.UseConfig(testConfigWithOAuth2Provider()).UseServerSecurity(&fakeValidator{})
 			},
-			wantConfig:     testConfigWithOAuth2Provider(),
-			wantValidator:  true,
-			wantSecReady:   true,
+			wantConfig:    testConfigWithOAuth2Provider(),
+			wantValidator: true,
+			wantSecReady:  true,
 		},
 		{
 			name: "post-init with config-driven security exposes both config and security",
@@ -501,9 +725,9 @@ func TestAccessors_LifecycleMatrix(t *testing.T) {
 					t.Fatalf("expected config-driven security wiring success, got %v", err)
 				}
 			},
-			wantConfig:     testConfigWithOAuth2Provider(),
-			wantValidator:  true,
-			wantSecReady:   true,
+			wantConfig:    testConfigWithOAuth2Provider(),
+			wantValidator: true,
+			wantSecReady:  true,
 		},
 	}
 
@@ -672,6 +896,65 @@ func TestDocumentation_AccessorContractSynchronization(t *testing.T) {
 			hasMutationSafetyWording := strings.Contains(lower, "internal runtime state") || strings.Contains(lower, "app internals")
 			if !hasMutationSafetyWording {
 				t.Fatalf("%s must document that external mutation does not affect internals", doc.name)
+			}
+		})
+	}
+}
+
+func TestDocumentation_HealthReadinessPresetContractSynchronization(t *testing.T) {
+	t.Parallel()
+
+	type docSpec struct {
+		name string
+		path string
+	}
+
+	docs := []docSpec{
+		{name: "package docs", path: "doc.go"},
+		{name: "readme", path: "../README.md"},
+		{name: "docs home", path: "../docs/home.md"},
+	}
+
+	for _, doc := range docs {
+		doc := doc
+		t.Run(doc.name, func(t *testing.T) {
+			raw, err := os.ReadFile(doc.path)
+			if err != nil {
+				t.Fatalf("read %s (%s): %v", doc.name, doc.path, err)
+			}
+
+			text := string(raw)
+			lower := strings.ToLower(text)
+
+			if !strings.Contains(text, "EnableHealthReadinessPresets(opts HealthReadinessOptions) error") {
+				t.Fatalf("%s must include explicit preset API signature", doc.name)
+			}
+
+			if !strings.Contains(text, "/healthz") || !strings.Contains(text, "/readyz") {
+				t.Fatalf("%s must document default preset paths /healthz and /readyz", doc.name)
+			}
+
+			hasCustomPathBehavior := strings.Contains(lower, "custom") &&
+				(strings.Contains(lower, "not duplicated") || strings.Contains(lower, "no implicit duplication"))
+			if !hasCustomPathBehavior {
+				t.Fatalf("%s must document custom-path behavior without implicit default duplication", doc.name)
+			}
+
+			hasReadinessSemantics := strings.Contains(lower, "readiness") &&
+				strings.Contains(lower, "200") &&
+				strings.Contains(lower, "503")
+			if !hasReadinessSemantics {
+				t.Fatalf("%s must document readiness 200/503 contract", doc.name)
+			}
+
+			hasNoImplicitRegistration := strings.Contains(lower, "no implicit") || strings.Contains(lower, "never auto-registered")
+			if !hasNoImplicitRegistration {
+				t.Fatalf("%s must document non-goal: no implicit preset registration", doc.name)
+			}
+
+			hasNoProviderProbing := strings.Contains(lower, "no provider-specific") || strings.Contains(lower, "provider-specific probing")
+			if !hasNoProviderProbing {
+				t.Fatalf("%s must document non-goal: no provider-specific probing", doc.name)
 			}
 		})
 	}

--- a/app/doc.go
+++ b/app/doc.go
@@ -18,4 +18,21 @@
 // GetConfig returns a defensive snapshot. Mutable descendants like
 // OAuth2.Providers maps and provider Scopes slices are deep-copied on each call,
 // so external mutation attempts do not alter internal runtime state.
+//
+// Health/readiness presets (explicit opt-in):
+//
+//	EnableHealthReadinessPresets(opts HealthReadinessOptions) error
+//
+// Preset behavior is additive and explicit:
+//   - `UseServer()` does not auto-register `/healthz` or `/readyz`.
+//   - Calling `EnableHealthReadinessPresets(...)` after server bootstrap registers
+//     defaults (`/healthz`, `/readyz`) unless per-endpoint paths are overridden.
+//   - Custom-path registration has no implicit duplication of default paths.
+//   - Health endpoint always returns `200` once registered.
+//   - Readiness endpoint returns `200` only when bootstrap invariants hold and all
+//     configured checks pass; otherwise it returns `503`.
+//
+// Non-goals:
+//   - No implicit route registration during bootstrap.
+//   - No provider-specific dependency probing in framework internals.
 package app

--- a/docs/home.md
+++ b/docs/home.md
@@ -57,3 +57,24 @@ Lifecycle semantics are explicit and deterministic:
 Immutability guarantee:
 - `GetConfig()` returns a defensive snapshot with deep copies of mutable descendants (`OAuth2.Providers` and provider `Scopes`).
 - External mutations to returned values do not alter internal runtime state.
+
+## Health/readiness preset operational behavior
+
+`app.Application` exposes explicit opt-in preset registration via:
+
+- `EnableHealthReadinessPresets(opts HealthReadinessOptions) error`
+
+Contract summary:
+- Default paths are `/healthz` and `/readyz` when overrides are not provided.
+- Custom paths are honored per endpoint (`HealthPath`, `ReadyPath`) with no implicit duplication of defaults.
+- Health endpoint returns `200` once presets are enabled.
+- Readiness endpoint returns `200` only when bootstrap invariants pass and all readiness checks return `nil`; otherwise `503`.
+
+Ordering and conflict behavior:
+- Calling preset registration before `UseServer()` returns `ErrServerNotReady`.
+- Blank paths or duplicated health/ready path values return `ErrInvalidPresetOptions`.
+- Conflicts with already registered GET routes return `ErrRouteConflict` and no partial preset registration is applied.
+
+Non-goals:
+- No implicit health/readiness route registration during bootstrap (`UseServer()` remains side-effect free for presets).
+- No provider-specific probing in framework internals; dependency readiness checks are caller-provided.

--- a/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/apply-progress.md
+++ b/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/apply-progress.md
@@ -1,0 +1,52 @@
+# Apply Progress: issue-31-health-readiness-presets
+
+## Implementation Progress
+
+**Change**: issue-31-health-readiness-presets  
+**Mode**: Standard
+
+### Completed Tasks
+- [x] 1.1 In `app/application.go`, add `ReadinessCheck`, `HealthReadinessOptions`, and sentinel errors `ErrRouteConflict`/`ErrInvalidPresetOptions` with doc comments.
+- [x] 1.2 Implement option resolution + validation in `app/application.go` (default `/healthz` and `/readyz`, reject blank paths, reject same health/ready path).
+- [x] 1.3 Add ordering guard in `EnableHealthReadinessPresets` to return `ErrServerNotReady` if `UseServer()` has not completed.
+- [x] 2.1 Implement `EnableHealthReadinessPresets(opts HealthReadinessOptions) error` in `app/application.go` with explicit opt-in only (no `UseServer()` auto-registration side effects).
+- [x] 2.2 Add preflight GET-route conflict detection in `app/application.go` against registered routes; return wrapped `ErrRouteConflict` with method/path context.
+- [x] 2.3 Register health handler in `app/application.go` at resolved `HealthPath` that always returns HTTP 200 once presets are enabled.
+- [x] 2.4 Register readiness handler in `app/application.go` at resolved `ReadyPath`; evaluate baseline bootstrap invariants + `Checks` synchronously in order and return 200 only when all pass, otherwise 503.
+- [x] 3.1 In `app/application_test.go`, add table-driven `t.Run` tests for options/defaults/validation and assert `errors.Is` for `ErrInvalidPresetOptions` and `ErrServerNotReady`.
+- [x] 3.2 In `app/application_test.go`, add conflict tests that pre-register colliding GET paths and verify deterministic `ErrRouteConflict` with no partial preset registration.
+- [x] 3.3 In `app/application_test.go`, add `httptest` coverage for default and custom paths (`/healthz`/`/readyz` and overrides) including readiness 200 (all checks pass) and 503 (failed check or unmet invariant).
+- [x] 3.4 Add non-regression tests in `app/application_test.go` confirming existing manual route registration flows remain unchanged when presets are not enabled.
+- [x] 3.5 Run verification commands: `go test ./...`, `go test -race ./app`, and `go build ./...`; resolve failures before marking implementation complete.
+- [x] 3.6 Add explicit automated documentation synchronization evidence in `app/application_test.go` for health/readiness preset contract + non-goals coverage across `app/doc.go`, `README.md`, and `docs/home.md`.
+- [x] 4.1 Update `app/doc.go` with API usage, explicit opt-in requirement, readiness semantics (200/503), and non-goals (no implicit registration, no provider probing).
+- [x] 4.2 Update `README.md` with a buildable `package main` example for default preset paths and a second example with custom path overrides and checks.
+- [x] 4.3 Update `docs/home.md` with operational behavior for health/readiness endpoints, including default paths and custom-path behavior without implicit duplication.
+
+### Files Changed
+| File | Action | What Was Done |
+|---|---|---|
+| `app/application.go` | Modified | Added new preset API contract/types, options resolution/validation, conflict preflight helpers, readiness evaluation, and endpoint registration logic. |
+| `app/application_test.go` | Modified | Added table-driven and integration-style tests for ordering, validation, conflicts, readiness status contract, custom/default paths, and non-regression behavior. |
+| `app/doc.go` | Modified | Documented explicit opt-in preset API, readiness semantics, non-goals, and custom-path no-duplication wording used by docs sync tests. |
+| `README.md` | Modified | Added explicit preset API signature line and explicit non-goals wording alongside existing preset examples/semantics. |
+| `docs/home.md` | Modified | Added operations-focused health/readiness preset contract summary and error behavior. |
+| `openspec/changes/issue-31-health-readiness-presets/tasks.md` | Modified | Marked all tasks complete (`[x]`) and added task 3.6 for docs synchronization automated evidence. |
+| `openspec/changes/issue-31-health-readiness-presets/apply-progress.md` | Modified | Merged prior apply progress with this batch and captured verification rerun status. |
+
+### Verification Commands
+- `go test ./...` ✅
+- `go test -race ./app` ✅
+- `go build ./...` ✅
+
+### Deviations from Design
+None — implementation matches design.
+
+### Issues Found
+- Verify CRITICAL gap addressed: added `TestDocumentation_HealthReadinessPresetContractSynchronization` to provide explicit automated evidence for documentation contract/non-goals coverage.
+
+### Remaining Tasks
+None.
+
+### Status
+16/16 tasks complete. Ready for verify.

--- a/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/archive-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/archive-report.md
@@ -1,0 +1,56 @@
+# Archive Report: issue-31-health-readiness-presets
+
+## Summary
+
+- Verification status: **PASS** (no CRITICAL/WARNING/SUGGESTION issues)
+- Archive mode: **hybrid**
+- Archive date: **2026-05-01**
+- Result: Delta specs synced to main specs, then change moved to archived changes.
+
+## Dependency Traceability
+
+### Engram dependencies (full content retrieved)
+
+| Artifact | Topic Key | Observation ID |
+|---|---|---:|
+| Explore | `sdd/issue-31-health-readiness-presets/explore` | 464 |
+| Proposal | `sdd/issue-31-health-readiness-presets/proposal` | 465 |
+| Spec | `sdd/issue-31-health-readiness-presets/spec` | 466 |
+| Design | `sdd/issue-31-health-readiness-presets/design` | 468 |
+| Tasks | `sdd/issue-31-health-readiness-presets/tasks` | 469 |
+| Apply Progress | `sdd/issue-31-health-readiness-presets/apply-progress` | 473 |
+| Verify Report | `sdd/issue-31-health-readiness-presets/verify-report` | 474 |
+
+### OpenSpec dependencies read
+
+- `openspec/config.yaml`
+- `openspec/changes/issue-31-health-readiness-presets/proposal.md`
+- `openspec/changes/issue-31-health-readiness-presets/specs/app-health-readiness-presets/spec.md`
+- `openspec/changes/issue-31-health-readiness-presets/design.md`
+- `openspec/changes/issue-31-health-readiness-presets/tasks.md`
+- `openspec/changes/issue-31-health-readiness-presets/apply-progress.md`
+- `openspec/changes/issue-31-health-readiness-presets/verify-report.md`
+
+## Spec Sync Actions
+
+| Domain | Delta Source | Main Target | Action | Details |
+|---|---|---|---|---|
+| `app-health-readiness-presets` | `openspec/changes/issue-31-health-readiness-presets/specs/app-health-readiness-presets/spec.md` | `openspec/specs/app-health-readiness-presets/spec.md` | **Created** | Main spec did not exist; copied full delta spec as initial source of truth (5 ADDED requirements, 7 scenarios). |
+
+## Archive Move
+
+- Source: `openspec/changes/issue-31-health-readiness-presets/`
+- Destination: `openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/`
+- Method: directory move preserving all artifacts as audit trail
+
+## Post-Archive Verification
+
+- [x] Main specs updated correctly
+- [x] Change folder moved to archive
+- [x] Archive contains proposal/specs/design/tasks/apply-progress/verify-report/archive-report
+- [x] Active changes no longer contains `issue-31-health-readiness-presets`
+
+## Notes
+
+- `openspec/config.yaml` has no `rules.archive` overrides; default archive behavior applied.
+- This change is fully closed in SDD lifecycle: explore → proposal → spec → design → tasks → apply → verify → archive.

--- a/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/design.md
+++ b/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/design.md
@@ -1,0 +1,111 @@
+# Design: Health/Readiness Presets for App Bootstrap
+
+## Technical Approach
+
+Add an explicit preset registration API on `app.Application` that is called after `UseServer()`. The API registers two GET endpoints with defaults (`/healthz`, `/readyz`), supports per-endpoint path overrides, and evaluates readiness synchronously from bootstrap invariants plus optional caller-provided checks. The implementation stays additive: existing `RegisterGET`/`RegisterPOST`/`RegisterProtectedGET` flows remain unchanged.
+
+## Architecture Decisions
+
+### Decision: Explicit opt-in preset method on `Application`
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Auto-register in `UseServer()` | Less code for consumers, but implicit behavior and surprise route collisions | ❌ |
+| Explicit `EnableHealthReadinessPresets(...)` | Slightly more API surface, but deterministic and aligned with current bootstrap style | ✅ |
+
+Rationale: Preserves current explicit bootstrap contract and non-goal of hidden framework behavior.
+
+### Decision: Readiness contract = bootstrap invariant + sync checks
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Framework probes dependencies (DB/cloud/provider) | Richer defaults, but provider coupling and boundary violation | ❌ |
+| Internal invariant + caller checks (`[]ReadinessCheck`) | Consumer responsibility, but framework remains provider-agnostic | ✅ |
+
+Rationale: Keeps `security/*` and `app` free of provider logic while still supporting real readiness.
+
+### Decision: Preflight route conflict checks before registration
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Let Gin panic on duplicates | Minimal code, non-deterministic failure mode for consumers | ❌ |
+| Pre-check existing routes and return typed error | Small upfront check, deterministic error model and testability | ✅ |
+
+Rationale: Change requires explicit conflict behavior; API must return errors, not crash process.
+
+## Data Flow
+
+```text
+Caller bootstrap
+  UseConfig -> UseServer -> (optional UseServerSecurity)
+                  |
+                  v
+EnableHealthReadinessPresets(options)
+  1) ensureServerReady
+  2) resolve defaults/overrides
+  3) validate distinct non-empty paths
+  4) preflight conflict scan against existing GET routes
+  5) register GET health and ready handlers
+
+Request /healthz(or override) -> 200
+Request /readyz(or override)
+  -> evaluate baseline invariant
+  -> run checks in order (sync)
+  -> 200 if all pass, else 503
+```
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `app/application.go` | Modify | Add options/check types, preset registration method, conflict detection helper, readiness evaluator, new sentinel errors. |
+| `app/application_test.go` | Modify | Add table-driven tests for default/custom paths, readiness 200/503 behavior, ordering guard, and route conflict errors. |
+| `app/doc.go` | Modify | Document API signatures and readiness semantics/non-goals. |
+| `README.md` | Modify | Add buildable `package main` usage snippet for defaults and custom paths. |
+| `docs/home.md` | Modify | Add operational contract summary for `/healthz` and `/readyz`. |
+
+## Interfaces / Contracts
+
+```go
+// app/application.go
+var (
+    ErrRouteConflict         = errors.New("route conflict")
+    ErrInvalidPresetOptions  = errors.New("invalid preset options")
+)
+
+type ReadinessCheck func() error
+
+type HealthReadinessOptions struct {
+    HealthPath string // default: "/healthz"
+    ReadyPath  string // default: "/readyz"
+    Checks     []ReadinessCheck
+}
+
+func (a *Application) EnableHealthReadinessPresets(opts HealthReadinessOptions) error
+```
+
+Contract details:
+- `EnableHealthReadinessPresets` MUST return `ErrServerNotReady` if called before `UseServer()`.
+- Empty/blank paths are invalid (`ErrInvalidPresetOptions`).
+- Duplicate target paths (`HealthPath == ReadyPath`) are invalid (`ErrInvalidPresetOptions`).
+- Existing GET route collisions return `ErrRouteConflict` wrapped with method/path context.
+- `/healthz` handler always returns `200` once registered.
+- `/readyz` returns `200` only when baseline invariant passes and all checks return `nil`; otherwise `503`.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Unit | Options defaults + validation | Table tests for empty/custom/same-path inputs and expected sentinel errors. |
+| Unit | Conflict detection | Register existing GET route, then assert `errors.Is(err, ErrRouteConflict)` from preset call. |
+| Integration | Endpoints and status behavior | `httptest` requests against defaults and overrides; assert `/healthz` 200 and `/readyz` 200/503 via deterministic checks. |
+| Integration | Ordering guard | Call preset before `UseServer()` and assert `ErrServerNotReady`. |
+| Integration | Non-regression | Existing manual route registration tests continue unchanged to guarantee additive behavior. |
+
+## Migration / Rollout
+
+No migration required. Rollout is opt-in and additive: existing services keep manual health routes; new behavior activates only when `EnableHealthReadinessPresets(...)` is called. Documentation ships in the same change to standardize semantics.
+
+## Open Questions
+
+- [ ] Should readiness failure responses include structured JSON reason codes or stay status-only to avoid leaking dependency details?

--- a/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/exploration.md
+++ b/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/exploration.md
@@ -1,0 +1,54 @@
+## Exploration: issue-31-health-readiness-presets
+
+### Current State
+`app.Application` already provides explicit bootstrap state (`serverReady`, `securityReady`) and deterministic registration guards (`ErrServerNotReady`, `ErrSecurityNotReady`). Route registration is currently manual via `RegisterGET`, `RegisterPOST`, and `RegisterProtectedGET`; there are no built-in `/healthz` or `/readyz` presets. Existing docs/examples show manual health route registration (README uses `/health`), and no `/docs/*` page currently defines health/readiness semantics.
+
+The codebase is well-positioned for this change because:
+- endpoint wiring belongs in `app` (bootstrap boundary),
+- readiness-relevant state already exists,
+- tests in `app/application_test.go` already validate order guards and route behavior patterns.
+
+### Affected Areas
+- `app/application.go` — add opt-in preset API, path override support, and readiness evaluation semantics.
+- `app/application_test.go` — add tests for default endpoints, custom paths, and ready/not-ready behavior.
+- `app/doc.go` — document the new preset API and readiness contract for package-level docs.
+- `README.md` — add usage examples for enabling presets and overriding paths.
+- `docs/home.md` (and/or another `docs/*` page) — document health/readiness semantics and operational expectations.
+- `openspec/specs/app-bootstrap/spec.md` — likely needs a new requirement/scenarios for preset endpoint behavior.
+
+### Approaches
+1. **Fixed-state presets (bootstrap-only readiness)** — add an opt-in method that registers `/healthz` + `/readyz` and computes readiness from internal app state only.
+   - Pros: Smallest implementation delta; deterministic; easy to test.
+   - Cons: Weak dependency semantics; `readyz` can become mostly equivalent to "bootstrap completed" and may not represent downstream dependency health.
+   - Effort: Low.
+
+2. **Preset API with pluggable readiness checks (recommended)** — add opt-in preset registration with defaults (`/healthz`, `/readyz`) plus path overrides and optional readiness check callbacks. `readyz` returns 200 only when bootstrap state is valid and all checks pass; otherwise 503.
+   - Pros: Meets issue intent (bootstrap + dependency semantics); supports ready/not-ready tests naturally; flexible without coupling to specific providers.
+   - Cons: Slightly larger API surface (options/check function contract); requires careful docs to keep semantics clear.
+   - Effort: Medium.
+
+3. **Implicit auto-registration in `UseServer()`** — always register health/readiness unless disabled.
+   - Pros: Minimal consumer setup.
+   - Cons: Violates issue requirement for explicit opt-in; increases risk of route conflicts; surprising behavior for existing consumers.
+   - Effort: Low.
+
+### Recommendation
+Use **Approach 2**.
+
+Add an explicit opt-in method at the `app` boundary (for example, `EnableHealthReadinessPresets(opts ...)`) with:
+- defaults: `/healthz`, `/readyz`,
+- path overrides for each endpoint,
+- explicit readiness semantics:
+  - `healthz`: process/router liveness endpoint (responds 200 once registered),
+  - `readyz`: returns 200 only if app bootstrap prerequisites are satisfied and optional dependency checks pass; otherwise 503.
+
+This keeps current manual registration behavior unchanged, aligns with the existing no-singleton/explicit-dependency architecture, and gives enough flexibility for real operational readiness.
+
+### Risks
+- **Route collision behavior**: Gin can panic on duplicate method/path registration; preset registration must avoid unexpected crashes when paths overlap existing routes.
+- **Semantic ambiguity**: if readiness criteria are under-specified, consumers may treat `readyz` inconsistently across services.
+- **Backward-compat expectations**: existing apps using manual `/health` endpoints may misinterpret preset behavior unless docs clearly separate manual vs preset routes.
+- **Test determinism for dependency checks**: readiness callbacks must remain synchronous and deterministic to keep unit tests fast/reliable.
+
+### Ready for Proposal
+Yes — proceed to proposal/spec with one key contract decision upfront: define the exact readiness check API shape (single callback vs list of checks) and duplicate-route handling behavior (return typed error vs no-op).

--- a/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/proposal.md
+++ b/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/proposal.md
@@ -1,0 +1,64 @@
+# Proposal: Health/Readiness Presets for App Bootstrap
+
+## Intent
+
+Provide an explicit, opt-in way to expose standard health endpoints in `app.Application` so services can adopt consistent `/healthz` and `/readyz` behavior without framework lock-in or provider coupling.
+
+## Scope
+
+### In Scope
+- Add an opt-in API on `app.Application` to register health/readiness presets.
+- Provide default paths (`/healthz`, `/readyz`) with per-endpoint path overrides.
+- Define readiness semantics: `readyz` returns `200` only when bootstrap prerequisites are satisfied and optional readiness checks pass; otherwise `503`.
+- Define deterministic duplicate-route handling and test coverage for default/custom and ready/not-ready flows.
+- Document usage and semantics in `app/doc.go`, `README.md`, and `docs/home.md`.
+
+### Out of Scope
+- Auto-registering health/readiness in `UseServer()` or any implicit bootstrap step.
+- Provider-specific dependency probing (DB, OAuth, cloud SDKs) inside framework core.
+- Async/background readiness orchestration or lifecycle manager features.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `app-bootstrap`: add explicit preset registration contract, readiness semantics, and deterministic error behavior for conflicts/order.
+
+## Approach
+
+Implement an additive API (for example `EnableHealthReadinessPresets(...)`) at the bootstrap boundary. Keep route registration explicit, evaluate readiness synchronously via bootstrap state plus optional caller-provided checks, and return contextual errors instead of silent no-ops for invalid ordering or route conflicts.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `app/application.go` | Modified | Preset API, path options, readiness evaluation, duplicate-route error handling |
+| `app/application_test.go` | Modified | Default/custom path tests; ready/not-ready status tests; conflict/order tests |
+| `app/doc.go` | Modified | Exported API docs and readiness contract |
+| `README.md`, `docs/home.md` | Modified | Operational usage examples and non-goals |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Route collisions with existing handlers | Med | Pre-check/guard and return typed contextual errors |
+| Inconsistent readiness interpretation across teams | Med | Document strict contract and examples in package/docs |
+| Callback misuse causing flaky tests | Low | Keep checks synchronous/deterministic and cover with table tests |
+
+## Rollback Plan
+
+Revert preset API additions and docs, preserving existing manual `RegisterGET`/`RegisterPOST`/`RegisterProtectedGET` flows; consumers can continue using manually registered health routes.
+
+## Dependencies
+
+- Existing `app.Application` ordering guards and route registration infrastructure.
+
+## Success Criteria
+
+- [ ] Teams can opt in to `/healthz` and `/readyz` without changing existing manual routes.
+- [ ] Custom endpoint paths are supported with deterministic behavior.
+- [ ] `readyz` returns `503` when bootstrap/check preconditions fail and `200` when all pass.
+- [ ] Duplicate/conflicting preset registration fails with explicit, test-covered errors.
+- [ ] Docs clearly state semantics and non-goals.

--- a/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/specs/app-health-readiness-presets/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/specs/app-health-readiness-presets/spec.md
@@ -1,0 +1,70 @@
+# Delta for app-health-readiness-presets
+
+## ADDED Requirements
+
+### Requirement: Explicit health/readiness preset opt-in
+
+`app.Application` MUST provide an explicit opt-in API to register health/readiness presets. The API MUST register `/healthz` and `/readyz` by default when no override is provided, and MUST NOT auto-register these routes from `UseServer()` or any implicit bootstrap step.
+
+#### Scenario: Opt-in registers default endpoints
+
+- GIVEN an application with server bootstrap completed
+- WHEN the caller explicitly enables health/readiness presets without path overrides
+- THEN `/healthz` and `/readyz` are registered successfully
+- AND no preset route exists before the explicit opt-in call
+
+### Requirement: Configurable endpoint path overrides
+
+The preset API MUST allow per-endpoint path overrides for health and readiness. Custom paths MUST behave identically to defaults for status semantics and route handling.
+
+#### Scenario: Custom paths are honored
+
+- GIVEN an application with presets enabled using custom health and readiness paths
+- WHEN requests are sent to the configured custom paths
+- THEN the framework serves the health and readiness handlers on those paths
+- AND default paths are not implicitly duplicated unless explicitly requested
+
+### Requirement: Readiness evaluation contract
+
+The readiness endpoint MUST return `200 OK` only when bootstrap prerequisites are satisfied and all configured readiness checks pass. It MUST return `503 Service Unavailable` when prerequisites are not satisfied or any readiness check fails. Readiness checks MUST be evaluated synchronously and deterministically for each request.
+
+#### Scenario: Ready state returns 200
+
+- GIVEN bootstrap prerequisites are satisfied and all readiness checks pass
+- WHEN a request is sent to the readiness endpoint
+- THEN the response status is `200 OK`
+
+#### Scenario: Not-ready state returns 503
+
+- GIVEN bootstrap prerequisites are not satisfied OR at least one readiness check fails
+- WHEN a request is sent to the readiness endpoint
+- THEN the response status is `503 Service Unavailable`
+
+### Requirement: Deterministic conflict and ordering errors
+
+Preset registration MUST fail with explicit contextual errors when called in invalid bootstrap order or when target routes conflict with already registered routes. The API MUST NOT silently overwrite handlers or partially register conflicting preset routes.
+
+#### Scenario: Duplicate/conflicting route registration fails
+
+- GIVEN a route path already registered for health or readiness
+- WHEN preset registration targets the same path
+- THEN the call returns an explicit conflict error
+- AND no conflicting preset handler is installed
+
+#### Scenario: Invalid ordering fails deterministically
+
+- GIVEN server bootstrap prerequisites are incomplete
+- WHEN preset registration is invoked
+- THEN the call returns an explicit ordering error
+- AND no preset routes are registered
+
+### Requirement: Documentation synchronization for readiness presets
+
+Documentation MUST define preset usage, readiness semantics, and non-goals consistently across `app/doc.go`, `README.md`, and `/docs/*` user-facing pages (including `docs/home.md`).
+
+#### Scenario: Documentation covers contract and non-goals
+
+- GIVEN the change updates package and user docs
+- WHEN a reader reviews `app/doc.go`, `README.md`, and `docs/home.md`
+- THEN endpoint defaults, custom-path behavior, and `200/503` readiness rules are consistent
+- AND docs explicitly state non-goals (no implicit registration and no provider-specific probing)

--- a/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/tasks.md
+++ b/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Health/Readiness Presets for App Bootstrap
+
+## Phase 1: Foundation (API contract and validation)
+
+- [x] 1.1 In `app/application.go`, add `ReadinessCheck`, `HealthReadinessOptions`, and sentinel errors `ErrRouteConflict`/`ErrInvalidPresetOptions` with doc comments.
+- [x] 1.2 Implement option resolution + validation in `app/application.go` (default `/healthz` and `/readyz`, reject blank paths, reject same health/ready path).
+- [x] 1.3 Add ordering guard in `EnableHealthReadinessPresets` to return `ErrServerNotReady` if `UseServer()` has not completed.
+
+## Phase 2: Core implementation (preset registration + readiness behavior)
+
+- [x] 2.1 Implement `EnableHealthReadinessPresets(opts HealthReadinessOptions) error` in `app/application.go` with explicit opt-in only (no `UseServer()` auto-registration side effects).
+- [x] 2.2 Add preflight GET-route conflict detection in `app/application.go` against registered routes; return wrapped `ErrRouteConflict` with method/path context.
+- [x] 2.3 Register health handler in `app/application.go` at resolved `HealthPath` that always returns HTTP 200 once presets are enabled.
+- [x] 2.4 Register readiness handler in `app/application.go` at resolved `ReadyPath`; evaluate baseline bootstrap invariants + `Checks` synchronously in order and return 200 only when all pass, otherwise 503.
+
+## Phase 3: Tests and verification
+
+- [x] 3.1 In `app/application_test.go`, add table-driven `t.Run` tests for options/defaults/validation and assert `errors.Is` for `ErrInvalidPresetOptions` and `ErrServerNotReady`.
+- [x] 3.2 In `app/application_test.go`, add conflict tests that pre-register colliding GET paths and verify deterministic `ErrRouteConflict` with no partial preset registration.
+- [x] 3.3 In `app/application_test.go`, add `httptest` coverage for default and custom paths (`/healthz`/`/readyz` and overrides) including readiness 200 (all checks pass) and 503 (failed check or unmet invariant).
+- [x] 3.4 Add non-regression tests in `app/application_test.go` confirming existing manual route registration flows remain unchanged when presets are not enabled.
+- [x] 3.5 Run verification commands: `go test ./...`, `go test -race ./app`, and `go build ./...`; resolve failures before marking implementation complete.
+- [x] 3.6 Add explicit automated documentation synchronization evidence in `app/application_test.go` for health/readiness preset contract + non-goals coverage across `app/doc.go`, `README.md`, and `docs/home.md`.
+
+## Phase 4: Documentation and rollout notes
+
+- [x] 4.1 Update `app/doc.go` with API usage, explicit opt-in requirement, readiness semantics (200/503), and non-goals (no implicit registration, no provider probing).
+- [x] 4.2 Update `README.md` with a buildable `package main` example for default preset paths and a second example with custom path overrides and checks.
+- [x] 4.3 Update `docs/home.md` with operational behavior for health/readiness endpoints, including default paths and custom-path behavior without implicit duplication.

--- a/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/verify-report.md
+++ b/openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/verify-report.md
@@ -1,0 +1,113 @@
+## Verification Report
+
+**Change**: issue-31-health-readiness-presets  
+**Version**: N/A  
+**Mode**: Standard
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 16 |
+| Tasks complete | 16 |
+| Tasks incomplete | 0 |
+
+Incomplete tasks: None.
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed
+
+```text
+Command: go build ./...
+Result: exit code 0
+```
+
+**Tests**: ✅ 204 passed / ❌ 0 failed / ⚠️ 0 skipped
+
+```text
+Commands:
+- go test ./...               -> pass
+- go test -race ./app        -> pass
+- go test -v ./app           -> pass
+- go test -count=1 -json ./... -> passed=204 failed=0 skipped=0
+```
+
+**Coverage**: 80.9% / threshold: 0% → ✅ Above threshold
+
+```text
+Command: go test -coverprofile=<tmp> ./... && go tool cover -func=<tmp>
+Total coverage: 80.9%
+app package (go test -cover ./app): 92.5%
+```
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Explicit health/readiness preset opt-in | Opt-in registers default endpoints | `app/application_test.go > TestEnableHealthReadinessPresets_OptionsAndOrdering/defaults_are_accepted`; `.../TestEnableHealthReadinessPresets_HTTPBehavior_DefaultAndCustomPaths/default_paths_with_readiness_pass_and_fail`; `.../TestManualRouteRegistration_UnchangedWithoutPresets` | ✅ COMPLIANT |
+| Configurable endpoint path overrides | Custom paths are honored | `app/application_test.go > TestEnableHealthReadinessPresets_HTTPBehavior_DefaultAndCustomPaths/custom_paths_are_honored_and_defaults_not_duplicated` | ✅ COMPLIANT |
+| Readiness evaluation contract | Ready state returns 200 | `app/application_test.go > TestEnableHealthReadinessPresets_HTTPBehavior_DefaultAndCustomPaths/default_paths_with_readiness_pass_and_fail` | ✅ COMPLIANT |
+| Readiness evaluation contract | Not-ready state returns 503 | `app/application_test.go > TestEnableHealthReadinessPresets_HTTPBehavior_DefaultAndCustomPaths/default_paths_with_readiness_pass_and_fail`; `.../unmet_invariant_returns_503` | ✅ COMPLIANT |
+| Deterministic conflict and ordering errors | Duplicate/conflicting route registration fails | `app/application_test.go > TestEnableHealthReadinessPresets_ConflictPreflightAndNoPartialRegistration/health_conflict_fails_and_does_not_install_readiness`; `.../ready_conflict_fails` | ✅ COMPLIANT |
+| Deterministic conflict and ordering errors | Invalid ordering fails deterministically | `app/application_test.go > TestEnableHealthReadinessPresets_OptionsAndOrdering/fails_before_server_bootstrap` | ✅ COMPLIANT |
+| Documentation synchronization for readiness presets | Documentation covers contract and non-goals | `app/application_test.go > TestDocumentation_HealthReadinessPresetContractSynchronization/(package_docs|readme|docs_home)` | ✅ COMPLIANT |
+
+**Compliance summary**: 7/7 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Explicit health/readiness preset opt-in | ✅ Implemented | `EnableHealthReadinessPresets` is explicit opt-in; defaults resolve to `/healthz` + `/readyz`; `UseServer()` has no implicit preset side effects. |
+| Configurable endpoint path overrides | ✅ Implemented | `HealthReadinessOptions` + `resolveHealthReadinessOptions` honor custom paths and preserve no-duplication behavior. |
+| Readiness evaluation contract | ✅ Implemented | `readinessStatus` checks baseline invariant and synchronous ordered checks; returns 200 only on full success, otherwise 503. |
+| Deterministic conflict and ordering errors | ✅ Implemented | `ensureServerReady` returns `ErrServerNotReady`; `ensureNoPresetRouteConflict` returns wrapped `ErrRouteConflict` with method/path context before registration. |
+| Documentation synchronization for readiness presets | ✅ Implemented | `app/doc.go`, `README.md`, and `docs/home.md` consistently describe defaults, custom paths, 200/503 semantics, and non-goals. |
+
+---
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Explicit opt-in method on `Application` | ✅ Yes | `EnableHealthReadinessPresets(...)` implemented exactly as design, with no auto-registration in `UseServer()`. |
+| Readiness = bootstrap invariant + sync checks | ✅ Yes | `readinessInvariantSatisfied` and ordered synchronous checks enforce the selected contract. |
+| Preflight route conflict checks before registration | ✅ Yes | Route preflight via `ensureNoPresetRouteConflict` happens before handler registration. |
+| File Changes table alignment | ✅ Yes | All designed files were updated (`app/application.go`, `app/application_test.go`, `app/doc.go`, `README.md`, `docs/home.md`). |
+
+---
+
+### Re-check of Prior CRITICAL Finding
+
+- ✅ Previously reported CRITICAL gap (missing automated evidence for documentation contract scenario) is now resolved.
+- Evidence: `TestDocumentation_HealthReadinessPresetContractSynchronization` exists and passed for package docs, README, and docs home.
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+- None.
+
+**WARNING** (should fix):
+- None.
+
+**SUGGESTION** (nice to have):
+- None.
+
+---
+
+### Verdict
+
+**PASS**
+
+All tasks are complete, implementation aligns with spec and design, full verification rerun passed, and all 7/7 spec scenarios are behaviorally compliant.

--- a/openspec/specs/app-health-readiness-presets/spec.md
+++ b/openspec/specs/app-health-readiness-presets/spec.md
@@ -1,0 +1,70 @@
+# Delta for app-health-readiness-presets
+
+## ADDED Requirements
+
+### Requirement: Explicit health/readiness preset opt-in
+
+`app.Application` MUST provide an explicit opt-in API to register health/readiness presets. The API MUST register `/healthz` and `/readyz` by default when no override is provided, and MUST NOT auto-register these routes from `UseServer()` or any implicit bootstrap step.
+
+#### Scenario: Opt-in registers default endpoints
+
+- GIVEN an application with server bootstrap completed
+- WHEN the caller explicitly enables health/readiness presets without path overrides
+- THEN `/healthz` and `/readyz` are registered successfully
+- AND no preset route exists before the explicit opt-in call
+
+### Requirement: Configurable endpoint path overrides
+
+The preset API MUST allow per-endpoint path overrides for health and readiness. Custom paths MUST behave identically to defaults for status semantics and route handling.
+
+#### Scenario: Custom paths are honored
+
+- GIVEN an application with presets enabled using custom health and readiness paths
+- WHEN requests are sent to the configured custom paths
+- THEN the framework serves the health and readiness handlers on those paths
+- AND default paths are not implicitly duplicated unless explicitly requested
+
+### Requirement: Readiness evaluation contract
+
+The readiness endpoint MUST return `200 OK` only when bootstrap prerequisites are satisfied and all configured readiness checks pass. It MUST return `503 Service Unavailable` when prerequisites are not satisfied or any readiness check fails. Readiness checks MUST be evaluated synchronously and deterministically for each request.
+
+#### Scenario: Ready state returns 200
+
+- GIVEN bootstrap prerequisites are satisfied and all readiness checks pass
+- WHEN a request is sent to the readiness endpoint
+- THEN the response status is `200 OK`
+
+#### Scenario: Not-ready state returns 503
+
+- GIVEN bootstrap prerequisites are not satisfied OR at least one readiness check fails
+- WHEN a request is sent to the readiness endpoint
+- THEN the response status is `503 Service Unavailable`
+
+### Requirement: Deterministic conflict and ordering errors
+
+Preset registration MUST fail with explicit contextual errors when called in invalid bootstrap order or when target routes conflict with already registered routes. The API MUST NOT silently overwrite handlers or partially register conflicting preset routes.
+
+#### Scenario: Duplicate/conflicting route registration fails
+
+- GIVEN a route path already registered for health or readiness
+- WHEN preset registration targets the same path
+- THEN the call returns an explicit conflict error
+- AND no conflicting preset handler is installed
+
+#### Scenario: Invalid ordering fails deterministically
+
+- GIVEN server bootstrap prerequisites are incomplete
+- WHEN preset registration is invoked
+- THEN the call returns an explicit ordering error
+- AND no preset routes are registered
+
+### Requirement: Documentation synchronization for readiness presets
+
+Documentation MUST define preset usage, readiness semantics, and non-goals consistently across `app/doc.go`, `README.md`, and `/docs/*` user-facing pages (including `docs/home.md`).
+
+#### Scenario: Documentation covers contract and non-goals
+
+- GIVEN the change updates package and user docs
+- WHEN a reader reviews `app/doc.go`, `README.md`, and `docs/home.md`
+- THEN endpoint defaults, custom-path behavior, and `200/503` readiness rules are consistent
+- AND docs explicitly state non-goals (no implicit registration and no provider-specific probing)


### PR DESCRIPTION
Closes #31

## Summary
- Add explicit opt-in health/readiness presets in `app.Application` with defaults (`/healthz`, `/readyz`) and path overrides.
- Implement deterministic readiness semantics (`200` when ready, `503` when not ready) plus route-conflict and ordering safeguards.
- Add tests and documentation updates, and archive the full SDD hybrid artifact trail for this change.

## Changes
| File | Change |
|------|--------|
| `app/application.go` | Added presets API, readiness checks, and conflict/order validation logic |
| `app/application_test.go` | Added coverage for defaults, overrides, ready/not-ready, conflicts, and docs sync contract |
| `app/doc.go` | Documented preset behavior and readiness semantics |
| `README.md` | Added usage and contract details for health/readiness presets |
| `docs/home.md` | Updated docs index/context for new preset capability |
| `openspec/specs/app-health-readiness-presets/spec.md` | Added main capability spec after archive |
| `openspec/changes/archive/2026-05-01-issue-31-health-readiness-presets/*` | Archived full SDD artifacts (explore/proposal/spec/design/tasks/apply/verify/archive) |

## Test Plan
- [x] `go test ./...`
- [x] `go test -race ./app`
- [x] `go build ./...`