### PR TITLE
fix(docs): migrate Pages deploy to GitHub Actions to support just-the-docs theme

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,53 @@
+name: docs-deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Jekyll docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Build Jekyll
+        run: bundle exec jekyll build --source . --destination ./_site
+        working-directory: docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,28 @@
+name: docs-preview
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Jekyll docs (preview)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Build Jekyll
+        run: bundle exec jekyll build --source . --destination ./_site
+        working-directory: docs


### PR DESCRIPTION
## Summary

- Migrates GitHub Pages deployment from the native runner to a custom GitHub Actions workflow
- Adds `docs-preview` workflow that runs the Jekyll build on any PR touching `docs/**`

## Root Cause

The native GitHub Pages runner uses `github-pages` gem v232 (Jekyll 3.10.0) which has a **restricted theme allowlist** that excludes `just-the-docs`. The `Gemfile` alone cannot fix this because the native runner does not use it to install gems — it has its own fixed set.

## Solution

- **`docs-deploy.yml`**: triggers on push to `main` with changes in `docs/**`, runs `bundle install` + `bundle exec jekyll build`, uploads artifact and deploys to Pages via `actions/deploy-pages`
- **`docs-preview.yml`**: triggers on PRs with changes in `docs/**`, runs the same build step without deploying — catches failures before merging

## Required Manual Action

After merging, change **GitHub → Settings → Pages → Build and deployment → Source** from `Deploy from a branch` to **`GitHub Actions`**. Without this change the native runner keeps running alongside the new workflow.

Closes #44