### PR TITLE
docs: fix punctuation in index intro

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ permalink: /
 
 # common-fwk Documentation
 
-`common-fwk` is a Go framework that provides reusable building blocks for microservices:
+`common-fwk` is a Go framework that provides reusable building blocks for microservices.
 config management, JWT security, HTTP middleware, structured logging, health endpoints, and
 a deterministic application bootstrap boundary.
 


### PR DESCRIPTION
## Summary

- Minor punctuation fix in `docs/index.md` to trigger the new `docs-preview` workflow and validate the Jekyll build pipeline end-to-end.

Closes #44