### PR TITLE
fix(docs): add Gemfile to resolve just-the-docs theme dependency

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+gem "just-the-docs"


### PR DESCRIPTION
## Summary

- Adds `docs/Gemfile` declaring `github-pages` and `just-the-docs` gems
- Without this file, Bundler cannot resolve the `just-the-docs` theme and the Jekyll build fails
- Fixes the failing GitHub Pages deployment

Closes #44