### PR TITLE
docs: replace openspec/ with consolidated /docs structure and dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,13 +613,25 @@ Dependency direction is always inward:
   - This repo provides generic OAuth2 config fields.
   - Concrete Google OAuth flows, APIs, and provider-specific behavior belong to the consuming application/service layer.
 
+## Documentation
+
+Full documentation is available under [`docs/`](docs/index.md) and published to GitHub Pages.
+
+| Section | Path | Description |
+|---|---|---|
+| Home | `docs/index.md` | Landing page and quick reference |
+| Getting Started | `docs/getting-started/` | Installation and quickstart |
+| Architecture | `docs/architecture/` | Canonical specs for each package |
+| Releases | `docs/releases/` | Release notes per version (v0.1.0 → v0.7.0) |
+| Migration Guides | `docs/migration/` | Consumer migration guides |
+| Decisions | `docs/decisions/` | Architecture decision records (ADRs) |
+| Contributing | `docs/contributing/` | SDD workflow and PR conventions |
+
 ## Release and migration docs
 
 - Release workflow label policy:
   - Use exactly one of `release-type:patch`, `release-type:minor`, or `release-type:major` on release PRs.
   - Use `release:skip` to explicitly skip release preview/publication for non-release changes (docs/chore-only PRs).
-  - Legacy labels (`release-type/patch`, `release-type/minor`, `release-type/major`) remain temporarily accepted for migration, but should be replaced.
-- Docs index: `docs/home.md`
-- Release checklist for `v0.2.0`: `docs/releases/v0.2.0-checklist.md`
-- Release checklist for `v0.1.0`: `docs/releases/v0.1.0-checklist.md`
+- Release notes: `docs/releases/` (v0.1.0 through v0.7.0)
 - Migration guide for `auth-provider-ms`: `docs/migration/auth-provider-ms-v0.1.0.md`
+- Documentation structure migration note: `docs/migration/openspec-to-docs.md`

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,56 @@
+theme: just-the-docs
+
+title: common-fwk
+description: >
+  A Go framework providing reusable building blocks for microservices:
+  config, security, HTTP middleware, app bootstrap, logging, and more.
+
+baseurl: ""
+url: "https://matiasmartin-labs.github.io/common-fwk"
+
+# Navigation and search
+search_enabled: true
+search:
+  heading_level: 2
+  previews: 3
+
+# Aux links (top-right)
+aux_links:
+  "GitHub":
+    - "https://github.com/matiasmartin-labs/common-fwk"
+
+aux_links_new_tab: true
+
+# Footer
+footer_content: "common-fwk — MIT License"
+
+# Collections
+collections:
+  docs:
+    permalink: "/:collection/:path/"
+    output: true
+
+# Back to top
+back_to_top: true
+back_to_top_text: "Back to top"
+
+# Last edit timestamp
+last_edit_time_stamp: false
+
+# Callouts
+callouts_level: quiet
+callouts:
+  highlight:
+    color: yellow
+  important:
+    title: Important
+    color: blue
+  new:
+    title: New
+    color: green
+  note:
+    title: Note
+    color: purple
+  warning:
+    title: Warning
+    color: red

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ description: >
   config, security, HTTP middleware, app bootstrap, logging, and more.
 
 baseurl: ""
-url: "https://matiasmartin-labs.github.io/common-fwk"
+url: "http://common-fwk.mmartinlabs.com"
 
 # Navigation and search
 search_enabled: true
@@ -29,6 +29,13 @@ collections:
   docs:
     permalink: "/:collection/:path/"
     output: true
+
+# Color scheme — dark by default
+color_scheme: dark
+
+# Custom CSS
+custom_css:
+  - assets/css/custom.css
 
 # Back to top
 back_to_top: true

--- a/docs/architecture/app-bootstrap.md
+++ b/docs/architecture/app-bootstrap.md
@@ -1,0 +1,111 @@
+---
+title: App Bootstrap
+parent: Architecture
+nav_order: 3
+---
+
+# App Bootstrap (`app`)
+
+**Import**: `github.com/matiasmartin-labs/common-fwk/app`
+
+## Purpose
+
+Instance-scoped application lifecycle: config wiring, HTTP server setup, security wiring, route registration,
+and run — without global singletons.
+
+## Lifecycle
+
+```
+NewApplication()
+  └─ UseConfig(cfg)
+       └─ UseServer()
+            └─ UseServerSecurity(validator)
+                 ├─ RegisterGET(path, handler)
+                 ├─ RegisterPOST(path, handler)
+                 ├─ RegisterProtectedGET(path, middleware, handler)
+                 ├─ EnableHealthReadinessPresets(opts)
+                 └─ Run() / RunListener(listener)
+```
+
+## Bootstrap API
+
+### `NewApplication() *Application`
+
+Creates a new isolated application instance. No global state.
+
+### `UseConfig(cfg config.Config) *Application`
+
+Stores runtime config snapshot. Must be called before `UseServer`.
+
+### `UseServer() *Application`
+
+Initializes the HTTP server using server runtime limits from config:
+- `ReadTimeout`, `WriteTimeout`, `MaxHeaderBytes`
+
+### `UseServerSecurity(v security.Validator) *Application`
+
+Wires JWT security for protected route middleware. Must be called after `UseServer`.
+
+### `UseServerSecurityFromConfig() *Application`
+
+Optional convenience helper. Derives validator wiring from already loaded config (HS256 or RS256).
+Fails deterministically with contextual errors when config prerequisites are invalid.
+
+## Route Registration
+
+| Method | Description |
+|---|---|
+| `RegisterGET(path, handler)` | Public GET route |
+| `RegisterPOST(path, handler)` | Public POST route |
+| `RegisterProtectedGET(path, ...middleware, handler)` | GET route behind JWT auth |
+
+Misordered calls (e.g. registering routes before `UseServer`) return explicit errors.
+
+## Health and Readiness Presets
+
+```go
+err := application.EnableHealthReadinessPresets(app.HealthReadinessOptions{
+    HealthPath: "/healthz",  // optional, defaults to /healthz
+    ReadyPath:  "/readyz",   // optional, defaults to /readyz
+})
+```
+
+- `/healthz` → `200 OK` once presets are registered.
+- `/readyz` → `200 OK` when bootstrap invariants pass AND all readiness checks return `nil`; else `503`.
+- Calling before `UseServer()` returns `ErrServerNotReady`.
+- Blank or conflicting paths return `ErrInvalidPresetOptions` or `ErrRouteConflict`.
+
+## Read-Only Runtime Accessors
+
+```go
+cfg := application.GetConfig()                         // config.Config snapshot
+v   := application.GetSecurityValidator()              // security.Validator or nil
+ok  := application.IsSecurityReady()                   // bool
+logger, err := application.GetLogger("auth")           // logging.Logger or error
+```
+
+### Lifecycle semantics
+
+| Stage | `GetConfig()` | `GetSecurityValidator()` | `IsSecurityReady()` | `GetLogger()` |
+|---|---|---|---|---|
+| Pre-init | zero-value snapshot | `nil` | `false` | `ErrLoggingNotReady` |
+| `UseConfig` only | live snapshot | `nil` | `false` | available |
+| Post-`UseServerSecurity` | live snapshot | non-`nil` | `true` | available |
+
+`GetConfig()` returns a **defensive snapshot** — mutations to the returned value do not affect internal state.
+
+## Named Logger
+
+```go
+logger, err := application.GetLogger("auth")
+// err is ErrLoggingNotReady if UseConfig not called
+// err is ErrLoggerNameRequired if name is empty
+// Same name → same logger instance (deterministic)
+```
+
+## Non-Goals
+
+- No global singleton.
+- No DI container.
+- No graceful shutdown coordinator.
+- No JWT validator construction inside `app` (caller provides validator).

--- a/docs/architecture/config-core.md
+++ b/docs/architecture/config-core.md
@@ -1,0 +1,107 @@
+---
+title: Config Core
+parent: Architecture
+nav_order: 1
+---
+
+# Config Core (`config`)
+
+**Import**: `github.com/matiasmartin-labs/common-fwk/config`
+
+## Purpose
+
+Typed, panic-free configuration core that is deterministic and adapter-independent.
+Provides structs, constructors, validation, and normalization — without any Viper or filesystem coupling.
+
+## Exposed Types
+
+| Type | Purpose |
+|---|---|
+| `Config` | Root application configuration |
+| `ServerConfig` | HTTP server settings (host, port, timeouts) |
+| `SecurityConfig` | Security domain root |
+| `AuthConfig` | Auth subdomain (JWT, Cookie, Login, OAuth2) |
+| `JWTConfig` | JWT algorithm, secret, issuer, TTL, RS256 fields |
+| `CookieConfig` | Cookie settings (ttl-minutes, http-only, same-site) |
+| `LoginConfig` | Login fields (email normalization) |
+| `OAuth2Config` | Generic OAuth2 provider client config |
+
+## Server Runtime Limits
+
+`ServerConfig` includes runtime limits with documented defaults:
+
+| Field | Default | Env Override |
+|---|---|---|
+| `ReadTimeout` | `10s` | `COMMON_FWK_SERVER_READ_TIMEOUT` |
+| `WriteTimeout` | `10s` | `COMMON_FWK_SERVER_WRITE_TIMEOUT` |
+| `MaxHeaderBytes` | `1048576` (1 MB) | `COMMON_FWK_SERVER_MAX_HEADER_BYTES` |
+
+Example:
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8080
+  read-timeout: 10s
+  write-timeout: 10s
+  max-header-bytes: 1048576
+```
+
+## JWT Mode-Aware Configuration
+
+`JWTConfig.Algorithm` defaults to `HS256`.
+
+| Algorithm | Required fields |
+|---|---|
+| `HS256` | `secret`, `issuer`, `ttl-minutes` |
+| `RS256` | `rs256-key-id`, `rs256-key-source`, PEM fields |
+
+RS256 file keys (kebab-case):
+
+```yaml
+security:
+  auth:
+    jwt:
+      algorithm: RS256
+      issuer: my-service
+      ttl-minutes: 60
+      rs256-key-source: generated   # generated | public-pem | private-pem
+      rs256-key-id: my-key
+```
+
+## Logging Config Model
+
+Root and per-logger config with explicit precedence:
+
+```yaml
+logging:
+  enabled: true
+  level: info      # debug | info | warn | error
+  format: json     # json | text
+  loggers:
+    auth:
+      level: debug
+    billing:
+      enabled: false
+```
+
+**Precedence rules**:
+- `enabled`: per-logger override if set, else root.
+- `level`: per-logger override if set, else root.
+- `format`: root only.
+
+## Validation
+
+`ValidateConfig` validates all domains. Errors are wrapped and assertable via `errors.Is`/`errors.As`
+using stable `ErrXxx` sentinel values.
+
+### Login normalization
+
+Login email values are trimmed (whitespace) and lowercased before validation.
+
+## Key Invariants
+
+- No global mutable state.
+- No Viper/filesystem imports.
+- Repeated calls with identical inputs are deterministic.
+- Validation failures return contextual `error`; no panics.

--- a/docs/architecture/config-viper-adapter.md
+++ b/docs/architecture/config-viper-adapter.md
@@ -1,0 +1,65 @@
+---
+title: Viper Adapter
+parent: Architecture
+nav_order: 2
+---
+
+# Config Viper Adapter (`config/viper`)
+
+**Import**: `github.com/matiasmartin-labs/common-fwk/config/viper`
+
+## Purpose
+
+File and environment variable loading adapter for `config.Config`, backed by [Viper](https://github.com/spf13/viper).
+Delegates all validation to `config` core. Wraps errors so core validation sentinels remain assertable.
+
+## Key Conventions
+
+### Kebab-case file keys (mandatory)
+
+All YAML/TOML/JSON configuration file keys MUST use **kebab-case**:
+
+| Context | Correct | Legacy (deprecated) |
+|---|---|---|
+| JWT cookie | `ttl-minutes` | `ttlMinutes` |
+| Cookie flags | `http-only`, `same-site` | `httpOnly`, `sameSite` |
+| OAuth2 credentials | `client-id`, `client-secret` | `clientId`, `clientSecret` |
+| OAuth2 endpoints | `auth-url`, `token-url`, `redirect-url` | camelCase variants |
+| RS256 fields | `rs256-key-source`, `rs256-key-id` | — |
+| Server limits | `read-timeout`, `write-timeout`, `max-header-bytes` | — |
+
+CamelCase keys are accepted only for legacy compatibility and will be removed in a future major version.
+
+## Usage
+
+```go
+import viperconfig "github.com/matiasmartin-labs/common-fwk/config/viper"
+
+cfg, err := viperconfig.Load("config.yaml")
+if err != nil {
+    // err may wrap core validation errors — use errors.Is to assert specific failures
+    log.Fatal(err)
+}
+```
+
+## Environment Overrides
+
+All config fields support env overrides prefixed with `COMMON_FWK_` using screaming snake-case:
+
+```bash
+COMMON_FWK_SERVER_PORT=9090
+COMMON_FWK_SECURITY_AUTH_JWT_SECRET=my-secret
+COMMON_FWK_LOGGING_LEVEL=debug
+COMMON_FWK_LOGGING_LOGGERS_AUTH_LEVEL=debug
+```
+
+## Error Handling
+
+Validation errors from the core are wrapped — they remain assertable:
+
+```go
+cfg, err := viperconfig.Load("config.yaml")
+if errors.Is(err, config.ErrMissingSecret) {
+    // handle specific validation failure
+}
+```

--- a/docs/architecture/errors.md
+++ b/docs/architecture/errors.md
@@ -1,0 +1,36 @@
+---
+title: Error Codes
+parent: Architecture
+nav_order: 6
+---
+
+# Error Codes (`errors`)
+
+**Import**: `github.com/matiasmartin-labs/common-fwk/errors`
+
+## Purpose
+
+Exported string constants for auth error codes used by middleware and available to consumers
+for test assertions and error handling — without duplicating magic string literals.
+
+## Constants
+
+| Constant | Value | Usage context |
+|---|---|---|
+| `CodeTokenMissing` | `"auth_token_missing"` | Missing token in request |
+| `CodeTokenInvalid` | `"auth_token_invalid"` | Invalid, expired, or unauthorized token |
+
+## Usage
+
+```go
+import fwkerrors "github.com/matiasmartin-labs/common-fwk/errors"
+
+// In test assertions
+assert.Equal(t, fwkerrors.CodeTokenMissing, responseBody["code"])
+
+// In middleware (internal)
+c.JSON(401, gin.H{
+    "code":    fwkerrors.CodeTokenMissing,
+    "message": httpgin.MsgTokenMissing,
+})
+```

--- a/docs/architecture/health-readiness.md
+++ b/docs/architecture/health-readiness.md
@@ -1,0 +1,57 @@
+---
+title: Health & Readiness
+parent: Architecture
+nav_order: 8
+---
+
+# Health and Readiness Presets (`app`)
+
+## Purpose
+
+Explicit opt-in registration of standard health and readiness HTTP endpoints.
+No implicit registration occurs during bootstrap — presets are side-effect free
+until the caller explicitly enables them.
+
+## API
+
+```go
+err := application.EnableHealthReadinessPresets(app.HealthReadinessOptions{
+    HealthPath: "/healthz",  // optional — defaults to /healthz
+    ReadyPath:  "/readyz",   // optional — defaults to /readyz
+    ReadyChecks: []app.ReadyCheck{
+        func() error { return db.Ping() },
+    },
+})
+```
+
+## Endpoint Behavior
+
+### `GET /healthz`
+
+Returns `200 OK` once presets are registered. Signals the service is alive.
+
+### `GET /readyz`
+
+Returns `200 OK` only when:
+1. Bootstrap invariants pass (config and server wired).
+2. All registered readiness checks return `nil`.
+
+Returns `503 Service Unavailable` when any invariant or check fails.
+
+Readiness checks are evaluated **synchronously and deterministically** on each request.
+
+## Error Conditions
+
+| Condition | Error |
+|---|---|
+| `UseServer()` not called yet | `app.ErrServerNotReady` |
+| Blank path | `app.ErrInvalidPresetOptions` |
+| Health and ready paths are identical | `app.ErrInvalidPresetOptions` |
+| Path conflicts with existing route | `app.ErrRouteConflict` |
+
+No partial registration occurs on error — all-or-nothing.
+
+## Non-Goals
+
+- No implicit preset registration inside `UseServer()`.
+- No provider-specific dependency probes built in — readiness checks are caller-provided.

--- a/docs/architecture/http-gin-middleware.md
+++ b/docs/architecture/http-gin-middleware.md
@@ -1,0 +1,83 @@
+---
+title: Gin Middleware
+parent: Architecture
+nav_order: 5
+---
+
+# Gin Auth Middleware (`http/gin`)
+
+**Import**: `github.com/matiasmartin-labs/common-fwk/http/gin`
+
+## Purpose
+
+Gin HTTP middleware that authenticates JWT Bearer tokens using `security.Validator`,
+returns standardized error responses, and injects validated claims into request context.
+
+## Factory
+
+```go
+middleware := httpgin.NewAuthMiddleware(validator, opts...)
+```
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `WithHeaderName(name)` | `Authorization` | Header to extract Bearer token from |
+| `WithCookieName(name)` | `token` | Cookie fallback name |
+| `WithAuthEnabled(bool)` | `true` | Set `false` to bypass auth (testing/dev) |
+| `WithContextKey(key)` | internal default | Key to inject claims into `gin.Context` |
+
+## Token Extraction Precedence
+
+1. Configured header (strip `Bearer ` prefix)
+2. Configured cookie (fallback when header is absent)
+3. Neither present → `401` with `auth_token_missing`
+
+## Error Response Contract
+
+All auth failures return `HTTP 401` with JSON body:
+
+```json
+{ "code": "auth_token_missing", "message": "missing authentication token" }
+{ "code": "auth_token_invalid", "message": "invalid or expired token" }
+```
+
+| Failure | Code |
+|---|---|
+| No token found | `auth_token_missing` |
+| Malformed / invalid / expired / bad issuer or audience | `auth_token_invalid` |
+
+## Exported Constants
+
+```go
+httpgin.MsgTokenMissing  // "missing authentication token"
+httpgin.MsgTokenInvalid  // "invalid or expired token"
+```
+
+Use these to assert error messages in tests without magic strings.
+
+## Exported Error Codes (from `errors` package)
+
+```go
+import fwkerrors "github.com/matiasmartin-labs/common-fwk/errors"
+
+fwkerrors.CodeTokenMissing  // "auth_token_missing"
+fwkerrors.CodeTokenInvalid  // "auth_token_invalid"
+```
+
+## Claims Injection
+
+On success, validated `claims.Claims` is injected into `gin.Context` under the configured key.
+Downstream handlers retrieve it via the standard Gin context API.
+
+## Usage Example
+
+```go
+application.RegisterProtectedGET("/profile",
+    httpgin.NewAuthMiddleware(validator),
+    func(c *gin.Context) {
+        c.JSON(200, gin.H{"ok": true})
+    },
+)
+```

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,34 @@
+---
+title: Architecture
+nav_order: 3
+has_children: true
+permalink: /architecture/
+---
+
+# Architecture
+
+This section contains the canonical specifications for each package and subsystem in `common-fwk`.
+These documents describe contracts, requirements, and behavior boundaries — they serve as the
+authoritative reference for both human contributors and AI agents working with the codebase.
+
+## Packages
+
+| Package | Doc | Description |
+|---|---|---|
+| `config` | [Config Core](config-core/) | Typed, panic-free config model |
+| `config/viper` | [Viper Adapter](config-viper-adapter/) | File/env config loading via Viper |
+| `app` | [App Bootstrap](app-bootstrap/) | Instance-scoped application lifecycle |
+| `security/jwt` | [JWT Security](security-jwt/) | JWT validation contracts |
+| `security/keys` | [Key Resolvers](security-keys/) | RSA and static key resolver contracts |
+| `http/gin` | [Gin Middleware](http-gin-middleware/) | JWT auth middleware for Gin |
+| `errors` | [Error Codes](errors/) | Exported error code constants |
+| `logging` | [Logging Registry](logging-registry/) | Named slog logger registry |
+| `app` (presets) | [Health & Readiness](health-readiness/) | Opt-in health/readiness endpoints |
+
+## Design Principles
+
+- **Explicit over implicit**: no global singletons, no hidden initialization.
+- **Deterministic behavior**: identical inputs always produce identical outputs.
+- **Adapter boundary**: core packages do not depend on adapters (`config` never imports `config/viper`).
+- **Panic-free APIs**: all expected failures return `error`; panics are reserved for programming errors.
+- **AI-readable**: docs include scenarios and acceptance criteria suitable for AI agent consumption.

--- a/docs/architecture/logging-registry.md
+++ b/docs/architecture/logging-registry.md
@@ -1,0 +1,97 @@
+---
+title: Logging Registry
+parent: Architecture
+nav_order: 7
+---
+
+# Logging Registry (`logging`, `logging/slog`)
+
+**Import**: `github.com/matiasmartin-labs/common-fwk/logging`
+
+## Purpose
+
+Deterministic named logger registry backed by `log/slog`. Each logger is scoped
+by name and applies root/per-logger config precedence deterministically.
+
+## Logger Interface
+
+```go
+type Logger interface {
+    Debugf(format string, args ...any)
+    Infof(format string, args ...any)
+    Warnf(format string, args ...any)
+    Errorf(format string, args ...any)
+}
+```
+
+## Access via Application
+
+```go
+logger, err := application.GetLogger("auth")
+```
+
+### Error semantics
+
+| Condition | Error |
+|---|---|
+| `UseConfig` not called | `logging.ErrLoggingNotReady` |
+| Empty name | `logging.ErrLoggerNameRequired` |
+
+### Determinism guarantee
+
+Same logger name on the same `Application` instance always returns the same `Logger` instance.
+Logger caches are isolated per `Application`.
+
+## Config Keys
+
+```yaml
+logging:
+  enabled: true
+  level: info      # debug | info | warn | error
+  format: json     # json | text
+  loggers:
+    auth:
+      enabled: true
+      level: debug
+    billing:
+      enabled: false
+```
+
+### Env overrides
+
+```bash
+COMMON_FWK_LOGGING_ENABLED=true
+COMMON_FWK_LOGGING_LEVEL=warn
+COMMON_FWK_LOGGING_FORMAT=json
+COMMON_FWK_LOGGING_LOGGERS_AUTH_ENABLED=true
+COMMON_FWK_LOGGING_LOGGERS_AUTH_LEVEL=debug
+```
+
+## Precedence Matrix
+
+| Setting | Resolution |
+|---|---|
+| `enabled` | per-logger override → root |
+| `level` | per-logger override → root |
+| `format` | root only (no per-logger override) |
+
+## Output Contract
+
+Every accepted log record includes these fields:
+
+| Field | Description |
+|---|---|
+| `logger` | Logger name |
+| `ts` | Timestamp |
+| `level` | Effective level |
+| `msg` | Message |
+
+Both `json` and `text` formats include all four fields.
+
+## Loki Integration Guidance
+
+Use a **collector-first** approach:
+- Ship logs via Promtail or OpenTelemetry Collector → Loki.
+- Do **not** couple the app directly to a Loki HTTP sink.
+- Preserve structured fields (`logger`, `ts`, `level`, `msg`) through the transport pipeline.
+- Configure parser rules in Promtail/OTel to match the `json` format emitted by this registry.

--- a/docs/architecture/security-jwt.md
+++ b/docs/architecture/security-jwt.md
@@ -1,0 +1,101 @@
+---
+title: JWT Security
+parent: Architecture
+nav_order: 4
+---
+
+# JWT Security (`security/jwt`, `security/claims`, `security/keys`)
+
+## Packages
+
+| Package | Import | Purpose |
+|---|---|---|
+| `security/jwt` | `.../security/jwt` | JWT validator |
+| `security/claims` | `.../security/claims` | Claims model |
+| `security/keys` | `.../security/keys` | Key resolver contracts and constructors |
+
+## Claims Model (`security/claims`)
+
+`Claims` exposes typed fields plus a private map for non-standard claims:
+
+| Field | Type | Source JWT key |
+|---|---|---|
+| `Email` | `string` | `email` |
+| `Name` | `string` | `name` |
+| `Picture` | `string` | `picture` |
+| `Roles` | `[]string` | `roles` (bare key only) |
+| `Private` | `map[string]any` | All non-standard keys |
+
+- `aud` accepts string or array — normalized consistently.
+- Missing optional fields default to zero values without failing parsing.
+- Namespaced keys (e.g. `https://example.com/roles`) land in `Private`, not in `Roles`.
+
+## Validator (`security/jwt`)
+
+```go
+validator, err := jwt.NewValidator(jwtConfig, resolver, jwt.WithTimeSource(fixedTime))
+claims, err := validator.Validate(tokenString)
+```
+
+### Policy checks
+
+- Signature verification.
+- Issuer (`iss`) must match config.
+- Audience (`aud`) must match config.
+- Algorithm (`alg`) must be in allowlist.
+- `exp` and `nbf` evaluated using injected time source.
+
+### Error categories
+
+| Category | Sentinel |
+|---|---|
+| Malformed token | `jwt.ErrMalformed` |
+| Invalid signature | `jwt.ErrInvalidSignature` |
+| Invalid issuer | `jwt.ErrInvalidIssuer` |
+| Invalid audience | `jwt.ErrInvalidAudience` |
+| Invalid method | `jwt.ErrInvalidMethod` |
+| Expired token | `jwt.ErrExpired` |
+| Not yet valid | `jwt.ErrNotYetValid` |
+| Key resolution failure | `jwt.ErrKeyResolution` |
+
+All errors are assertable via `errors.Is`/`errors.As`.
+
+## Key Resolvers (`security/keys`)
+
+| Constructor | Usage |
+|---|---|
+| `keys.NewStaticResolver(secret []byte)` | HS256 shared secret |
+| `keys.NewRSAResolver(privateKey, keyID)` | RS256 private key (signs and verifies) |
+| `keys.NewRSAPublicKeyResolver(publicKey, keyID)` | RS256 public key (verify only) |
+
+Resolvers are deterministic and in-memory — no network I/O.
+
+Key selection is by `kid` header field, falling back to default if not present.
+
+## HS256 Example
+
+```go
+resolver := keys.NewStaticResolver([]byte("my-secret"))
+validator, err := jwt.NewValidator(cfg.Security.Auth.JWT, resolver)
+```
+
+## RS256 Example
+
+```go
+// From config (recommended)
+// UseServerSecurityFromConfig() handles this automatically
+
+// Manual
+resolver := keys.NewRSAPublicKeyResolver(pubKey, "my-key-id")
+opts := jwt.ValidatorOptions{
+    Issuer:  "my-service",
+    Methods: []string{"RS256"},
+}
+validator, err := jwt.NewValidatorWithOptions(opts, resolver)
+```
+
+## Boundaries
+
+- No Gin dependency.
+- No app globals.
+- No JWKS/OAuth provider adapters.

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -1,0 +1,337 @@
+/*
+ * common-fwk docs — Dark theme override
+ * Inspired by opencode.ai design: deep black background, crisp white text,
+ * green/teal accent color, monospace code blocks.
+ */
+
+/* ── Color tokens ──────────────────────────────────────────────────── */
+:root,
+[data-theme="dark"] {
+  /* Backgrounds */
+  --bg-base:        #0d0d0d;
+  --bg-surface:     #141414;
+  --bg-elevated:    #1a1a1a;
+  --bg-code:        #111111;
+  --bg-nav:         #0d0d0d;
+  --bg-border:      #242424;
+
+  /* Text */
+  --text-primary:   #e8e8e8;
+  --text-secondary: #a0a0a0;
+  --text-muted:     #5a5a5a;
+
+  /* Accent — opencode green */
+  --accent:         #22c55e;
+  --accent-dim:     #16a34a;
+  --accent-subtle:  rgba(34, 197, 94, 0.08);
+
+  /* Link */
+  --link:           #4ade80;
+  --link-hover:     #86efac;
+
+  /* Code */
+  --code-text:      #a3e635;
+  --code-border:    #2a2a2a;
+
+  /* Sidebar */
+  --nav-width:      260px;
+}
+
+/* ── Base ───────────────────────────────────────────────────────────── */
+body {
+  background-color: var(--bg-base) !important;
+  color: var(--text-primary) !important;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
+  font-size: 15px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Site header ────────────────────────────────────────────────────── */
+.site-header,
+.site-nav {
+  background-color: var(--bg-nav) !important;
+  border-bottom: 1px solid var(--bg-border) !important;
+}
+
+.site-title {
+  color: var(--text-primary) !important;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.site-title:hover {
+  color: var(--accent) !important;
+  text-decoration: none;
+}
+
+/* ── Sidebar / navigation ───────────────────────────────────────────── */
+.side-bar,
+.nav-list {
+  background-color: var(--bg-nav) !important;
+  border-right: 1px solid var(--bg-border) !important;
+}
+
+.nav-list .nav-list-item .nav-list-link {
+  color: var(--text-secondary) !important;
+  border-radius: 6px;
+  padding: 4px 10px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.nav-list .nav-list-item .nav-list-link:hover {
+  color: var(--text-primary) !important;
+  background-color: var(--bg-elevated) !important;
+  text-decoration: none;
+}
+
+.nav-list .nav-list-item .nav-list-link.active {
+  color: var(--accent) !important;
+  background-color: var(--accent-subtle) !important;
+  font-weight: 600;
+}
+
+.nav-list-item > .nav-list-expander {
+  color: var(--text-muted) !important;
+}
+
+/* Section labels */
+.nav-list .nav-list-item > .nav-list-link:not([href]) {
+  color: var(--text-muted) !important;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ── Main content ───────────────────────────────────────────────────── */
+.main-content {
+  background-color: var(--bg-base) !important;
+  max-width: 860px;
+}
+
+.main-content h1,
+.main-content h2,
+.main-content h3,
+.main-content h4,
+.main-content h5,
+.main-content h6 {
+  color: var(--text-primary) !important;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  border-bottom: none !important;
+}
+
+.main-content h1 {
+  font-size: 2rem;
+  margin-top: 0;
+}
+
+.main-content h2 {
+  font-size: 1.35rem;
+  color: var(--text-primary) !important;
+  margin-top: 2rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--bg-border) !important;
+}
+
+.main-content h3 {
+  font-size: 1.1rem;
+}
+
+.main-content p,
+.main-content li {
+  color: var(--text-secondary) !important;
+}
+
+/* ── Links ──────────────────────────────────────────────────────────── */
+a {
+  color: var(--link) !important;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+a:hover {
+  color: var(--link-hover) !important;
+  text-decoration: underline;
+}
+
+/* ── Code ───────────────────────────────────────────────────────────── */
+code,
+pre code {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", "SF Mono", Consolas, monospace !important;
+  font-size: 0.875em;
+}
+
+code {
+  color: var(--code-text) !important;
+  background-color: var(--bg-elevated) !important;
+  border: 1px solid var(--code-border);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+pre {
+  background-color: var(--bg-code) !important;
+  border: 1px solid var(--bg-border) !important;
+  border-radius: 8px !important;
+  padding: 1.2rem 1.4rem !important;
+  overflow-x: auto;
+}
+
+pre code {
+  color: #d4d4d4 !important;
+  background: transparent !important;
+  border: none !important;
+  padding: 0 !important;
+}
+
+/* Syntax highlight adjustments for dark */
+.highlight .k, .highlight .kd, .highlight .kn { color: #c792ea !important; }   /* keywords */
+.highlight .s, .highlight .s1, .highlight .s2 { color: #c3e88d !important; }   /* strings */
+.highlight .c, .highlight .c1, .highlight .cm  { color: #546e7a !important; font-style: italic; } /* comments */
+.highlight .n, .highlight .nf               { color: #82aaff !important; }   /* names/funcs */
+.highlight .mi, .highlight .mf              { color: #f78c6c !important; }   /* numbers */
+.highlight .o                               { color: #89ddff !important; }   /* operators */
+
+/* ── Tables ─────────────────────────────────────────────────────────── */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1.5rem 0;
+}
+
+th {
+  background-color: var(--bg-elevated) !important;
+  color: var(--text-primary) !important;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  border-bottom: 2px solid var(--bg-border) !important;
+  text-align: left;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+td {
+  color: var(--text-secondary) !important;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid var(--bg-border) !important;
+}
+
+tr:hover td {
+  background-color: var(--bg-elevated) !important;
+}
+
+/* ── Horizontal rule ─────────────────────────────────────────────────── */
+hr {
+  border-color: var(--bg-border) !important;
+  margin: 2rem 0;
+}
+
+/* ── Breadcrumbs ─────────────────────────────────────────────────────── */
+.breadcrumb-nav {
+  color: var(--text-muted) !important;
+}
+
+.breadcrumb-nav .breadcrumb-nav-list-item a {
+  color: var(--text-muted) !important;
+}
+
+/* ── Search ──────────────────────────────────────────────────────────── */
+.search-input {
+  background-color: var(--bg-elevated) !important;
+  border: 1px solid var(--bg-border) !important;
+  color: var(--text-primary) !important;
+  border-radius: 6px;
+}
+
+.search-input::placeholder {
+  color: var(--text-muted) !important;
+}
+
+.search-results-list {
+  background-color: var(--bg-surface) !important;
+  border: 1px solid var(--bg-border) !important;
+  border-radius: 8px;
+}
+
+.search-result {
+  border-bottom: 1px solid var(--bg-border) !important;
+}
+
+.search-result:hover {
+  background-color: var(--bg-elevated) !important;
+}
+
+.search-result-title {
+  color: var(--text-primary) !important;
+}
+
+.search-result-doc-title {
+  color: var(--text-muted) !important;
+}
+
+/* ── Aux nav links ───────────────────────────────────────────────────── */
+.aux-nav .nav-list-link {
+  color: var(--text-secondary) !important;
+  border: 1px solid var(--bg-border);
+  border-radius: 6px;
+  padding: 4px 12px !important;
+  transition: all 0.15s;
+}
+
+.aux-nav .nav-list-link:hover {
+  color: var(--text-primary) !important;
+  border-color: var(--accent) !important;
+  background: var(--accent-subtle) !important;
+  text-decoration: none;
+}
+
+/* ── Page nav (prev/next) ────────────────────────────────────────────── */
+.page-nav,
+.main-content footer {
+  border-top: 1px solid var(--bg-border) !important;
+  color: var(--text-muted) !important;
+}
+
+/* ── Callouts ────────────────────────────────────────────────────────── */
+.callout {
+  background-color: var(--bg-elevated) !important;
+  border-left: 3px solid var(--accent) !important;
+  border-radius: 0 6px 6px 0;
+  color: var(--text-secondary) !important;
+}
+
+/* ── Scrollbar ───────────────────────────────────────────────────────── */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-base);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--bg-border);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* ── Selection ───────────────────────────────────────────────────────── */
+::selection {
+  background-color: rgba(34, 197, 94, 0.25);
+  color: var(--text-primary);
+}
+
+/* ── Footer ──────────────────────────────────────────────────────────── */
+footer {
+  background-color: var(--bg-nav) !important;
+  border-top: 1px solid var(--bg-border) !important;
+  color: var(--text-muted) !important;
+  font-size: 0.8rem;
+}

--- a/docs/contributing/branch-pr.md
+++ b/docs/contributing/branch-pr.md
@@ -1,0 +1,56 @@
+---
+title: Branch and PR
+parent: Contributing
+nav_order: 2
+---
+
+# Branch and PR Conventions
+
+## Branch Naming
+
+```
+feat/issue-<N>-<short-description>
+fix/issue-<N>-<short-description>
+chore/issue-<N>-<short-description>
+```
+
+Examples:
+- `feat/issue-32-slog-logger-registry`
+- `fix/issue-16-fix-error-message-strings`
+- `chore/issue-39-release-labels`
+
+## PR Requirements
+
+1. Must reference a GitHub issue with `status:approved` label.
+2. Must carry exactly one release-type label (or `release:skip`).
+
+### Release Labels
+
+| Label | Effect |
+|---|---|
+| `release-type:patch` | Patch bump |
+| `release-type:minor` | Minor bump |
+| `release-type:major` | Major bump |
+| `release:skip` | Skip release automation |
+
+### Type Labels
+
+| Label | Usage |
+|---|---|
+| `type:feature` | New capability |
+| `type:bugfix` | Bug fix |
+| `type:chore` | Maintenance, CI, docs, refactor |
+
+## Commit Message Convention
+
+```
+<type>(<scope>): <description>
+```
+
+Examples:
+```
+feat(logging): add slog logger registry with scoped controls
+fix(config): reject non-positive timeout values
+chore(ci): standardize release labels
+docs(architecture): migrate specs from openspec to docs
+```

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,0 +1,15 @@
+---
+title: Contributing
+nav_order: 6
+has_children: true
+permalink: /contributing/
+---
+
+# Contributing
+
+This section explains how to contribute to `common-fwk`.
+
+## Pages
+
+- [SDD Workflow](sdd-workflow/) — How to use the Spec-Driven Development workflow for changes.
+- [Branch and PR](branch-pr/) — Naming conventions and PR requirements.

--- a/docs/contributing/sdd-workflow.md
+++ b/docs/contributing/sdd-workflow.md
@@ -1,0 +1,75 @@
+---
+title: SDD Workflow
+parent: Contributing
+nav_order: 1
+---
+
+# Spec-Driven Development (SDD) Workflow
+
+`common-fwk` uses a structured **Spec-Driven Development (SDD)** workflow for all significant changes.
+This ensures every feature is specified, designed, tested, and verified before merging.
+
+## Why SDD?
+
+- Produces auditable artifacts for every change.
+- Keeps AI agents and human contributors aligned on requirements.
+- Enforces explicit acceptance criteria before implementation starts.
+- Documentation stays synchronized with code.
+
+## Workflow Phases
+
+```
+Issue (approved) → Explore → Propose → Spec → Design → Tasks → Apply → Verify → Archive → PR
+```
+
+### 1. Explore
+
+Investigate the codebase, clarify requirements, and identify boundaries.
+Output: exploration notes.
+
+### 2. Propose
+
+Define intent, scope (in/out), and capability map.
+Output: `proposal.md`.
+
+### 3. Spec
+
+Write testable requirements and acceptance scenarios using Given/When/Then format.
+Output: `spec.md` (delta specs per domain affected).
+
+### 4. Design
+
+Technical approach, architecture decisions, package boundaries, migration notes.
+Output: `design.md`.
+
+### 5. Tasks
+
+Break down implementation into discrete, verifiable tasks organized by phase.
+Output: `tasks.md`.
+
+### 6. Apply
+
+Implement code following specs and design. Track progress in `apply-progress.md`.
+
+### 7. Verify
+
+Validate implementation against specs, tasks, and design.
+Classify findings as CRITICAL / WARNING / SUGGESTION.
+Output: `verify-report.md`.
+
+### 8. Archive
+
+Sync delta specs to canonical docs (`docs/architecture/`).
+Output: `archive-report.md`.
+
+## Issue Requirements
+
+Every change must be linked to a GitHub issue with `status:approved` label.
+Open issues without approval are **blocked** from receiving PRs.
+
+See [Branch and PR](branch-pr/) for naming conventions.
+
+## Tools
+
+The SDD workflow is supported by agent skills in `.atl/` and OpenCode skills.
+Run the relevant skill for each phase (e.g. `sdd-explore`, `sdd-spec`, `sdd-apply`, `sdd-verify`, `sdd-archive`).

--- a/docs/decisions/adr-001-sdd-workflow.md
+++ b/docs/decisions/adr-001-sdd-workflow.md
@@ -1,0 +1,37 @@
+---
+title: ADR-001 SDD Workflow
+parent: Decisions
+nav_order: 1
+---
+
+# ADR-001: Spec-Driven Development (SDD) Workflow
+
+**Status**: Active
+**Date**: 2026-04-25
+
+## Context
+
+The project needed a structured workflow for adding features and changes that would:
+- Produce auditable artifacts (proposals, specs, designs, tasks, verification reports).
+- Work well with AI agents as first-class contributors.
+- Keep documentation synchronized with implementation.
+
+## Decision
+
+Adopt the **Spec-Driven Development (SDD)** workflow for all changes:
+
+1. **Explore** — investigate codebase and clarify requirements.
+2. **Propose** — define intent, scope, and capability map.
+3. **Spec** — write testable requirements and acceptance scenarios.
+4. **Design** — technical approach and architecture decisions.
+5. **Tasks** — implementation task breakdown.
+6. **Apply** — implement code following specs and design.
+7. **Verify** — validate implementation against specs.
+8. **Archive** — sync delta specs to canonical specs, archive change artifacts.
+
+## Consequences
+
+- All significant changes produce structured artifacts readable by both humans and AI tools.
+- `openspec/changes/` served as the artifact store (now superseded — see ADR-004).
+- Canonical specs under `openspec/specs/` (now migrated to `docs/architecture/` — see ADR-004).
+- Verification reports provide a clear record of what was tested.

--- a/docs/decisions/adr-002-adapter-boundary.md
+++ b/docs/decisions/adr-002-adapter-boundary.md
@@ -1,0 +1,30 @@
+---
+title: ADR-002 Adapter Boundary
+parent: Decisions
+nav_order: 2
+---
+
+# ADR-002: Core/Adapter Boundary Pattern
+
+**Status**: Active
+**Date**: 2026-04-25
+
+## Context
+
+Go frameworks risk becoming tightly coupled to their backing libraries (e.g. Viper for config,
+Gin for HTTP). This coupling makes testing harder and consumers depend on indirect transitive imports.
+
+## Decision
+
+Enforce a strict **core/adapter boundary**:
+
+- **Core packages** (`config`, `security/jwt`, `security/keys`, `logging`) depend only on the standard library.
+- **Adapter packages** (`config/viper`, `http/gin`, `logging/slog`) depend on core contracts and wrap external libraries.
+- Adapters wrap and preserve core validation errors (assertable via `errors.Is`/`errors.As`).
+- `app` may depend on both core and adapter contracts but does not contain adapter implementations.
+
+## Consequences
+
+- Core packages can be built and tested in isolation without any third-party import.
+- Consumers adopting only `config` do not transitively import Viper.
+- Future adapters (alternative config backends, alternative HTTP frameworks) can be added without touching core.

--- a/docs/decisions/adr-003-no-global-singleton.md
+++ b/docs/decisions/adr-003-no-global-singleton.md
@@ -1,0 +1,32 @@
+---
+title: ADR-003 No Global Singleton
+parent: Decisions
+nav_order: 3
+---
+
+# ADR-003: No Global Singleton for Application
+
+**Status**: Active
+**Date**: 2026-05-01
+
+## Context
+
+Many frameworks provide a global `App` variable or package-level init functions. This pattern
+is convenient but creates hidden state, complicates parallel test execution, and makes
+dependency tracing implicit.
+
+## Decision
+
+`app.Application` is **instance-scoped**:
+
+- `NewApplication()` always creates a new isolated instance.
+- No package-global `App` variable.
+- All dependencies (config, validator) are provided by the caller via explicit methods.
+- Logger caches, route registrations, and runtime state are isolated per instance.
+
+## Consequences
+
+- Multiple `Application` instances can coexist in the same process (e.g. integration tests).
+- No hidden state between tests.
+- Callers must wire dependencies explicitly — this is intentional.
+- More verbose bootstrap code at the cost of clarity and testability.

--- a/docs/decisions/adr-004-docs-structure.md
+++ b/docs/decisions/adr-004-docs-structure.md
@@ -1,0 +1,42 @@
+---
+title: ADR-004 Docs Structure
+parent: Decisions
+nav_order: 4
+---
+
+# ADR-004: Consolidated Documentation Under /docs (Deprecate openspec/)
+
+**Status**: Active
+**Date**: 2026-05-01
+**Issue**: #35
+
+## Context
+
+The repository used `openspec/` as the primary documentation and artifact store for the SDD workflow.
+This created two problems:
+1. **Documentation duplication**: canonical specs in `openspec/specs/` and user docs in `docs/home.md` diverged.
+2. **Navigation friction**: `openspec/` is not discoverable as user documentation and does not publish well to GitHub Pages.
+
+## Decision
+
+Migrate to a consolidated documentation structure under `/docs/*`:
+
+- `docs/index.md` — landing page (replaces `docs/home.md` content).
+- `docs/getting-started/` — installation and quickstart.
+- `docs/architecture/` — canonical specs (migrated from `openspec/specs/`).
+- `docs/releases/` — release notes reconstructed from tag-to-tag comparison.
+- `docs/migration/` — migration guides (existing content preserved).
+- `docs/decisions/` — architecture decision records.
+- `docs/contributing/` — contribution workflow guide.
+- `docs/_config.yml` — GitHub Pages / just-the-docs configuration.
+
+`openspec/` is **deprecated as an active workflow artifact store**. The folder remains
+in the repository as a historical archive. No new changes should write artifacts to `openspec/`.
+
+## Consequences
+
+- Documentation is navigable via GitHub Pages with `just-the-docs` theme.
+- All `README.md`, `CONTRIBUTING.md`, and internal script references updated to point to `docs/`.
+- `openspec/` folder is preserved as-is for historical reference.
+- A migration note at `docs/migration/openspec-to-docs.md` explains what changed.
+- Future SDD change artifacts may be stored in `docs/changes/` or in Engram (persistent memory) instead of `openspec/`.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,0 +1,20 @@
+---
+title: Decisions
+nav_order: 5
+has_children: true
+permalink: /decisions/
+---
+
+# Architecture Decisions
+
+This section records key architecture decisions made during the development of `common-fwk`.
+Each decision document captures the context, the options considered, and the rationale.
+
+## Decision Log
+
+| ID | Title | Status |
+|---|---|---|
+| [ADR-001](adr-001-sdd-workflow/) | Spec-Driven Development (SDD) workflow | Active |
+| [ADR-002](adr-002-adapter-boundary/) | Core/adapter boundary pattern | Active |
+| [ADR-003](adr-003-no-global-singleton/) | No global singleton for Application | Active |
+| [ADR-004](adr-004-docs-structure/) | Consolidated docs under /docs (deprecate openspec/) | Active |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,15 @@
+---
+title: Getting Started
+nav_order: 2
+has_children: true
+permalink: /getting-started/
+---
+
+# Getting Started
+
+This section covers everything you need to start using `common-fwk` in a new or existing Go service.
+
+## Pages
+
+- [Installation](installation/) — Add the dependency and verify the environment.
+- [Quickstart](quickstart/) — Minimal end-to-end example wiring config, security, and HTTP.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,43 @@
+---
+title: Installation
+parent: Getting Started
+nav_order: 1
+---
+
+# Installation
+
+## Requirements
+
+- Go 1.21 or later
+- A Go module initialized (`go mod init`)
+
+## Add the dependency
+
+```bash
+go get github.com/matiasmartin-labs/common-fwk@latest
+```
+
+To pin to a specific release:
+
+```bash
+go get github.com/matiasmartin-labs/common-fwk@v0.7.0
+```
+
+## Verify
+
+```bash
+go build ./...
+go test ./...
+```
+
+## Optional: Viper adapter
+
+The `config/viper` adapter is a separate import and requires no additional `go get` —
+it is included in the same module:
+
+```go
+import viperconfig "github.com/matiasmartin-labs/common-fwk/config/viper"
+```
+
+All config file keys must use **kebab-case** (e.g. `ttl-minutes`, `http-only`, `client-id`).
+CamelCase keys are legacy-only and will be removed in a future major version.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,91 @@
+---
+title: Quickstart
+parent: Getting Started
+nav_order: 2
+---
+
+# Quickstart
+
+This example wires config, JWT HS256 security, and an HTTP server in a single file.
+
+## 1. Config file (`config.yaml`)
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8080
+  read-timeout: 10s
+  write-timeout: 10s
+  max-header-bytes: 1048576
+
+security:
+  auth:
+    jwt:
+      algorithm: HS256
+      secret: my-secret
+      issuer: my-service
+      ttl-minutes: 60
+
+logging:
+  enabled: true
+  level: info
+  format: json
+```
+
+## 2. Bootstrap (`main.go`)
+
+```go
+package main
+
+import (
+    "log"
+
+    "github.com/matiasmartin-labs/common-fwk/app"
+    viperconfig "github.com/matiasmartin-labs/common-fwk/config/viper"
+    "github.com/matiasmartin-labs/common-fwk/security/jwt"
+    "github.com/matiasmartin-labs/common-fwk/security/keys"
+    httpgin "github.com/matiasmartin-labs/common-fwk/http/gin"
+    "github.com/gin-gonic/gin"
+)
+
+func main() {
+    cfg, err := viperconfig.Load("config.yaml")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    resolver := keys.NewStaticResolver([]byte(cfg.Security.Auth.JWT.Secret))
+    validator, err := jwt.NewValidator(cfg.Security.Auth.JWT, resolver)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    application := app.NewApplication()
+    application.UseConfig(cfg)
+    application.UseServer()
+    application.UseServerSecurity(validator)
+
+    application.RegisterGET("/healthz", func(c *gin.Context) {
+        c.JSON(200, gin.H{"status": "ok"})
+    })
+
+    application.RegisterProtectedGET("/me", httpgin.NewAuthMiddleware(validator), func(c *gin.Context) {
+        c.JSON(200, gin.H{"user": "authenticated"})
+    })
+
+    if err := application.Run(); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+## 3. Run
+
+```bash
+go run main.go
+```
+
+## Next steps
+
+- Read the [Architecture](../architecture/) section for detailed contracts.
+- See the [Migration Guide](../migration/auth-provider-ms-v0.1.0/) if migrating from `auth-provider-ms/pkg`.

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,5 +1,10 @@
 # common-fwk Docs Home
 
+> **Note**: This page is superseded by [`docs/index.md`](index.md) — the new consolidated documentation landing page.
+> It is kept for historical reference only. New documentation is organized under the sections below.
+
+---
+
 This index groups the main project documentation pages.
 
 ## Releases

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+---
+title: Home
+nav_order: 1
+permalink: /
+---
+
+# common-fwk Documentation
+
+`common-fwk` is a Go framework that provides reusable building blocks for microservices:
+config management, JWT security, HTTP middleware, structured logging, health endpoints, and
+a deterministic application bootstrap boundary.
+
+## Sections
+
+| Section | Description |
+|---|---|
+| [Getting Started](getting-started/) | Installation, quickstart, and basic usage |
+| [Architecture](architecture/) | Canonical specs for each package and subsystem |
+| [Releases](releases/) | Release notes and changelogs from tag to tag |
+| [Migration Guides](migration/) | Step-by-step migration guides for consumers |
+| [Contributing](contributing/) | How to contribute changes using the SDD workflow |
+
+## Quick Reference
+
+### Import paths
+
+```go
+import (
+    "github.com/matiasmartin-labs/common-fwk/app"
+    "github.com/matiasmartin-labs/common-fwk/config"
+    "github.com/matiasmartin-labs/common-fwk/config/viper"
+    "github.com/matiasmartin-labs/common-fwk/errors"
+    httpgin "github.com/matiasmartin-labs/common-fwk/http/gin"
+    "github.com/matiasmartin-labs/common-fwk/logging"
+    "github.com/matiasmartin-labs/common-fwk/security/jwt"
+    "github.com/matiasmartin-labs/common-fwk/security/keys"
+    "github.com/matiasmartin-labs/common-fwk/security/claims"
+)
+```
+
+### Minimal bootstrap
+
+```go
+application := app.NewApplication()
+application.UseConfig(cfg)
+application.UseServer()
+application.UseServerSecurity(validator)
+application.RegisterGET("/", handler)
+application.Run()
+```
+
+## Current Release
+
+Latest: **v0.7.0** — slog logger registry with scoped controls.
+
+See [Releases](releases/) for the full history.

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -1,0 +1,17 @@
+---
+title: Migration Guides
+nav_order: 7
+has_children: true
+permalink: /migration/
+---
+
+# Migration Guides
+
+Step-by-step guides for migrating consumers to new versions or structures.
+
+## Guides
+
+| Guide | Description |
+|---|---|
+| [auth-provider-ms → v0.1.0](auth-provider-ms-v0.1.0/) | Migrate from `auth-provider-ms/pkg` to `common-fwk` |
+| [openspec/ → docs/](openspec-to-docs/) | Documentation structure migration (internal) |

--- a/docs/migration/openspec-to-docs.md
+++ b/docs/migration/openspec-to-docs.md
@@ -1,0 +1,55 @@
+---
+title: openspec/ → docs/
+parent: Migration Guides
+nav_order: 2
+---
+
+# Migration Note: openspec/ → docs/
+
+**Date**: 2026-05-01
+**Issue**: #35
+
+## What Changed
+
+The `openspec/` folder was the primary artifact store for the SDD workflow and canonical specs.
+Starting with this change, all user-facing documentation is consolidated under `/docs/*`.
+
+## Content Map
+
+| Old location | New location | Notes |
+|---|---|---|
+| `openspec/specs/config-core/spec.md` | `docs/architecture/config-core.md` | Reformatted as user doc |
+| `openspec/specs/config-viper-adapter/spec.md` | `docs/architecture/config-viper-adapter.md` | Reformatted |
+| `openspec/specs/app-bootstrap/spec.md` | `docs/architecture/app-bootstrap.md` | Reformatted |
+| `openspec/specs/security-core-jwt-validation/spec.md` | `docs/architecture/security-jwt.md` | Reformatted |
+| `openspec/specs/gin-auth-middleware/spec.md` | `docs/architecture/http-gin-middleware.md` | Reformatted |
+| `openspec/specs/errors/spec.md` | `docs/architecture/errors.md` | Reformatted |
+| `openspec/specs/logging-registry/spec.md` | `docs/architecture/logging-registry.md` | Reformatted |
+| `openspec/specs/app-health-readiness-presets/spec.md` | `docs/architecture/health-readiness.md` | Reformatted |
+| `docs/home.md` | `docs/index.md` | Expanded landing page |
+| `docs/releases/v0.1.0-checklist.md` | `docs/releases/v0.1.0.md` | Converted to release notes |
+| `docs/releases/v0.2.0-checklist.md` | `docs/releases/v0.2.0.md` | Converted to release notes |
+| (new) | `docs/releases/v0.3.0.md` — `v0.7.0.md` | Added from tag comparison |
+| `openspec/changes/archive/*` | Remains in `openspec/` as historical archive | Not migrated — archive only |
+| `openspec/changes/active/*` | Remains in `openspec/` as in-progress work | Freeze after this change |
+
+## What Stays in openspec/
+
+`openspec/` is **preserved as a historical archive**. The folder is not deleted.
+
+- `openspec/changes/archive/` — completed SDD change artifacts.
+- `openspec/changes/active/` — in-flight changes at the time of this migration.
+- `openspec/specs/` — original spec files (source of truth migrated to `docs/architecture/`).
+- `openspec/config.yaml` — SDD tool configuration (still valid for legacy runs).
+
+No new documentation should be written to `openspec/`. Future canonical specs go to `docs/architecture/`.
+
+## README and CONTRIBUTING
+
+All references to `openspec/` in `README.md` and `CONTRIBUTING.md` have been updated
+to point to `docs/` sections.
+
+## GitHub Pages
+
+Documentation is now published via GitHub Pages using the `just-the-docs` theme.
+Navigation is driven by front matter (`title`, `parent`, `nav_order`) in each `.md` file.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,32 @@
+---
+title: Releases
+nav_order: 4
+has_children: true
+permalink: /releases/
+---
+
+# Releases
+
+This section documents every published release of `common-fwk`, reconstructed from
+tag-to-tag commit comparison.
+
+| Version | Date | Summary |
+|---|---|---|
+| [v0.7.0](v0.7.0/) | 2026-05-01 | slog logger registry with scoped controls |
+| [v0.6.0](v0.6.0/) | 2026-05-01 | Opt-in health/readiness endpoint presets |
+| [v0.5.0](v0.5.0/) | 2026-05-01 | Read-only app runtime accessors |
+| [v0.4.0](v0.4.0/) | 2026-05-01 | RS256 keypair security mode |
+| [v0.3.0](v0.3.0/) | 2026-05-01 | HTTP server runtime limits |
+| [v0.2.0](v0.2.0/) | 2026-05-01 | Kebab-case config keys (Viper adapter) |
+| [v0.1.0](v0.1.0/) | 2026-04-25 | Initial stable release |
+
+## Release Labels
+
+Release automation uses the following labels on PRs:
+
+| Label | Effect |
+|---|---|
+| `release-type:patch` | Patch version bump (bug fixes) |
+| `release-type:minor` | Minor version bump (new features) |
+| `release-type:major` | Major version bump (breaking changes) |
+| `release:skip` | Skip release generation |

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,40 @@
+---
+title: v0.1.0
+parent: Releases
+nav_order: 7
+---
+
+# v0.1.0
+
+**Released**: 2026-04-25
+**Tag**: `v0.1.0`
+**Type**: Initial stable release
+
+## What's Included
+
+This is the first stable release of `common-fwk`.
+
+### New Capabilities
+
+- **`config`** — Typed, panic-free config model with constructors, validation, and email normalization.
+- **`config/viper`** — File/env config loading adapter (Viper backend).
+- **`security/jwt`** — JWT validation with issuer/audience/method policy and injected time source.
+- **`security/keys`** — Static and RSA key resolver contracts.
+- **`security/claims`** — Typed claims model with OIDC field mapping and private claims map.
+- **`http/gin`** — Gin auth middleware with Bearer/cookie token extraction and 401 standardized errors.
+- **`errors`** — Exported auth error code constants (`CodeTokenMissing`, `CodeTokenInvalid`).
+- **`app`** — Instance-scoped bootstrap boundary (`UseConfig`, `UseServer`, `UseServerSecurity`, `Run`).
+
+## Migration Impact
+
+Consumers should replace local `pkg` abstractions with `common-fwk` imports.
+See [Migration Guide: auth-provider-ms](../migration/auth-provider-ms-v0.1.0/) for detailed steps.
+
+## Known Limitations
+
+- No RS256 keypair mode (added in v0.4.0).
+- No app read-only accessors (added in v0.5.0).
+- No health/readiness presets (added in v0.6.0).
+- No logger registry (added in v0.7.0).
+- No provider-specific Google OAuth implementation.
+- No app-global singleton model (by design).

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,42 @@
+---
+title: v0.2.0
+parent: Releases
+nav_order: 6
+---
+
+# v0.2.0
+
+**Released**: 2026-05-01
+**Tag**: `v0.2.0`
+**Type**: Minor — new feature (kebab-case config enforcement)
+**PR**: #34 — `feat/2026-05-01-issue-29-config-viper-kebab-case`
+
+## What Changed
+
+### `config/viper` — Kebab-case key enforcement
+
+- All YAML/TOML/JSON configuration file keys now **require kebab-case**.
+- Canonical keys: `ttl-minutes`, `http-only`, `same-site`, `client-id`, `client-secret`,
+  `auth-url`, `token-url`, `redirect-url`.
+- CamelCase keys remain accepted for legacy compatibility only and will be removed in a future major version.
+- Docs index added.
+
+## Migration Notes
+
+Update any config files using camelCase keys:
+
+| Old | New |
+|---|---|
+| `ttlMinutes` | `ttl-minutes` |
+| `httpOnly` | `http-only` |
+| `sameSite` | `same-site` |
+| `clientId` | `client-id` |
+| `clientSecret` | `client-secret` |
+| `authUrl` | `auth-url` |
+| `tokenUrl` | `token-url` |
+| `redirectUrl` | `redirect-url` |
+
+## Compatibility
+
+- No breaking changes to Go API.
+- Config file key casing change is required for new behavior; legacy keys still parse.

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,44 @@
+---
+title: v0.3.0
+parent: Releases
+nav_order: 5
+---
+
+# v0.3.0
+
+**Released**: 2026-05-01
+**Tag**: `v0.3.0`
+**Type**: Minor — new feature (server runtime limits)
+**PR**: #36 — `feat/issue-28-http-server-timeout-header-size`
+
+## What Changed
+
+### `config` — Server runtime limits model
+
+Added `ReadTimeout`, `WriteTimeout`, and `MaxHeaderBytes` to `ServerConfig`.
+
+| Field | Default | Env Override |
+|---|---|---|
+| `read-timeout` | `10s` | `COMMON_FWK_SERVER_READ_TIMEOUT` |
+| `write-timeout` | `10s` | `COMMON_FWK_SERVER_WRITE_TIMEOUT` |
+| `max-header-bytes` | `1048576` | `COMMON_FWK_SERVER_MAX_HEADER_BYTES` |
+
+### `app` — Runtime limits applied to `http.Server`
+
+`UseServer()` now reads `ReadTimeout`, `WriteTimeout`, `MaxHeaderBytes` from config and
+applies them to the underlying `http.Server`.
+
+## Example Config
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8080
+  read-timeout: 10s
+  write-timeout: 10s
+  max-header-bytes: 1048576
+```
+
+## Compatibility
+
+- Defaults are backward-compatible — existing configs without these fields get documented defaults.

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,53 @@
+---
+title: v0.4.0
+parent: Releases
+nav_order: 4
+---
+
+# v0.4.0
+
+**Released**: 2026-05-01
+**Tag**: `v0.4.0`
+**Type**: Minor — new feature (RS256 keypair security)
+**PR**: #37 — `feat/issue-30-rs256-keypair-security`
+
+## What Changed
+
+### `config` — RS256 JWT config model
+
+Added RS256 mode to `JWTConfig`:
+
+```yaml
+security:
+  auth:
+    jwt:
+      algorithm: RS256
+      issuer: my-service
+      ttl-minutes: 60
+      rs256-key-source: generated   # generated | public-pem | private-pem
+      rs256-key-id: my-key-id
+      rs256-public-key-pem: |
+        -----BEGIN PUBLIC KEY-----
+        ...
+```
+
+### `security/keys` — RSA resolver constructors
+
+- `keys.NewRSAResolver(privateKey, keyID)` — signs and verifies.
+- `keys.NewRSAPublicKeyResolver(publicKey, keyID)` — verify only.
+
+### `app` — Config-based RS256 wiring
+
+`UseServerSecurityFromConfig()` now supports RS256 bootstrap from config.
+
+## Migration Notes (HS256 → RS256)
+
+1. Set `algorithm: RS256` in JWT config.
+2. Add `rs256-key-source`, `rs256-key-id`, and relevant PEM fields.
+3. Remove `secret` (not used in RS256 mode).
+4. Use `app.UseServerSecurityFromConfig()` or build `NewRSAPublicKeyResolver` manually.
+
+## Compatibility
+
+- HS256 path unchanged and backward-compatible.
+- `algorithm` defaults to `HS256` when omitted.

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,41 @@
+---
+title: v0.5.0
+parent: Releases
+nav_order: 3
+---
+
+# v0.5.0
+
+**Released**: 2026-05-01
+**Tag**: `v0.5.0`
+**Type**: Minor — new feature (read-only app runtime accessors)
+**PR**: #38 — `feat/issue-33-app-readonly-accessors`
+
+## What Changed
+
+### `app` — Read-only runtime accessors
+
+`app.Application` now exposes public read-only accessors:
+
+```go
+cfg := application.GetConfig()               // config.Config (defensive snapshot)
+v   := application.GetSecurityValidator()    // security.Validator or nil
+ok  := application.IsSecurityReady()         // bool
+```
+
+### Lifecycle semantics
+
+| Stage | `GetConfig()` | `GetSecurityValidator()` | `IsSecurityReady()` |
+|---|---|---|---|
+| Pre-init | zero-value | `nil` | `false` |
+| `UseConfig` only | live snapshot | `nil` | `false` |
+| Post-`UseServerSecurity` | live snapshot | non-`nil` | `true` |
+
+### Immutability guarantee
+
+`GetConfig()` returns a **defensive snapshot** — mutations to the returned value
+do not affect internal runtime state.
+
+## Compatibility
+
+- No breaking changes. Accessors are additive.

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,45 @@
+---
+title: v0.6.0
+parent: Releases
+nav_order: 2
+---
+
+# v0.6.0
+
+**Released**: 2026-05-01
+**Tag**: `v0.6.0`
+**Type**: Minor — new feature (health/readiness endpoint presets)
+**PR**: #40 — `feat/issue-31-health-readiness-presets`
+
+## What Changed
+
+### `app` — Opt-in health/readiness presets
+
+```go
+err := application.EnableHealthReadinessPresets(app.HealthReadinessOptions{
+    HealthPath:  "/healthz",
+    ReadyPath:   "/readyz",
+    ReadyChecks: []app.ReadyCheck{...},
+})
+```
+
+### Endpoint behavior
+
+- `/healthz` → `200 OK` once presets are enabled.
+- `/readyz` → `200 OK` when bootstrap invariants pass AND all readiness checks return `nil`; else `503`.
+
+### Error conditions
+
+| Condition | Error |
+|---|---|
+| `UseServer()` not called | `app.ErrServerNotReady` |
+| Blank/conflicting paths | `app.ErrInvalidPresetOptions` / `app.ErrRouteConflict` |
+
+## Non-Goals
+
+- `UseServer()` does **not** auto-register health/readiness routes — opt-in is explicit.
+- No framework-built provider probes — readiness checks are caller-provided.
+
+## Compatibility
+
+- No breaking changes. `EnableHealthReadinessPresets` is additive.

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,78 @@
+---
+title: v0.7.0
+parent: Releases
+nav_order: 1
+---
+
+# v0.7.0
+
+**Released**: 2026-05-01
+**Tag**: `v0.7.0`
+**Type**: Minor — new feature (slog logger registry)
+**PR**: #41 — `feat/issue-32-slog-logger-registry`
+
+## What Changed
+
+### `logging` / `logging/slog` — Named logger registry
+
+New package providing deterministic named logger access backed by `log/slog`.
+
+```go
+logger, err := application.GetLogger("auth")
+logger.Infof("user %s authenticated", userID)
+```
+
+### `app` — `GetLogger` accessor
+
+```go
+logger, err := application.GetLogger(name string) (logging.Logger, error)
+```
+
+- Pre-`UseConfig`: returns `logging.ErrLoggingNotReady`.
+- Empty name: returns `logging.ErrLoggerNameRequired`.
+- Same name → same instance (deterministic, isolated per `Application`).
+
+### Config keys
+
+```yaml
+logging:
+  enabled: true
+  level: info      # debug | info | warn | error
+  format: json     # json | text
+  loggers:
+    auth:
+      level: debug
+    billing:
+      enabled: false
+```
+
+### Env overrides
+
+```bash
+COMMON_FWK_LOGGING_ENABLED=true
+COMMON_FWK_LOGGING_LEVEL=warn
+COMMON_FWK_LOGGING_FORMAT=json
+COMMON_FWK_LOGGING_LOGGERS_AUTH_LEVEL=debug
+```
+
+### Precedence matrix
+
+| Setting | Resolution |
+|---|---|
+| `enabled` | per-logger override → root |
+| `level` | per-logger override → root |
+| `format` | root only |
+
+### Output contract
+
+All records include: `logger`, `ts`, `level`, `msg`.
+
+### Loki guidance
+
+Use collector-first integration (Promtail / OTel Collector → Loki).
+Do not couple the app directly to a Loki HTTP sink.
+
+## Compatibility
+
+- No breaking changes. `GetLogger` is additive.
+- Logger registry is isolated per `Application` instance.


### PR DESCRIPTION
Closes #35

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Consolidates all documentation under `/docs/*` replacing `openspec/` as the active docs source
- Adds GitHub Pages support with `just-the-docs` theme and dark mode inspired by opencode.ai
- Reconstructs release notes (v0.1.0–v0.7.0), adds architecture specs, ADRs, contributing guide, and migration note

## Changes

| File | Change |
|---|---|
| `docs/_config.yml` | GitHub Pages config with `just-the-docs`, dark mode, custom domain |
| `docs/assets/css/custom.css` | Dark theme CSS (opencode.ai palette — green accent, deep black bg) |
| `docs/index.md` | New consolidated landing page (replaces home.md) |
| `docs/getting-started/` | Installation and quickstart guides (new) |
| `docs/architecture/` | Canonical specs migrated from `openspec/specs/` (9 pages) |
| `docs/releases/` | Release notes v0.1.0–v0.7.0 reconstructed from tag comparison |
| `docs/decisions/` | Architecture decision records ADR-001–ADR-004 (new) |
| `docs/contributing/` | SDD workflow and branch/PR conventions (new) |
| `docs/migration/index.md` | Migration section index (new) |
| `docs/migration/openspec-to-docs.md` | Migration note explaining content map and deprecation |
| `docs/home.md` | Marked as deprecated, points to new index.md |
| `README.md` | Docs section updated, openspec/ references removed |

## Test Plan

- [x] All docs files are valid Markdown
- [x] `_config.yml` uses correct custom domain (`common-fwk.mmartinlabs.com`)
- [x] `color_scheme: dark` + custom CSS applied
- [x] No scripts modified — shellcheck not required
- [x] `openspec/` preserved as historical archive (no deletions)