### PR TITLE
feat(app): add GetRSAPublicKey and GetRSAKeyID accessors (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,10 +479,14 @@ Accessor lifecycle + immutability contract:
 - `GetSecurityValidator() security.Validator`
 - `IsSecurityReady() bool`
 - `GetRSAPrivateKey() *rsa.PrivateKey`
+- `GetRSAPublicKey() *rsa.PublicKey`
+- `GetRSAKeyID() string`
 - `GetConfig()` is safe in all lifecycle stages and never triggers implicit bootstrap.
 - Before security wiring, `GetSecurityValidator()` returns `nil` and `IsSecurityReady()` returns `false`.
 - `GetConfig()` deep-copies mutable descendants (OAuth2 providers map and nested scopes slices) on each read.
 - `GetRSAPrivateKey()` returns a non-nil key only when `UseServerSecurityFromConfig()` was called with RS256 algorithm and `Generated` or `PrivatePEM` key source. Returns `nil` for `PublicPEM`, direct `UseServerSecurity(v)` wiring, or when no security is wired. Never panics.
+- `GetRSAPublicKey()` returns a non-nil key for any RS256 key source (`Generated`, `PrivatePEM`, `PublicPEM`). Returns `nil` for direct `UseServerSecurity(v)` wiring or when no security is wired. Never panics.
+- `GetRSAKeyID()` returns the non-empty key ID for any RS256 key source. Returns empty string for direct `UseServerSecurity(v)` wiring or when no security is wired. Never panics.
 
 ### 6) Named logger registry (`GetLogger`) and logging config
 

--- a/app/application.go
+++ b/app/application.go
@@ -68,6 +68,8 @@ type Application struct {
 	serverReady    bool
 	securityReady  bool
 	rsaPrivateKey  *rsa.PrivateKey
+	rsaPublicKey   *rsa.PublicKey
+	rsaKeyID       string
 }
 
 // GetConfig returns a read-only snapshot of the current runtime config.
@@ -86,6 +88,23 @@ func (a *Application) GetSecurityValidator() security.Validator {
 // configured key source does not provide a private key (e.g. PublicPEM).
 func (a *Application) GetRSAPrivateKey() *rsa.PrivateKey {
 	return a.rsaPrivateKey
+}
+
+// GetRSAPublicKey returns the RSA public key derived during security wiring.
+//
+// Returns non-nil for any RS256 key source (Generated, PrivatePEM, PublicPEM).
+// Returns nil when security was not wired via UseServerSecurityFromConfig or
+// algorithm is not RS256.
+func (a *Application) GetRSAPublicKey() *rsa.PublicKey {
+	return a.rsaPublicKey
+}
+
+// GetRSAKeyID returns the key ID associated with the RSA key during security wiring.
+//
+// Returns non-empty for any RS256 key source. Returns empty string when security
+// was not wired via UseServerSecurityFromConfig or algorithm is not RS256.
+func (a *Application) GetRSAKeyID() string {
+	return a.rsaKeyID
 }
 
 // IsSecurityReady reports whether security runtime was fully wired.
@@ -231,6 +250,8 @@ func (a *Application) UseServerSecurityFromConfig() (*Application, error) {
 
 	a.UseServerSecurity(validator)
 	a.rsaPrivateKey = compat.RSAPrivateKey
+	a.rsaPublicKey = compat.RSAPublicKey
+	a.rsaKeyID = compat.RSAKeyID
 	return a, nil
 }
 

--- a/app/application_test.go
+++ b/app/application_test.go
@@ -1426,3 +1426,167 @@ func TestGetRSAPrivateKey(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRSAPublicKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T) *Application
+		wantNonNil bool
+	}{
+		{
+			name: "Generated key source returns non-nil",
+			setup: func(t *testing.T) *Application {
+				a := NewApplication().UseConfig(rs256AppConfig(config.NewRS256GeneratedConfig("gen-key")))
+				_, err := a.UseServerSecurityFromConfig()
+				if err != nil {
+					t.Fatalf("UseServerSecurityFromConfig: %v", err)
+				}
+				return a
+			},
+			wantNonNil: true,
+		},
+		{
+			name: "PrivatePEM key source returns non-nil",
+			setup: func(t *testing.T) *Application {
+				a := NewApplication().UseConfig(rs256AppConfig(config.NewRS256PrivatePEMConfig("priv-key", mustRSAPrivatePEM(t))))
+				_, err := a.UseServerSecurityFromConfig()
+				if err != nil {
+					t.Fatalf("UseServerSecurityFromConfig: %v", err)
+				}
+				return a
+			},
+			wantNonNil: true,
+		},
+		{
+			name: "PublicPEM key source returns non-nil",
+			setup: func(t *testing.T) *Application {
+				a := NewApplication().UseConfig(rs256AppConfig(config.NewRS256PublicPEMConfig("pub-key", mustRSAPublicPEM(t))))
+				_, err := a.UseServerSecurityFromConfig()
+				if err != nil {
+					t.Fatalf("UseServerSecurityFromConfig: %v", err)
+				}
+				return a
+			},
+			wantNonNil: true,
+		},
+		{
+			name: "HS256 algorithm returns nil",
+			setup: func(_ *testing.T) *Application {
+				return NewApplication().UseConfig(testConfig()).UseServerSecurity(&fakeValidator{})
+			},
+			wantNonNil: false,
+		},
+		{
+			name: "no security wired returns nil without panic",
+			setup: func(_ *testing.T) *Application {
+				return NewApplication()
+			},
+			wantNonNil: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := tc.setup(t)
+
+			var got *rsa.PublicKey
+			mustNotPanic(t, "GetRSAPublicKey", func() {
+				got = a.GetRSAPublicKey()
+			})
+
+			if tc.wantNonNil && got == nil {
+				t.Fatalf("expected non-nil RSA public key, got nil")
+			}
+			if !tc.wantNonNil && got != nil {
+				t.Fatalf("expected nil RSA public key, got non-nil")
+			}
+		})
+	}
+}
+
+func TestGetRSAKeyID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T) *Application
+		wantNonEmpty  bool
+	}{
+		{
+			name: "Generated key source returns non-empty key ID",
+			setup: func(t *testing.T) *Application {
+				a := NewApplication().UseConfig(rs256AppConfig(config.NewRS256GeneratedConfig("my-key")))
+				_, err := a.UseServerSecurityFromConfig()
+				if err != nil {
+					t.Fatalf("UseServerSecurityFromConfig: %v", err)
+				}
+				return a
+			},
+			wantNonEmpty: true,
+		},
+		{
+			name: "PrivatePEM key source returns non-empty key ID",
+			setup: func(t *testing.T) *Application {
+				a := NewApplication().UseConfig(rs256AppConfig(config.NewRS256PrivatePEMConfig("my-key", mustRSAPrivatePEM(t))))
+				_, err := a.UseServerSecurityFromConfig()
+				if err != nil {
+					t.Fatalf("UseServerSecurityFromConfig: %v", err)
+				}
+				return a
+			},
+			wantNonEmpty: true,
+		},
+		{
+			name: "PublicPEM key source returns non-empty key ID",
+			setup: func(t *testing.T) *Application {
+				a := NewApplication().UseConfig(rs256AppConfig(config.NewRS256PublicPEMConfig("my-key", mustRSAPublicPEM(t))))
+				_, err := a.UseServerSecurityFromConfig()
+				if err != nil {
+					t.Fatalf("UseServerSecurityFromConfig: %v", err)
+				}
+				return a
+			},
+			wantNonEmpty: true,
+		},
+		{
+			name: "HS256 algorithm returns empty key ID",
+			setup: func(_ *testing.T) *Application {
+				return NewApplication().UseConfig(testConfig()).UseServerSecurity(&fakeValidator{})
+			},
+			wantNonEmpty: false,
+		},
+		{
+			name: "no security wired returns empty without panic",
+			setup: func(_ *testing.T) *Application {
+				return NewApplication()
+			},
+			wantNonEmpty: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := tc.setup(t)
+
+			var got string
+			mustNotPanic(t, "GetRSAKeyID", func() {
+				got = a.GetRSAKeyID()
+			})
+
+			if tc.wantNonEmpty && got == "" {
+				t.Fatalf("expected non-empty RSA key ID, got empty")
+			}
+			if !tc.wantNonEmpty && got != "" {
+				t.Fatalf("expected empty RSA key ID, got %q", got)
+			}
+		})
+	}
+}

--- a/app/doc.go
+++ b/app/doc.go
@@ -7,6 +7,8 @@
 //	IsSecurityReady() bool
 //	GetLogger(name string) (logging.Logger, error)
 //	GetRSAPrivateKey() *rsa.PrivateKey
+//	GetRSAPublicKey() *rsa.PublicKey
+//	GetRSAKeyID() string
 //
 // Lifecycle contract:
 //   - Pre-init (fresh NewApplication): GetConfig returns zero-value config snapshot,
@@ -24,6 +26,20 @@
 //     PrivatePEM key source.
 //   - Returns nil when key source is PublicPEM, when security was wired via
 //     UseServerSecurity(v) directly, or when security was never wired.
+//   - Never panics regardless of bootstrap state.
+//
+// RSA public key accessor:
+//   - GetRSAPublicKey() returns a non-nil *rsa.PublicKey when security was wired
+//     via UseServerSecurityFromConfig() with RS256 algorithm (any key source).
+//   - Returns nil when security was wired via UseServerSecurity(v) directly,
+//     when algorithm is not RS256, or when security was never wired.
+//   - Never panics regardless of bootstrap state.
+//
+// RSA key ID accessor:
+//   - GetRSAKeyID() returns the non-empty key ID string when security was wired
+//     via UseServerSecurityFromConfig() with RS256 algorithm (any key source).
+//   - Returns empty string when security was wired via UseServerSecurity(v) directly,
+//     when algorithm is not RS256, or when security was never wired.
 //   - Never panics regardless of bootstrap state.
 //
 // Immutability contract:

--- a/docs/home.md
+++ b/docs/home.md
@@ -63,15 +63,27 @@ server:
 - `GetSecurityValidator() security.Validator`
 - `IsSecurityReady() bool`
 - `GetRSAPrivateKey() *rsa.PrivateKey`
+- `GetRSAPublicKey() *rsa.PublicKey`
+- `GetRSAKeyID() string`
 
 Lifecycle semantics are explicit and deterministic:
-- Pre-init (`NewApplication()`): config accessor returns zero-value snapshot; security accessors return `nil` / `false`; `GetRSAPrivateKey()` returns `nil`.
+- Pre-init (`NewApplication()`): config accessor returns zero-value snapshot; security accessors return `nil` / `false`; `GetRSAPrivateKey()` returns `nil`; `GetRSAPublicKey()` returns `nil`; `GetRSAKeyID()` returns `""`.
 - Partial-init (`UseConfig(...)` only): config accessor reflects configured runtime state; security accessors remain `nil` / `false`.
 - Post-init (security wiring success): security validator accessor is non-`nil` and `IsSecurityReady()` is `true`.
 
 RSA private key accessor (`GetRSAPrivateKey()`):
 - Returns a non-nil `*rsa.PrivateKey` only when `UseServerSecurityFromConfig()` is called with RS256 algorithm and `Generated` or `PrivatePEM` key source.
 - Returns `nil` for `PublicPEM` key source, direct `UseServerSecurity(v)` wiring, or when no security is wired.
+- Never panics regardless of bootstrap state.
+
+RSA public key accessor (`GetRSAPublicKey()`):
+- Returns a non-nil `*rsa.PublicKey` for any RS256 key source (`Generated`, `PrivatePEM`, `PublicPEM`).
+- Returns `nil` for direct `UseServerSecurity(v)` wiring or when no security is wired.
+- Never panics regardless of bootstrap state.
+
+RSA key ID accessor (`GetRSAKeyID()`):
+- Returns the non-empty key ID string for any RS256 key source.
+- Returns `""` for direct `UseServerSecurity(v)` wiring or when no security is wired.
 - Never panics regardless of bootstrap state.
 
 Immutability guarantee:

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -12,6 +12,7 @@ tag-to-tag commit comparison.
 
 | Version | Date | Summary |
 |---|---|---|
+| [v0.10.0](v0.10.0/) | 2026-05-02 | RSA public key accessor |
 | [v0.9.0](v0.9.0/) | 2026-05-02 | RSA private key accessor |
 | [v0.8.0](v0.8.0/) | 2026-05-02 | Default JSON 404/405 handlers |
 | [v0.7.0](v0.7.0/) | 2026-05-01 | slog logger registry with scoped controls |

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -1,0 +1,52 @@
+---
+title: v0.10.0
+parent: Releases
+nav_order: 1
+---
+
+# v0.10.0
+
+**Released**: 2026-05-02
+**Tag**: `v0.10.0`
+**Type**: Minor — new feature (RSA public key accessor)
+**PR**: #53 — `feat/issue-53-rsa-public-key-accessor`
+
+## What Changed
+
+### `app` — RSA public key and key ID accessors (`GetRSAPublicKey()`, `GetRSAKeyID()`)
+
+Services that act as identity providers and need to serve a JWKS endpoint previously had to
+hold a separate public key reference outside the framework. Now `app.Application` surfaces
+both the RSA public key and its key ID via read-only accessors.
+
+```go
+app, err := fwkapp.NewApplication().
+    UseConfig(cfg).
+    UseServer().
+    UseServerSecurityFromConfig()
+
+pubKey := app.GetRSAPublicKey()
+keyID  := app.GetRSAKeyID()
+app.RegisterGET("/.well-known/jwks.json", jwks.NewHandlerFromPublicKey(pubKey, keyID))
+```
+
+| Key source | `GetRSAPublicKey()` result | `GetRSAKeyID()` result |
+|---|---|---|
+| `Generated` | non-nil `*rsa.PublicKey` | non-empty string |
+| `PrivatePEM` | non-nil `*rsa.PublicKey` (derived from private key) | non-empty string |
+| `PublicPEM` | non-nil `*rsa.PublicKey` (parsed from PEM) | non-empty string |
+| HS256 algorithm | `nil` | `""` |
+| No security wired | `nil` (no panic) | `""` (no panic) |
+
+This is the companion to v0.9.0's `GetRSAPrivateKey()`. Together they allow full JWKS-based
+key management without any auxiliary bootstrap struct or `server.Bootstrap.KeyPair` workaround.
+
+## Compatibility
+
+- No breaking changes. Both accessors are new additive methods with no side effects.
+- The internal `CompatOptions` struct gains `RSAPublicKey *rsa.PublicKey` and `RSAKeyID string` fields — not part of the public API surface.
+
+## Closes
+
+- #53 (RSA public key accessor)
+- Eliminates `server.Bootstrap.KeyPair` workaround in downstream services

--- a/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/apply-progress.md
+++ b/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/apply-progress.md
@@ -1,0 +1,43 @@
+# Apply Progress: issue-53-rsa-public-key-accessor
+
+**Mode**: Strict TDD  
+**Status**: COMPLETE ✅  
+**Date**: 2026-05-02
+
+## TDD Cycle Evidence
+
+| Task | RED | GREEN | REFACTOR |
+|------|-----|-------|----------|
+| T1.1 TestGetRSAPublicKey | ✅ compile error | ✅ passes | — |
+| T1.2 TestGetRSAKeyID | ✅ compile error | ✅ passes | — |
+| T2.1-2.5 Implementation | — | ✅ all tests green | — |
+| T3.1-3.4 Documentation | — | ✅ doc sync test passes | — |
+| T4.1 Full suite | — | ✅ `go test ./...` all pass | — |
+
+## Completed Tasks
+
+- [x] 1.1 TestGetRSAPublicKey (5 scenarios: Generated, PrivatePEM, PublicPEM, HS256, unwired)
+- [x] 1.2 TestGetRSAKeyID (5 scenarios: Generated, PrivatePEM, PublicPEM, HS256, unwired)
+- [x] 1.3 RED confirmed
+- [x] 2.1 CompatOptions: RSAPublicKey + RSAKeyID fields added
+- [x] 2.2 resolveRS256: 4-return signature; parseRS256PublicPEM added
+- [x] 2.3 Application: rsaPublicKey + rsaKeyID fields
+- [x] 2.4 UseServerSecurityFromConfig: wired new fields
+- [x] 2.5 GetRSAPublicKey() and GetRSAKeyID() methods added
+- [x] 2.6 GREEN confirmed
+- [x] 3.1 doc.go updated with new signatures
+- [x] 3.2 app tests pass
+- [x] 3.3 README.md updated
+- [x] 3.4 docs/home.md updated
+- [x] 4.1 Full suite: all 12 packages pass
+
+## Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `app/application_test.go` | Modified | Added TestGetRSAPublicKey and TestGetRSAKeyID |
+| `security/jwt/compat.go` | Modified | Extended CompatOptions, updated resolveRS256, added parseRS256PublicPEM |
+| `app/application.go` | Modified | Added fields + accessors |
+| `app/doc.go` | Modified | Added accessor signatures |
+| `README.md` | Modified | Added accessor rows |
+| `docs/home.md` | Modified | Added accessor docs |

--- a/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/archive.md
+++ b/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/archive.md
@@ -1,0 +1,82 @@
+# Archive Report
+
+**Change**: issue-53-rsa-public-key-accessor  
+**Archived**: 2026-05-02  
+**Release**: v0.10.0  
+**Branch**: feat/issue-53-rsa-public-key-accessor  
+**Artifact store**: hybrid  
+
+---
+
+## Verification Status
+
+**Verdict**: PASS  
+**Tasks**: 14/14 complete  
+**Spec scenarios**: 12/12 compliant  
+**Critical issues**: None  
+
+---
+
+## Specs Synced
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| security-rs256-keypair-management | Updated | 3 requirements added (RSA public key accessor, RSA key ID accessor, CompatOptions fields); existing 3 requirements preserved |
+
+**Main spec**: `openspec/specs/security-rs256-keypair-management/spec.md`
+
+---
+
+## Archive Contents
+
+- `proposal.md` ✅
+- `explore.md` ✅
+- `specs/security-rs256-keypair-management/spec.md` ✅
+- `design.md` ✅
+- `tasks.md` ✅ (14/14 tasks complete)
+- `verify-report.md` ✅
+- `apply-progress.md` ✅
+- `archive.md` ✅ (this file)
+
+---
+
+## Implementation Summary
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `app/application.go` | Added `rsaPublicKey *rsa.PublicKey` and `rsaKeyID string` private fields; added `GetRSAPublicKey()` and `GetRSAKeyID()` public accessors; wired both in `UseServerSecurityFromConfig` |
+| `app/application_test.go` | Added `TestGetRSAPublicKey` and `TestGetRSAKeyID` table-driven tests covering all 3 RS256 sources, HS256, and unwired cases |
+| `security/jwt/compat.go` | Added `RSAPublicKey *rsa.PublicKey` and `RSAKeyID string` fields to `CompatOptions`; populated both in `resolveRS256` |
+| `app/doc.go` | Updated package godoc to document new accessors |
+| `README.md` | Added `GetRSAPublicKey()` and `GetRSAKeyID()` to accessor table and documentation |
+| `docs/home.md` | Added RSA public key and key ID accessor documentation |
+| `docs/releases/v0.10.0.md` | Created release notes |
+| `docs/releases/index.md` | Added v0.10.0 entry at top |
+
+---
+
+## Source of Truth Updated
+
+`openspec/specs/security-rs256-keypair-management/spec.md` now includes all three new requirements:
+- **RSA public key accessor on Application** (5 scenarios)
+- **RSA key ID accessor on Application** (3 scenarios)
+- **CompatOptions carries RSA public key and key ID**
+
+---
+
+## SDD Cycle Complete
+
+| Phase | Status |
+|-------|--------|
+| Explore | ✅ |
+| Propose | ✅ |
+| Spec | ✅ |
+| Design | ✅ |
+| Tasks | ✅ |
+| Apply | ✅ |
+| Verify | ✅ PASS |
+| Archive | ✅ |
+
+The change has been fully planned, implemented, verified, and archived. Ready for the next change.

--- a/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/design.md
+++ b/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/design.md
@@ -1,0 +1,87 @@
+# Design: RSA Public Key and Key ID Accessors on app.Application
+
+## Technical Approach
+
+Mirror issue-52's `GetRSAPrivateKey()` pattern exactly. Extend `CompatOptions` with two new fields, populate them in `resolveRS256` for all three RS256 key sources, capture them in `Application` during `UseServerSecurityFromConfig`, and expose them as O(1) nil-safe accessors.
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|--------|----------|----------|
+| Add fields to `CompatOptions` | Minimal surface; consistent with `RSAPrivateKey` already there | ✅ Chosen |
+| Return public key from resolver | Requires interface change; breaks provider boundary | ❌ Rejected |
+| Recompute public key on each call | Wastes CPU; breaks nil semantics for HS256/unwired | ❌ Rejected |
+
+## Data Flow
+
+```
+FromConfigJWT (RS256 branch)
+  └─→ resolveRS256(cfg)
+        ├─ Generated:   priv → &priv.PublicKey + cfg.KeyID
+        ├─ PrivatePEM:  priv → &priv.PublicKey + cfg.KeyID
+        └─ PublicPEM:   parsedPub + cfg.KeyID
+  └─→ CompatOptions{ RSAPublicKey, RSAKeyID, RSAPrivateKey, ... }
+
+UseServerSecurityFromConfig
+  └─→ a.rsaPublicKey = compat.RSAPublicKey
+  └─→ a.rsaKeyID     = compat.RSAKeyID
+
+GetRSAPublicKey() → a.rsaPublicKey  (nil if HS256 or unwired)
+GetRSAKeyID()     → a.rsaKeyID      ("" if HS256 or unwired)
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `security/jwt/compat.go` | Modify | Add `RSAPublicKey *rsa.PublicKey` + `RSAKeyID string` to `CompatOptions`; populate both in `resolveRS256` for all three branches |
+| `app/application.go` | Modify | Add `rsaPublicKey *rsa.PublicKey` + `rsaKeyID string` fields; capture from `compat`; add two accessor methods |
+| `app/application_test.go` | Modify | Add `TestGetRSAPublicKey` + `TestGetRSAKeyID` table-driven tests covering all 5 scenarios each |
+| `app/doc.go` | Modify | Add `GetRSAPublicKey` + `GetRSAKeyID` signatures |
+| `README.md` | Modify | Add accessor rows to accessor table |
+| `docs/home.md` | Modify | Add accessor rows to accessor table |
+
+## Interfaces / Contracts
+
+```go
+// CompatOptions — additions only
+type CompatOptions struct {
+    // ... existing fields ...
+    RSAPublicKey *rsa.PublicKey // non-nil for all RS256 key sources
+    RSAKeyID     string         // non-empty for all RS256 key sources
+}
+
+// Application — additions only
+func (a *Application) GetRSAPublicKey() *rsa.PublicKey { return a.rsaPublicKey }
+func (a *Application) GetRSAKeyID() string             { return a.rsaKeyID }
+```
+
+`resolveRS256` changes:
+
+```go
+// Generated & PrivatePEM branches: append to return
+RSAPublicKey: &priv.PublicKey,
+RSAKeyID:     cfg.KeyID,
+
+// PublicPEM branch: set after parsing pub
+RSAPublicKey: parsedPub,
+RSAKeyID:     cfg.KeyID,
+```
+
+Note: `resolveRS256` currently returns `(*rsa.PrivateKey, keys.Resolver, error)`. To also return the public key without changing the signature, the caller (`FromConfigJWT`) will derive `RSAPublicKey` from `CompatOptions.RSAPrivateKey` for Generated/PrivatePEM and from a new return value for PublicPEM. Simplest: change `resolveRS256` to return `(*rsa.PrivateKey, *rsa.PublicKey, keys.Resolver, error)` — internal function, no external API break.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | `GetRSAPublicKey` — all 5 scenarios | Table-driven in `application_test.go` |
+| Unit | `GetRSAKeyID` — all 3 scenarios | Table-driven in `application_test.go` |
+| Unit | `CompatOptions` field population | Existing `compat_test.go` extended |
+
+## Migration / Rollout
+
+No migration required. Purely additive — new fields on existing structs, new methods on existing type. Zero-value semantics (`nil`, `""`) are safe for unwired Applications.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/explore.md
+++ b/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/explore.md
@@ -1,0 +1,180 @@
+## Exploration: issue-53-rsa-public-key-accessor
+
+### Current State
+
+#### `app.Application` struct (post-issue-52)
+
+Defined in `app/application.go`:
+
+```go
+type Application struct {
+    cfg            config.Config
+    server         http.Server
+    handler        *gin.Engine
+    validator      security.Validator
+    loggerRegistry logging.Registry
+    logOutput      io.Writer
+    serverReady    bool
+    securityReady  bool
+    rsaPrivateKey  *rsa.PrivateKey   // added by issue-52
+}
+```
+
+Issue #52 already added `rsaPrivateKey` and `GetRSAPrivateKey()`. The public key accessor is its direct companion.
+
+#### Where the RSA public key lives
+
+The public key is reachable from the **existing** `rsaPrivateKey` field as `&a.rsaPrivateKey.PublicKey` (for Generated and PrivatePEM sources). However, when `KeySourcePublicPEM` is used, `rsaPrivateKey` is nil — only the public key is available, and it is **not** currently retained anywhere on `Application`.
+
+#### How security wiring works (full chain)
+
+1. `UseServerSecurityFromConfig()` calls `securityjwt.FromConfigJWT(cfg.Security.Auth.JWT)` → returns `CompatOptions`
+2. `CompatOptions` currently carries:
+   - `Options` — validator options including the `keys.Resolver`
+   - `TokenTTL` — duration
+   - `RSAPrivateKey *rsa.PrivateKey` — non-nil for Generated/PrivatePEM, nil for PublicPEM
+3. For RS256, `resolveRS256` in `security/jwt/compat.go` calls:
+   - `keys.NewRSAResolver(priv, cfg.KeyID)` for Generated/PrivatePEM — builds a `staticResolver` with `Key{ID: keyID, Verify: &priv.PublicKey}`
+   - `keys.ResolverFromRS256Config(cfg)` → `keys.NewRSAPublicKeyResolver(pub, cfg.KeyID)` for PublicPEM
+4. **The KeyID** (from `cfg.RS256.KeyID`) is stored in the `Key` inside the `staticResolver` but not surfaced to `Application`
+5. **The public key** is stored as `Key.Verify` (of type `*rsa.PublicKey`) inside the resolver — not surfaced to `Application`
+
+#### Key ID storage
+
+`config.RS256Config.KeyID` is used to construct the `keys.Key.ID` inside the resolver. It is **not** retained by `Application` directly. The key ID is required for all three key sources (Generated, PrivatePEM, PublicPEM) — `ErrRS256KeyIDRequired` is enforced.
+
+#### Issue #52 `GetRSAPrivateKey()` implementation
+
+```go
+// Application struct field
+rsaPrivateKey *rsa.PrivateKey
+
+// Accessor
+func (a *Application) GetRSAPrivateKey() *rsa.PrivateKey {
+    return a.rsaPrivateKey
+}
+
+// Captured in UseServerSecurityFromConfig
+a.rsaPrivateKey = compat.RSAPrivateKey
+```
+
+Pattern: zero-overhead, nil-safe, no locking, no error return.
+
+#### `CompatOptions` structure
+
+```go
+type CompatOptions struct {
+    Options       Options
+    TokenTTL      time.Duration
+    RSAPrivateKey *rsa.PrivateKey // non-nil only for RS256 Generated/PrivatePEM sources
+}
+```
+
+#### Test patterns in `app/application_test.go`
+
+- Tests use `t.Parallel()` at the function level and subtests use `t.Parallel()` too
+- Table-driven structure with `setup func(t *testing.T) *Application` + `wantNonNil bool`
+- Helper `mustNotPanic(t, name, fn)` ensures accessors never panic regardless of state
+- Helper `mustRSAPrivatePEM(t)` / `mustRSAPublicPEM(t)` generate keys inline
+- Helper `rs256AppConfig(rs256Cfg)` builds config for a given RS256 config
+- All three key sources are exercised: Generated, PrivatePEM, PublicPEM
+- `UseServerSecurity` direct path (no RSA) returns nil
+- "no security wired" returns nil without panic
+- `TestDocumentation_AccessorContractSynchronization` enforces accessor signatures exist in `doc.go`, `README.md`, `docs/home.md`
+
+---
+
+### Affected Areas
+
+- `app/application.go` — add `rsaPublicKey *rsa.PublicKey` and `rsaKeyID string` fields; capture in `UseServerSecurityFromConfig`; add `GetRSAPublicKey()` and `GetRSAKeyID()` accessors
+- `app/application_test.go` — add `TestGetRSAPublicKey` and `TestGetRSAKeyID` table-driven tests covering all three RS256 sources plus HS256 and unwired paths
+- `security/jwt/compat.go` — extend `CompatOptions` with `RSAPublicKey *rsa.PublicKey` and `RSAKeyID string`; populate them in `FromConfigJWT` / `resolveRS256`
+- `app/doc.go` — add accessor signatures and lifecycle contract for `GetRSAPublicKey()` and `GetRSAKeyID()` (required by documentation sync test)
+- `README.md` and `docs/home.md` — update accessor tables to include new signatures (required by documentation sync test)
+
+---
+
+### Approaches
+
+#### Approach 1: Extend `CompatOptions` (mirrors issue-52 pattern)
+
+Add `RSAPublicKey *rsa.PublicKey` and `RSAKeyID string` to `CompatOptions`. Populate them in `resolveRS256`. Capture in `UseServerSecurityFromConfig`.
+
+- **Pros**: Exact same pattern as issue-52 (`RSAPrivateKey`). Minimal blast radius. Changes confined to `security/jwt/compat.go` and `app/`. All three key sources can supply the public key.
+- **Cons**: `CompatOptions` grows two more fields.
+- **Effort**: Low
+
+#### Approach 2: Derive public key from `rsaPrivateKey` at accessor call time
+
+For Generated/PrivatePEM: return `&a.rsaPrivateKey.PublicKey`. For PublicPEM or when no private key: need a separate field anyway. This is a partial shortcut.
+
+- **Pros**: No change to `CompatOptions` for the Generated/PrivatePEM case.
+- **Cons**: Requires a separate `rsaPublicKey` field anyway for the PublicPEM case; inconsistent with how `rsaPrivateKey` is handled. Two code paths for one accessor is harder to reason about.
+- **Effort**: Low-to-Medium (still requires `CompatOptions` change for PublicPEM)
+
+#### Approach 3: Parse public key from resolver at accessor call time
+
+Cast `resolver.Resolve(ctx, keyID).Verify` to `*rsa.PublicKey`. No new fields on `Application`.
+
+- **Pros**: No struct changes.
+- **Cons**: Requires a `context.Context` or stored `kid`; the resolver is not stored on `Application` (only the `validator` is); would require surfacing the resolver itself. Violates the accessor pattern (should be O(1) field read, not a resolve call).
+- **Effort**: High (invasive)
+
+---
+
+### Recommendation
+
+**Approach 1 — Extend `CompatOptions`** following the exact issue-52 pattern.
+
+Add to `CompatOptions`:
+```go
+type CompatOptions struct {
+    Options       Options
+    TokenTTL      time.Duration
+    RSAPrivateKey *rsa.PrivateKey // non-nil for Generated/PrivatePEM
+    RSAPublicKey  *rsa.PublicKey  // non-nil for all RS256 sources (Generated/PrivatePEM/PublicPEM)
+    RSAKeyID      string          // non-empty for all RS256 sources
+}
+```
+
+In `resolveRS256`:
+- Generated: `priv` → `RSAPublicKey = &priv.PublicKey`, `RSAKeyID = cfg.KeyID`
+- PrivatePEM: `priv` → `RSAPublicKey = &priv.PublicKey`, `RSAKeyID = cfg.KeyID`
+- PublicPEM: `pub` from parse → `RSAPublicKey = pub`, `RSAKeyID = cfg.KeyID`
+
+In `Application`:
+```go
+rsaPublicKey *rsa.PublicKey
+rsaKeyID     string
+```
+
+Accessors:
+```go
+// GetRSAPublicKey returns the RSA public key used for RS256 token verification.
+// Returns nil when security was not wired, or when the algorithm is not RS256.
+func (a *Application) GetRSAPublicKey() *rsa.PublicKey {
+    return a.rsaPublicKey
+}
+
+// GetRSAKeyID returns the key ID associated with the RS256 key.
+// Returns empty string when security was not wired or algorithm is not RS256.
+func (a *Application) GetRSAKeyID() string {
+    return a.rsaKeyID
+}
+```
+
+---
+
+### Risks
+
+1. **PublicPEM returns nil private key but non-nil public key**: This is by design and the correct semantic — document clearly. `GetRSAPublicKey()` returns non-nil for ALL three RS256 key sources; `GetRSAPrivateKey()` returns nil for PublicPEM only.
+2. **KeyID is always required for RS256**: `ErrRS256KeyIDRequired` is enforced upstream; `GetRSAKeyID()` will never return empty when properly wired with RS256.
+3. **Documentation sync test**: `TestDocumentation_AccessorContractSynchronization` requires accessor signatures in `doc.go`, `README.md`, `docs/home.md`. Both new accessor signatures must be added.
+4. **HS256 path**: `GetRSAPublicKey()` returns nil and `GetRSAKeyID()` returns `""` when algorithm is HS256 — correct by design.
+5. **Direct wiring via `UseServerSecurity(v)`**: Both accessors return nil/empty — consistent with `GetRSAPrivateKey()` behavior.
+
+---
+
+### Ready for Proposal
+
+Yes. The approach is clear, low-risk, and directly mirrors issue-52. The proposal phase can proceed.

--- a/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/proposal.md
+++ b/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/proposal.md
@@ -1,0 +1,74 @@
+# Proposal: RSA Public Key and Key ID Accessors on app.Application
+
+## Intent
+
+Add `GetRSAPublicKey() *rsa.PublicKey` and `GetRSAKeyID() string` to `app.Application` as direct companions to issue-52's `GetRSAPrivateKey()`. Callers using PublicPEM-only configurations have no way to retrieve the RSA public key; KeyID is currently discarded after resolver construction and unreachable from Application.
+
+## Scope
+
+### In Scope
+- `GetRSAPublicKey() *rsa.PublicKey` accessor on `Application` — non-nil for all three RS256 sources
+- `GetRSAKeyID() string` accessor on `Application` — non-empty for all RS256 sources
+- Extend `CompatOptions` with `RSAPublicKey` and `RSAKeyID` fields
+- Populate both fields in `resolveRS256` for all three key sources
+- Table-driven tests covering Generated, PrivatePEM, PublicPEM, HS256, and unwired paths
+- Update `doc.go`, `README.md`, `docs/home.md` (required by documentation sync test)
+
+### Out of Scope
+- Exposing the keys.Resolver or staticResolver on Application
+- Rotating or mutating keys post-boot
+- Any changes to HS256 paths
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `security-rs256-keypair-management`: Add accessor contract for public key and key ID retrieval from a wired Application
+
+## Approach
+
+Follow the exact issue-52 pattern (Approach 1 from exploration):
+
+1. Add `RSAPublicKey *rsa.PublicKey` and `RSAKeyID string` to `CompatOptions` in `security/jwt/compat.go`
+2. Populate in `resolveRS256`: `&priv.PublicKey` + `cfg.KeyID` for Generated/PrivatePEM; parsed `pub` + `cfg.KeyID` for PublicPEM
+3. Add `rsaPublicKey *rsa.PublicKey` and `rsaKeyID string` fields to `Application`
+4. Capture from `compat` in `UseServerSecurityFromConfig`
+5. Expose via zero-overhead, nil-safe accessors
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `security/jwt/compat.go` | Modified | Add `RSAPublicKey`, `RSAKeyID` to `CompatOptions`; populate in `resolveRS256` |
+| `app/application.go` | Modified | Add struct fields + two accessors |
+| `app/application_test.go` | Modified | Add `TestGetRSAPublicKey` and `TestGetRSAKeyID` table-driven tests |
+| `app/doc.go` | Modified | Add accessor signatures (required by documentation sync test) |
+| `README.md` | Modified | Update accessor table |
+| `docs/home.md` | Modified | Update accessor table |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Documentation sync test fails if signatures not added to all three docs | Med | Explicitly covered in scope; update all three files |
+| PublicPEM returns nil private key — may surprise callers | Low | Document clearly: `GetRSAPublicKey()` is non-nil for all RS256 sources; `GetRSAPrivateKey()` is nil for PublicPEM |
+| `CompatOptions` drift if future key sources added | Low | Pattern is consistent; future sources must populate both fields |
+
+## Rollback Plan
+
+Revert `security/jwt/compat.go` (remove two fields + population), `app/application.go` (remove fields + accessors), docs, and tests. No database or persistent state involved — purely in-memory.
+
+## Dependencies
+
+- Issue-52 merged (`rsaPrivateKey` field and `GetRSAPrivateKey()` must be present)
+
+## Success Criteria
+
+- [ ] `GetRSAPublicKey()` returns non-nil for Generated, PrivatePEM, and PublicPEM RS256 configurations
+- [ ] `GetRSAPublicKey()` returns nil for HS256 and unwired Application
+- [ ] `GetRSAKeyID()` returns the configured key ID string for all RS256 configurations
+- [ ] `GetRSAKeyID()` returns `""` for HS256 and unwired Application
+- [ ] `TestDocumentation_AccessorContractSynchronization` passes (all three doc files updated)
+- [ ] All existing tests pass with no regressions

--- a/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/specs/security-rs256-keypair-management/spec.md
+++ b/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/specs/security-rs256-keypair-management/spec.md
@@ -1,10 +1,6 @@
-# security-rs256-keypair-management Specification
+# Delta for security-rs256-keypair-management
 
-## Purpose
-
-Define provider-agnostic, deterministic in-memory RSA keypair management contracts for RS256 validator bootstrap.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Deterministic in-memory keypair generation
 
@@ -49,6 +45,8 @@ Keypair management APIs MUST remain inside `security/*` without provider-specifi
 - GIVEN package `security/keys` is built and tested in isolation
 - WHEN dependency graph is evaluated
 - THEN no provider-specific adapter dependency is required
+
+## ADDED Requirements
 
 ### Requirement: RSA public key accessor on Application
 

--- a/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/tasks.md
+++ b/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: RSA Public Key and Key ID Accessors
+
+> TDD mode active. RED → GREEN → REFACTOR order is mandatory.
+
+## Phase 1: RED — Write Failing Tests
+
+- [x] 1.1 `app/application_test.go` — Add `TestGetRSAPublicKey` table-driven test covering 5 scenarios: Generated, PrivatePEM, PublicPEM, HS256, unwired. Must compile but fail (methods don't exist yet).
+- [x] 1.2 `app/application_test.go` — Add `TestGetRSAKeyID` table-driven test covering 5 scenarios: Generated, PrivatePEM, PublicPEM, HS256, unwired. Must compile but fail.
+- [x] 1.3 Run `go test ./app/...` — confirmed red (compile error).
+
+## Phase 2: GREEN — Implement Production Code
+
+- [x] 2.1 `security/jwt/compat.go` — Add `RSAPublicKey *rsa.PublicKey` and `RSAKeyID string` fields to `CompatOptions`.
+- [x] 2.2 `security/jwt/compat.go` — Update `resolveRS256` signature to `(*rsa.PrivateKey, *rsa.PublicKey, keys.Resolver, error)`; populate public key in all branches; add `parseRS256PublicPEM` for PublicPEM source; set `RSAKeyID = cfg.RS256.KeyID` in `CompatOptions` assembly.
+- [x] 2.3 `app/application.go` — Add private fields `rsaPublicKey *rsa.PublicKey` and `rsaKeyID string`.
+- [x] 2.4 `app/application.go` — In `UseServerSecurityFromConfig`, capture `compat.RSAPublicKey` → `a.rsaPublicKey` and `compat.RSAKeyID` → `a.rsaKeyID`.
+- [x] 2.5 `app/application.go` — Add `GetRSAPublicKey() *rsa.PublicKey { return a.rsaPublicKey }` and `GetRSAKeyID() string { return a.rsaKeyID }`.
+- [x] 2.6 Run `go test ./...` — confirmed all tests pass (green).
+
+## Phase 3: Documentation
+
+- [x] 3.1 `app/doc.go` — Add `GetRSAPublicKey() *rsa.PublicKey` and `GetRSAKeyID() string` to the accessor contract block.
+- [x] 3.2 Run `go test ./app/...` — confirmed passes.
+- [x] 3.3 `README.md` — Add accessor rows.
+- [x] 3.4 `docs/home.md` — Add same accessor rows.
+
+## Phase 4: Final Verification
+
+- [x] 4.1 Run `go test ./...` — full suite green, no regressions.

--- a/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/verify-report.md
+++ b/openspec/changes/archive/2026-05-02-issue-53-rsa-public-key-accessor/verify-report.md
@@ -1,0 +1,121 @@
+# Verification Report
+
+**Change**: issue-53-rsa-public-key-accessor  
+**Version**: N/A  
+**Mode**: Strict TDD  
+
+---
+
+## Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 14 |
+| Tasks complete | 14 |
+| Tasks incomplete | 0 |
+
+All tasks in Phases 1–4 are marked `[x]`.
+
+---
+
+## Build & Tests Execution
+
+**Build**: ✅ Passed (implicit — `go test ./...` exit code 0)
+
+**Tests**: ✅ All passed — 12 packages (no failures, no skipped)
+
+```
+ok  github.com/matiasmartin-labs/common-fwk          0.246s
+ok  github.com/matiasmartin-labs/common-fwk/app      0.416s
+ok  github.com/matiasmartin-labs/common-fwk/config   0.515s
+ok  github.com/matiasmartin-labs/common-fwk/config/viper  1.119s
+ok  github.com/matiasmartin-labs/common-fwk/errors   0.804s
+ok  github.com/matiasmartin-labs/common-fwk/http/gin 1.416s
+ok  github.com/matiasmartin-labs/common-fwk/logging  2.452s
+ok  github.com/matiasmartin-labs/common-fwk/logging/slog 1.692s
+?   github.com/matiasmartin-labs/common-fwk/security  [no test files]
+ok  github.com/matiasmartin-labs/common-fwk/security/claims 2.137s
+ok  github.com/matiasmartin-labs/common-fwk/security/jwt  2.048s
+ok  github.com/matiasmartin-labs/common-fwk/security/keys 2.964s
+```
+
+**Coverage**: Not measured (no threshold configured).
+
+---
+
+## Spec Compliance Matrix
+
+### Requirement: RSA public key accessor on Application
+
+| Scenario | Test | Result |
+|----------|------|--------|
+| GetRSAPublicKey — Generated source | `app/application_test.go > TestGetRSAPublicKey/Generated key source returns non-nil` | ✅ COMPLIANT |
+| GetRSAPublicKey — PrivatePEM source | `app/application_test.go > TestGetRSAPublicKey/PrivatePEM key source returns non-nil` | ✅ COMPLIANT |
+| GetRSAPublicKey — PublicPEM source | `app/application_test.go > TestGetRSAPublicKey/PublicPEM key source returns non-nil` | ✅ COMPLIANT |
+| GetRSAPublicKey — HS256 algorithm | `app/application_test.go > TestGetRSAPublicKey/HS256 algorithm returns nil` | ✅ COMPLIANT |
+| GetRSAPublicKey — not wired | `app/application_test.go > TestGetRSAPublicKey/no security wired returns nil without panic` | ✅ COMPLIANT |
+
+### Requirement: RSA key ID accessor on Application
+
+| Scenario | Test | Result |
+|----------|------|--------|
+| GetRSAKeyID — RS256 Generated | `app/application_test.go > TestGetRSAKeyID/Generated key source returns non-empty key ID` | ✅ COMPLIANT |
+| GetRSAKeyID — RS256 PrivatePEM | `app/application_test.go > TestGetRSAKeyID/PrivatePEM key source returns non-empty key ID` | ✅ COMPLIANT |
+| GetRSAKeyID — RS256 PublicPEM | `app/application_test.go > TestGetRSAKeyID/PublicPEM key source returns non-empty key ID` | ✅ COMPLIANT |
+| GetRSAKeyID — HS256 algorithm | `app/application_test.go > TestGetRSAKeyID/HS256 algorithm returns empty key ID` | ✅ COMPLIANT |
+| GetRSAKeyID — not wired | `app/application_test.go > TestGetRSAKeyID/no security wired returns empty without panic` | ✅ COMPLIANT |
+
+### Requirement: CompatOptions carries RSA public key and key ID
+
+| Scenario | Evidence | Result |
+|----------|----------|--------|
+| RSAPublicKey field in CompatOptions | `security/jwt/compat.go:24 — RSAPublicKey *rsa.PublicKey` | ✅ COMPLIANT |
+| RSAKeyID field in CompatOptions | `security/jwt/compat.go:25 — RSAKeyID string` | ✅ COMPLIANT |
+| Both populated in resolveRS256 | `compat.go:66-67` set in CompatOptions assembly | ✅ COMPLIANT |
+
+**Compliance summary**: 12/12 scenarios compliant
+
+---
+
+## Correctness (Static — Structural Evidence)
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| `GetRSAPublicKey() *rsa.PublicKey` on Application | ✅ Implemented | `app/application.go:98` |
+| `GetRSAKeyID() string` on Application | ✅ Implemented | `app/application.go:106` |
+| Private fields `rsaPublicKey`, `rsaKeyID` on struct | ✅ Implemented | `app/application.go:71-72` |
+| Wired in `UseServerSecurityFromConfig` | ✅ Implemented | `app/application.go:253-254` |
+| `RSAPublicKey` + `RSAKeyID` in `CompatOptions` | ✅ Implemented | `security/jwt/compat.go:24-25` |
+| `app/doc.go` updated | ✅ Implemented | Lines 10-11, 32, 39 |
+| `README.md` updated | ✅ Implemented | Lines 482-489 |
+| `docs/home.md` updated | ✅ Implemented | Lines 66-84 |
+
+---
+
+## Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Accessors on Application struct | ✅ Yes | Matches design |
+| CompatOptions as bridge for RSA key data | ✅ Yes | `compat.go:24-25,66-67` |
+| `parseRS256PublicPEM` for PublicPEM branch | ✅ Yes | Internal helper in jwt package |
+| TDD RED→GREEN order | ✅ Yes | Evidence in apply-progress |
+
+---
+
+## Issues Found
+
+**CRITICAL**: None
+
+**WARNING**: None
+
+**SUGGESTION**: 
+- Coverage was not measured. Consider adding `go test -cover` to CI to track coverage over time.
+
+---
+
+## Verdict
+
+**PASS**
+
+All 14 tasks complete, all 12 spec scenarios covered by passing tests, structural evidence confirmed in all required files. No regressions. Ready for archive.

--- a/security/jwt/compat.go
+++ b/security/jwt/compat.go
@@ -18,9 +18,11 @@ var ErrUnsupportedJWTAlgorithm = errors.New("unsupported jwt algorithm")
 
 // CompatOptions bundles validator options with token-issuing compatibility data.
 type CompatOptions struct {
-	Options      Options
-	TokenTTL     time.Duration
+	Options       Options
+	TokenTTL      time.Duration
 	RSAPrivateKey *rsa.PrivateKey // non-nil only for RS256 Generated/PrivatePEM sources
+	RSAPublicKey  *rsa.PublicKey  // non-nil for any RS256 source
+	RSAKeyID      string          // non-empty for any RS256 source
 }
 
 // FromConfigJWT maps config.JWTConfig to security/jwt validator options.
@@ -48,7 +50,7 @@ func FromConfigJWT(cfg config.JWTConfig) (CompatOptions, error) {
 			TokenTTL: ttl,
 		}, nil
 	case config.JWTAlgorithmRS256:
-		priv, resolver, err := resolveRS256(cfg.RS256)
+		priv, pub, resolver, err := resolveRS256(cfg.RS256)
 		if err != nil {
 			return CompatOptions{}, fmt.Errorf("build RS256 resolver: %w", err)
 		}
@@ -61,41 +63,48 @@ func FromConfigJWT(cfg config.JWTConfig) (CompatOptions, error) {
 			},
 			TokenTTL:      ttl,
 			RSAPrivateKey: priv,
+			RSAPublicKey:  pub,
+			RSAKeyID:      cfg.RS256.KeyID,
 		}, nil
 	default:
 		return CompatOptions{}, fmt.Errorf("algorithm %q: %w", algorithm, ErrUnsupportedJWTAlgorithm)
 	}
 }
 
-// resolveRS256 derives the private key and resolver from RS256 config.
+// resolveRS256 derives the private key, public key and resolver from RS256 config.
 // priv is nil for PublicPEM key source (verification-only).
-func resolveRS256(cfg config.RS256Config) (*rsa.PrivateKey, keys.Resolver, error) {
+func resolveRS256(cfg config.RS256Config) (*rsa.PrivateKey, *rsa.PublicKey, keys.Resolver, error) {
 	switch strings.TrimSpace(cfg.KeySource) {
 	case config.RS256KeySourceGenerated:
 		priv, err := keys.GenerateRSAKeyPair(0)
 		if err != nil {
-			return nil, nil, fmt.Errorf("build RS256 resolver: generate keypair: %w", err)
+			return nil, nil, nil, fmt.Errorf("build RS256 resolver: generate keypair: %w", err)
 		}
 		if strings.TrimSpace(cfg.KeyID) == "" {
-			return nil, nil, keys.ErrRS256KeyIDRequired
+			return nil, nil, nil, keys.ErrRS256KeyIDRequired
 		}
-		return priv, keys.NewRSAResolver(priv, cfg.KeyID), nil
+		return priv, &priv.PublicKey, keys.NewRSAResolver(priv, cfg.KeyID), nil
 	case config.RS256KeySourcePrivatePEM:
 		priv, err := parseRS256PrivatePEM(cfg.PrivateKeyPEM)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if strings.TrimSpace(cfg.KeyID) == "" {
-			return nil, nil, keys.ErrRS256KeyIDRequired
+			return nil, nil, nil, keys.ErrRS256KeyIDRequired
 		}
-		return priv, keys.NewRSAResolver(priv, cfg.KeyID), nil
+		return priv, &priv.PublicKey, keys.NewRSAResolver(priv, cfg.KeyID), nil
 	default:
 		// PublicPEM and unknown sources: delegate to ResolverFromRS256Config.
 		resolver, err := keys.ResolverFromRS256Config(cfg)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return nil, resolver, nil
+		// Extract public key from PublicPEM if available.
+		var pub *rsa.PublicKey
+		if strings.TrimSpace(cfg.PublicKeyPEM) != "" {
+			pub, _ = parseRS256PublicPEM(cfg.PublicKeyPEM)
+		}
+		return nil, pub, resolver, nil
 	}
 }
 
@@ -122,4 +131,24 @@ func parseRS256PrivatePEM(raw string) (*rsa.PrivateKey, error) {
 	}
 
 	return rsaKey, nil
+}
+
+// parseRS256PublicPEM decodes a PKIX PEM-encoded RSA public key.
+func parseRS256PublicPEM(raw string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(raw))
+	if block == nil {
+		return nil, fmt.Errorf("parse public pem: %w: pem decode failed", keys.ErrInvalidRS256PEM)
+	}
+
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public pem: %w: %w", keys.ErrInvalidRS256PEM, err)
+	}
+
+	rsaPub, ok := parsed.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("parse public pem: %w: public key is not RSA", keys.ErrInvalidRS256PEM)
+	}
+
+	return rsaPub, nil
 }


### PR DESCRIPTION
## Summary

- Add `GetRSAPublicKey() *rsa.PublicKey` to `app.Application` — returns the RSA public key used for RS256 token verification; `nil` if not applicable
- Add `GetRSAKeyID() string` to `app.Application` — returns the key ID associated with the RS256 key; empty string if not applicable
- Enables services to serve `/.well-known/jwks.json` without any auxiliary bootstrap struct

## Type

- [x] New feature

## Changes

| File | Change |
|------|--------|
| `app/application.go` | Added `rsaPublicKey`, `rsaKeyID` fields + `GetRSAPublicKey()`, `GetRSAKeyID()` methods; wired from `CompatOptions` |
| `security/jwt/compat.go` | Extended `CompatOptions` with `RSAPublicKey`, `RSAKeyID`; updated `resolveRS256` to return public key; added `parseRS256PublicPEM` helper |
| `app/application_test.go` | Added `TestGetRSAPublicKey` (5 scenarios) and `TestGetRSAKeyID` (5 scenarios) |
| `app/doc.go` | Updated accessor contract documentation |
| `README.md` | Added accessor rows for `GetRSAPublicKey` and `GetRSAKeyID` |
| `docs/home.md` | Added accessor docs with lifecycle semantics |
| `docs/releases/v0.10.0.md` | Created v0.10.0 release notes |
| `docs/releases/index.md` | Added v0.10.0 entry |

## Test Plan

- [x] `go test ./...` — all 12 packages pass
- [x] Strict TDD followed — tests written first (RED), then implementation (GREEN)
- [x] All 5 `GetRSAPublicKey` spec scenarios covered (Generated, PrivatePEM, PublicPEM, HS256→nil, unwired→nil)
- [x] All 5 `GetRSAKeyID` spec scenarios covered
- [x] `TestDocumentation_AccessorContractSynchronization` passes

## Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #53